### PR TITLE
fix(ui): complete MCP setup and diagnostics settings

### DIFF
--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -538,6 +538,11 @@ pub fn srelens_cli_status() -> Result<CliStatus, String> {
     }
 }
 
+#[cfg(unix)]
+fn posix_shell_path(path: &std::path::Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
+}
+
 /// Symlink the persistent executable to `~/.local/bin/srelens` so MCP clients
 /// can spawn `srelens --mcp-stdio`. AppImage builds use `$APPIMAGE`, not the
 /// temporary FUSE-mounted process path. Creates the directory if needed (no
@@ -560,10 +565,10 @@ pub fn install_srelens_cli() -> Result<String, String> {
         match std::os::unix::fs::symlink(&exe, &target) {
             Ok(()) => Ok(target.to_string_lossy().to_string()),
             Err(e) => Err(format!(
-                "Could not write {} ({e}). Run this in a terminal:\n  ln -sf \"{}\" \"{}\"",
+                "Could not write {} ({e}). Run this in a terminal:\n  ln -sf {} {}",
                 target.display(),
-                exe.display(),
-                target.display()
+                posix_shell_path(&exe),
+                posix_shell_path(&target)
             )),
         }
     }
@@ -577,6 +582,16 @@ pub fn install_srelens_cli() -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn fallback_command_quotes_shell_active_paths() {
+        let path = std::path::Path::new("/tmp/Srelens $HOME O'Brien\\build");
+        assert_eq!(
+            posix_shell_path(path),
+            "'/tmp/Srelens $HOME O'\\''Brien\\build'"
+        );
+    }
 
     #[test]
     fn running_executable_is_a_usable_cli_path() {

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -403,7 +403,8 @@ pub fn mcp_prompt_issues(
 #[derive(Debug, Serialize)]
 pub struct CliStatus {
     installed: bool,
-    /// The install path (`~/.local/bin/srelens`).
+    /// The usable command path (`~/.local/bin/srelens` on Unix, the running
+    /// desktop executable on Windows).
     path: String,
     /// What the symlink resolves to, if present.
     links_to: Option<String>,
@@ -430,19 +431,32 @@ fn dir_on_path(dir: &std::path::Path) -> bool {
 /// Report whether the `srelens` CLI is installed and where it points.
 #[tauri::command]
 pub fn srelens_cli_status() -> CliStatus {
-    let dir = cli_dir();
-    let path = cli_path();
-    CliStatus {
-        installed: path.as_ref().is_some_and(|p| p.exists()),
-        path: path
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default(),
-        links_to: path
-            .as_ref()
-            .and_then(|p| std::fs::read_link(p).ok())
-            .map(|p| p.to_string_lossy().to_string()),
-        on_path: dir.as_deref().is_some_and(dir_on_path),
+    #[cfg(windows)]
+    {
+        let path = std::env::current_exe().ok();
+        return CliStatus {
+            installed: path.as_ref().is_some_and(|p| p.exists()),
+            path: path.as_ref().map(|p| p.to_string_lossy().to_string()).unwrap_or_default(),
+            links_to: None,
+            on_path: path.as_ref().and_then(|p| p.parent()).is_some_and(dir_on_path),
+        };
+    }
+    #[cfg(not(windows))]
+    {
+        let dir = cli_dir();
+        let path = cli_path();
+        CliStatus {
+            installed: path.as_ref().is_some_and(|p| p.exists()),
+            path: path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            links_to: path
+                .as_ref()
+                .and_then(|p| std::fs::read_link(p).ok())
+                .map(|p| p.to_string_lossy().to_string()),
+            on_path: dir.as_deref().is_some_and(dir_on_path),
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -462,15 +462,31 @@ fn usable_cli_path(path: &std::path::Path, expected_exe: &std::path::Path) -> bo
 fn select_linux_cli_source(
     current_exe: std::path::PathBuf,
     appimage: Option<std::path::PathBuf>,
+    appdir: Option<std::path::PathBuf>,
 ) -> Result<std::path::PathBuf, String> {
-    match appimage {
-        Some(path) if path.is_absolute() && executable_file(&path) => Ok(path),
-        Some(path) => Err(format!(
+    let Some(path) = appimage else {
+        return Ok(current_exe);
+    };
+    let Some(mount) = appdir else {
+        return Err("APPIMAGE is set without its APPDIR mount".to_string());
+    };
+    if !path.is_absolute() || !executable_file(&path) {
+        return Err(format!(
             "APPIMAGE does not name an executable file: {}",
             path.display()
-        )),
-        None => Ok(current_exe),
+        ));
     }
+    let inside_mount = match (
+        std::fs::canonicalize(&current_exe),
+        std::fs::canonicalize(&mount),
+    ) {
+        (Ok(current), Ok(mount)) => current.starts_with(mount),
+        _ => false,
+    };
+    if !inside_mount {
+        return Err("APPIMAGE and APPDIR do not belong to the running executable".to_string());
+    }
+    Ok(path)
 }
 
 fn cli_source_executable() -> Result<std::path::PathBuf, String> {
@@ -480,6 +496,7 @@ fn cli_source_executable() -> Result<std::path::PathBuf, String> {
         return select_linux_cli_source(
             current,
             std::env::var_os("APPIMAGE").map(std::path::PathBuf::from),
+            std::env::var_os("APPDIR").map(std::path::PathBuf::from),
         );
     }
     #[cfg(not(target_os = "linux"))]
@@ -585,9 +602,10 @@ mod tests {
     #[test]
     fn appimage_path_replaces_the_temporary_process_path() {
         let appimage = std::env::current_exe().unwrap();
-        let transient = appimage.parent().unwrap().to_path_buf();
+        let mount = appimage.parent().unwrap().to_path_buf();
         assert_eq!(
-            select_linux_cli_source(transient, Some(appimage.clone())).unwrap(),
+            select_linux_cli_source(appimage.clone(), Some(appimage.clone()), Some(mount))
+                .unwrap(),
             appimage
         );
     }
@@ -597,7 +615,20 @@ mod tests {
     fn invalid_appimage_path_is_not_silently_replaced_by_the_fuse_path() {
         let current = std::env::current_exe().unwrap();
         let invalid = current.parent().unwrap().to_path_buf();
-        assert!(select_linux_cli_source(current, Some(invalid)).is_err());
+        assert!(select_linux_cli_source(current, Some(invalid.clone()), Some(invalid)).is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn inherited_appimage_environment_is_rejected() {
+        let current = std::env::current_exe().unwrap();
+        let unrelated_mount = std::path::PathBuf::from("/definitely-not-this-appimage-mount");
+        assert!(select_linux_cli_source(
+            current.clone(),
+            Some(current),
+            Some(unrelated_mount)
+        )
+        .is_err());
     }
 
     /// The command boundary, where the distinction has to survive: the pane

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -505,27 +505,26 @@ fn cli_source_executable() -> Result<std::path::PathBuf, String> {
 
 /// Report whether the `srelens` CLI is installed and where it points.
 #[tauri::command]
-pub fn srelens_cli_status() -> CliStatus {
+pub fn srelens_cli_status() -> Result<CliStatus, String> {
     #[cfg(windows)]
     {
         let path = std::env::current_exe().ok();
-        return CliStatus {
+        return Ok(CliStatus {
             installed: path.as_ref().is_some_and(|p| usable_cli_path(p, p)),
             path: path.as_ref().map(|p| p.to_string_lossy().to_string()).unwrap_or_default(),
             links_to: None,
             on_path: path.as_ref().and_then(|p| p.parent()).is_some_and(dir_on_path),
-        };
+        });
     }
     #[cfg(not(windows))]
     {
         let dir = cli_dir();
         let path = cli_path();
-        let source_exe = cli_source_executable().ok();
-        CliStatus {
+        let source_exe = cli_source_executable()?;
+        Ok(CliStatus {
             installed: path
                 .as_ref()
-                .zip(source_exe.as_ref())
-                .is_some_and(|(candidate, expected)| usable_cli_path(candidate, expected)),
+                .is_some_and(|candidate| usable_cli_path(candidate, &source_exe)),
             path: path
                 .as_ref()
                 .map(|p| p.to_string_lossy().to_string())
@@ -535,7 +534,7 @@ pub fn srelens_cli_status() -> CliStatus {
                 .and_then(|p| std::fs::read_link(p).ok())
                 .map(|p| p.to_string_lossy().to_string()),
             on_path: dir.as_deref().is_some_and(dir_on_path),
-        }
+        })
     }
 }
 

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -508,12 +508,12 @@ fn cli_source_executable() -> Result<std::path::PathBuf, String> {
 pub fn srelens_cli_status() -> Result<CliStatus, String> {
     #[cfg(windows)]
     {
-        let path = std::env::current_exe().ok();
+        let path = std::env::current_exe().map_err(|e| e.to_string())?;
         return Ok(CliStatus {
-            installed: path.as_ref().is_some_and(|p| usable_cli_path(p, p)),
-            path: path.as_ref().map(|p| p.to_string_lossy().to_string()).unwrap_or_default(),
+            installed: usable_cli_path(&path, &path),
+            path: path.to_string_lossy().to_string(),
             links_to: None,
-            on_path: path.as_ref().and_then(|p| p.parent()).is_some_and(dir_on_path),
+            on_path: path.parent().is_some_and(dir_on_path),
         });
     }
     #[cfg(not(windows))]

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -428,7 +428,7 @@ fn dir_on_path(dir: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
-fn usable_cli_path(path: &std::path::Path, current_exe: &std::path::Path) -> bool {
+fn executable_file(path: &std::path::Path) -> bool {
     let Ok(metadata) = std::fs::metadata(path) else {
         return false;
     };
@@ -442,10 +442,48 @@ fn usable_cli_path(path: &std::path::Path, current_exe: &std::path::Path) -> boo
             return false;
         }
     }
-    match (std::fs::canonicalize(path), std::fs::canonicalize(current_exe)) {
+    true
+}
+
+fn usable_cli_path(path: &std::path::Path, expected_exe: &std::path::Path) -> bool {
+    if !executable_file(path) {
+        return false;
+    }
+    match (
+        std::fs::canonicalize(path),
+        std::fs::canonicalize(expected_exe),
+    ) {
         (Ok(candidate), Ok(expected)) => candidate == expected,
         _ => false,
     }
+}
+
+#[cfg(target_os = "linux")]
+fn select_linux_cli_source(
+    current_exe: std::path::PathBuf,
+    appimage: Option<std::path::PathBuf>,
+) -> Result<std::path::PathBuf, String> {
+    match appimage {
+        Some(path) if path.is_absolute() && executable_file(&path) => Ok(path),
+        Some(path) => Err(format!(
+            "APPIMAGE does not name an executable file: {}",
+            path.display()
+        )),
+        None => Ok(current_exe),
+    }
+}
+
+fn cli_source_executable() -> Result<std::path::PathBuf, String> {
+    let current = std::env::current_exe().map_err(|e| e.to_string())?;
+    #[cfg(target_os = "linux")]
+    {
+        return select_linux_cli_source(
+            current,
+            std::env::var_os("APPIMAGE").map(std::path::PathBuf::from),
+        );
+    }
+    #[cfg(not(target_os = "linux"))]
+    Ok(current)
 }
 
 /// Report whether the `srelens` CLI is installed and where it points.
@@ -465,11 +503,11 @@ pub fn srelens_cli_status() -> CliStatus {
     {
         let dir = cli_dir();
         let path = cli_path();
-        let current_exe = std::env::current_exe().ok();
+        let source_exe = cli_source_executable().ok();
         CliStatus {
             installed: path
                 .as_ref()
-                .zip(current_exe.as_ref())
+                .zip(source_exe.as_ref())
                 .is_some_and(|(candidate, expected)| usable_cli_path(candidate, expected)),
             path: path
                 .as_ref()
@@ -484,12 +522,14 @@ pub fn srelens_cli_status() -> CliStatus {
     }
 }
 
-/// Symlink the running executable to `~/.local/bin/srelens` so MCP clients can
-/// spawn `srelens --mcp-stdio`. Creates the directory if needed (no elevation);
-/// returns the install path on success, or the manual command on failure.
+/// Symlink the persistent executable to `~/.local/bin/srelens` so MCP clients
+/// can spawn `srelens --mcp-stdio`. AppImage builds use `$APPIMAGE`, not the
+/// temporary FUSE-mounted process path. Creates the directory if needed (no
+/// elevation); returns the install path on success, or the manual command on
+/// failure.
 #[tauri::command]
 pub fn install_srelens_cli() -> Result<String, String> {
-    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let exe = cli_source_executable()?;
 
     #[cfg(unix)]
     {
@@ -539,6 +579,25 @@ mod tests {
     fn an_unrelated_executable_is_not_a_usable_cli_path() {
         let current = std::env::current_exe().unwrap();
         assert!(!usable_cli_path(std::path::Path::new("/bin/sh"), &current));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn appimage_path_replaces_the_temporary_process_path() {
+        let appimage = std::env::current_exe().unwrap();
+        let transient = appimage.parent().unwrap().to_path_buf();
+        assert_eq!(
+            select_linux_cli_source(transient, Some(appimage.clone())).unwrap(),
+            appimage
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn invalid_appimage_path_is_not_silently_replaced_by_the_fuse_path() {
+        let current = std::env::current_exe().unwrap();
+        let invalid = current.parent().unwrap().to_path_buf();
+        assert!(select_linux_cli_source(current, Some(invalid)).is_err());
     }
 
     /// The command boundary, where the distinction has to survive: the pane

--- a/apps/desktop/src-tauri/src/mcp.rs
+++ b/apps/desktop/src-tauri/src/mcp.rs
@@ -428,6 +428,26 @@ fn dir_on_path(dir: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
+fn usable_cli_path(path: &std::path::Path, current_exe: &std::path::Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return false;
+        }
+    }
+    match (std::fs::canonicalize(path), std::fs::canonicalize(current_exe)) {
+        (Ok(candidate), Ok(expected)) => candidate == expected,
+        _ => false,
+    }
+}
+
 /// Report whether the `srelens` CLI is installed and where it points.
 #[tauri::command]
 pub fn srelens_cli_status() -> CliStatus {
@@ -435,7 +455,7 @@ pub fn srelens_cli_status() -> CliStatus {
     {
         let path = std::env::current_exe().ok();
         return CliStatus {
-            installed: path.as_ref().is_some_and(|p| p.exists()),
+            installed: path.as_ref().is_some_and(|p| usable_cli_path(p, p)),
             path: path.as_ref().map(|p| p.to_string_lossy().to_string()).unwrap_or_default(),
             links_to: None,
             on_path: path.as_ref().and_then(|p| p.parent()).is_some_and(dir_on_path),
@@ -445,8 +465,12 @@ pub fn srelens_cli_status() -> CliStatus {
     {
         let dir = cli_dir();
         let path = cli_path();
+        let current_exe = std::env::current_exe().ok();
         CliStatus {
-            installed: path.as_ref().is_some_and(|p| p.exists()),
+            installed: path
+                .as_ref()
+                .zip(current_exe.as_ref())
+                .is_some_and(|(candidate, expected)| usable_cli_path(candidate, expected)),
             path: path
                 .as_ref()
                 .map(|p| p.to_string_lossy().to_string())
@@ -497,6 +521,25 @@ pub fn install_srelens_cli() -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn running_executable_is_a_usable_cli_path() {
+        let current = std::env::current_exe().unwrap();
+        assert!(usable_cli_path(&current, &current));
+    }
+
+    #[test]
+    fn a_directory_is_not_a_usable_cli_path() {
+        let current = std::env::current_exe().unwrap();
+        assert!(!usable_cli_path(current.parent().unwrap(), &current));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_unrelated_executable_is_not_a_usable_cli_path() {
+        let current = std::env::current_exe().unwrap();
+        assert!(!usable_cli_path(std::path::Path::new("/bin/sh"), &current));
+    }
 
     /// The command boundary, where the distinction has to survive: the pane
     /// only ever sees what `mcp_audit_tail` returns. An absent log resolves to

--- a/apps/desktop/src/components/McpSettingsSection.test.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 
@@ -31,6 +31,9 @@ const { mcpSecurity } = vi.hoisted(() => ({
 vi.mock("@srelens/core/lib/mcpSecurity", () => mcpSecurity);
 
 import { McpSettingsSection } from "./McpSettingsSection";
+
+const PLATFORM = navigator.platform;
+afterEach(() => Object.defineProperty(navigator, "platform", { configurable: true, value: PLATFORM }));
 
 beforeEach(() => {
   localStorage.clear();
@@ -80,7 +83,9 @@ describe("McpSettingsSection", () => {
       on_path: true,
     });
     render(<McpSettingsSection />);
-    fireEvent.click(screen.getByRole("button", { name: /Install srelens CLI/ }));
+    const install = screen.getByRole("button", { name: /Install srelens CLI/ });
+    await waitFor(() => expect((install as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(install);
     await waitFor(() => expect(mcp.installSrelensCli).toHaveBeenCalled());
     // After install the button relabels to Reinstall and the path is shown.
     expect(await screen.findByRole("button", { name: /Reinstall srelens CLI/ })).toBeDefined();
@@ -96,6 +101,28 @@ describe("McpSettingsSection", () => {
     });
     render(<McpSettingsSection />);
     expect(await screen.findByText(/isn't on your PATH/)).toBeDefined();
+  });
+
+  it("uses the absolute executable on Windows and hides unsupported installation", async () => {
+    Object.defineProperty(navigator, "platform", { configurable: true, value: "Win32" });
+    const path = String.raw`C:\Program Files\srelens\srelens.exe`;
+    mcp.srelensCliStatus.mockResolvedValue({ installed: true, path, links_to: null, on_path: false });
+    render(<McpSettingsSection />);
+
+    expect(await screen.findByText(/Run the PowerShell command in PowerShell/)).toBeDefined();
+    expect(screen.getAllByText(new RegExp(path.replace(/[\\]/g, "\\\\")))).not.toHaveLength(0);
+    expect(screen.queryByRole("button", { name: /Install srelens CLI/ })).toBeNull();
+  });
+
+  it("shows a CLI status failure and allows retry instead of offering installation", async () => {
+    mcp.srelensCliStatus.mockRejectedValueOnce(new Error("status unavailable"));
+    render(<McpSettingsSection />);
+    expect((await screen.findByRole("alert")).textContent).toMatch(/status unavailable/i);
+    expect(screen.queryByRole("button", { name: "Install srelens CLI" })).toBeNull();
+
+    mcp.srelensCliStatus.mockResolvedValue({ installed: false, path: "/home/u/.local/bin/srelens", links_to: null, on_path: false });
+    fireEvent.click(screen.getByRole("button", { name: "Retry CLI status" }));
+    expect(await screen.findByRole("button", { name: "Install srelens CLI" })).toBeDefined();
   });
 
   it("shows the client config for the selected tool and transport", async () => {

--- a/apps/desktop/src/components/McpSettingsSection.tsx
+++ b/apps/desktop/src/components/McpSettingsSection.tsx
@@ -44,6 +44,8 @@ export function McpSettingsSection() {
   const [runningUrl, setRunningUrl] = useState<string | null>(null);
   const [serverError, setServerError] = useState("");
   const [cli, setCli] = useState<CliStatus | null>(null);
+  const [cliLoading, setCliLoading] = useState(true);
+  const [cliError, setCliError] = useState("");
   const [cliMessage, setCliMessage] = useState("");
   const [tool, setTool] = useState<McpTool>("claude-code");
   const [transport, setTransport] = useState<McpTransport>("stdio");
@@ -64,6 +66,20 @@ export function McpSettingsSection() {
   // reflected without restarting srelens, and without a second Refresh
   // button next to the one that already exists.
   const [promptIssuesNonce, setPromptIssuesNonce] = useState(0);
+  const windows = /win/i.test(navigator.platform ?? "");
+
+  async function refreshCli() {
+    setCliLoading(true);
+    setCliError("");
+    try {
+      setCli(await srelensCliStatus());
+    } catch (error) {
+      setCli(null);
+      setCliError(String(error));
+    } finally {
+      setCliLoading(false);
+    }
+  }
 
   async function refreshToken() {
     try {
@@ -77,7 +93,7 @@ export function McpSettingsSection() {
 
   useEffect(() => {
     void mcpHttpStatus().then(setRunningUrl).catch(() => {});
-    void srelensCliStatus().then(setCli).catch(() => {});
+    void refreshCli();
     void refreshToken();
   }, []);
 
@@ -130,7 +146,9 @@ export function McpSettingsSection() {
       setCli(await srelensCliStatus());
       notify.success("srelens CLI installed");
     } catch (e) {
+      setCli(null);
       setCliMessage(String(e));
+      await refreshCli();
     }
   }
 
@@ -172,7 +190,9 @@ export function McpSettingsSection() {
   }
 
   const url = runningUrl ?? `http://127.0.0.1:${settings.port}/mcp`;
-  const config = mcpClientConfig(tool, transport, { url, token });
+  const command = cli?.installed && cli.path ? cli.path : undefined;
+  const config = mcpClientConfig(tool, transport, { url, token, command, platform: windows ? "windows" : "unix" });
+  const configReady = transport === "http" || (!cliLoading && !cliError && !!command);
 
   return (
     <div className="flex flex-col gap-6">
@@ -223,21 +243,26 @@ export function McpSettingsSection() {
       <section className="flex flex-col gap-2">
         <h4 className="text-sm font-medium">srelens CLI</h4>
         <p className="text-sm text-muted-foreground">
-          Installs a <code className="fl-mono">srelens</code> command on your PATH so MCP clients can
-          spawn <code className="fl-mono">srelens --mcp-stdio</code>.
+          {windows ? "Windows MCP clients start the installed desktop executable directly." : <>
+            Installs a <code className="fl-mono">srelens</code> command on your PATH so MCP clients can
+            spawn <code className="fl-mono">srelens --mcp-stdio</code>.
+          </>}
         </p>
         <div className="flex flex-wrap items-center gap-3">
-          <Button onClick={() => void installCli()}>
+          {!windows && !cliError && <Button disabled={cliLoading} onClick={() => void installCli()}>
             <Download data-icon="inline-start" />
             {cli?.installed ? "Reinstall srelens CLI" : "Install srelens CLI"}
-          </Button>
+          </Button>}
+          {cliLoading && <span role="status" className="text-sm text-muted-foreground">Checking CLI installation…</span>}
           {cli?.installed && (
             <span className="text-sm text-muted-foreground">
-              Installed at <code className="fl-mono">{cli.path}</code>
+              {windows ? "Using" : "Installed at"} <code className="fl-mono">{cli.path}</code>
             </span>
           )}
+          {cliError && <><p role="alert" className="text-sm text-destructive">Could not check CLI installation: {cliError}</p>
+            <Button variant="ghost" size="sm" onClick={() => void refreshCli()}>Retry CLI status</Button></>}
         </div>
-        {cli?.installed && !cli.on_path && (
+        {!windows && cli?.installed && !cli.on_path && (
           <p className="text-sm text-amber-600 dark:text-amber-500">
             Its directory isn't on your PATH yet — add it (e.g.{" "}
             <code className="fl-mono">export PATH="$HOME/.local/bin:$PATH"</code>) so clients can find{" "}
@@ -375,6 +400,7 @@ export function McpSettingsSection() {
             size="sm"
             className="absolute right-2 top-2"
             onClick={() => void copy(config.snippet)}
+            disabled={!configReady}
             aria-label="Copy config"
           >
             <Copy data-icon="inline-start" />

--- a/packages/core/src/lib/mcpClients.test.ts
+++ b/packages/core/src/lib/mcpClients.test.ts
@@ -42,14 +42,19 @@ describe("mcpClientConfig", () => {
     const command = String.raw`C:\Program Files\srelens\srelens.exe`;
     expect(JSON.parse(mcpClientConfig("cursor", "stdio", { command }).snippet).mcpServers.srelens.command).toBe(command);
     expect(mcpClientConfig("codex", "stdio", { command }).snippet).toContain(String.raw`command = "C:\\Program Files\\srelens\\srelens.exe"`);
-    expect(mcpClientConfig("claude-code", "stdio", { command }).snippet).toContain(String.raw`-- "C:\\Program Files\\srelens\\srelens.exe" --mcp-stdio`);
+    expect(mcpClientConfig("claude-code", "stdio", { command }).snippet).toContain(String.raw`-- 'C:\Program Files\srelens\srelens.exe' --mcp-stdio`);
   });
 
   it("shell-escapes command substitution characters in executable paths", () => {
     const command = String.raw`/Applications/Srelens $(touch /tmp/unsafe) ` + "`whoami`";
     const snippet = mcpClientConfig("claude-code", "stdio", { command }).snippet;
-    expect(snippet).toContain(String.raw`\$(touch /tmp/unsafe)`);
-    expect(snippet).toContain("\\`whoami\\`");
+    expect(snippet).toContain(`'/Applications/Srelens $(touch /tmp/unsafe) \`whoami\`'`);
+  });
+
+  it("protects Bash history expansion in Unix executable paths", () => {
+    const command = "/home/user!/srelens";
+    expect(mcpClientConfig("claude-code", "stdio", { command }).snippet)
+      .toContain("-- '/home/user!/srelens' --mcp-stdio");
   });
 
   it("uses PowerShell quoting for shell-active Windows executable paths", () => {

--- a/packages/core/src/lib/mcpClients.test.ts
+++ b/packages/core/src/lib/mcpClients.test.ts
@@ -52,6 +52,13 @@ describe("mcpClientConfig", () => {
     expect(snippet).toContain("\\`whoami\\`");
   });
 
+  it("uses PowerShell quoting for shell-active Windows executable paths", () => {
+    const command = String.raw`C:\Apps\$(whoami)\O'Brien\srelens.exe`;
+    const snippet = mcpClientConfig("claude-code", "stdio", { command, platform: "windows" }).snippet;
+    expect(snippet).toContain(String.raw`-- 'C:\Apps\$(whoami)\O''Brien\srelens.exe' --mcp-stdio`);
+    expect(snippet).not.toContain(String.raw`-- "C:\Apps`);
+  });
+
   it("emits a url entry with a bearer header for JSON tools over http", () => {
     const c = mcpClientConfig("cursor", "http", {
       url: "http://127.0.0.1:9000/mcp",

--- a/packages/core/src/lib/mcpClients.test.ts
+++ b/packages/core/src/lib/mcpClients.test.ts
@@ -38,6 +38,13 @@ describe("mcpClientConfig", () => {
     }
   });
 
+  it("uses an absolute executable path when stdio cannot rely on PATH", () => {
+    const command = String.raw`C:\Program Files\srelens\srelens.exe`;
+    expect(JSON.parse(mcpClientConfig("cursor", "stdio", { command }).snippet).mcpServers.srelens.command).toBe(command);
+    expect(mcpClientConfig("codex", "stdio", { command }).snippet).toContain(String.raw`command = "C:\\Program Files\\srelens\\srelens.exe"`);
+    expect(mcpClientConfig("claude-code", "stdio", { command }).snippet).toContain(`-- "${command}" --mcp-stdio`);
+  });
+
   it("emits a url entry with a bearer header for JSON tools over http", () => {
     const c = mcpClientConfig("cursor", "http", {
       url: "http://127.0.0.1:9000/mcp",

--- a/packages/core/src/lib/mcpClients.test.ts
+++ b/packages/core/src/lib/mcpClients.test.ts
@@ -57,6 +57,12 @@ describe("mcpClientConfig", () => {
       .toContain("-- '/home/user!/srelens' --mcp-stdio");
   });
 
+  it("quotes literal backslashes in Unix executable paths", () => {
+    const command = String.raw`/home/alice\ops/.local/bin/srelens`;
+    expect(mcpClientConfig("claude-code", "stdio", { command, platform: "unix" }).snippet)
+      .toContain(String.raw`-- '/home/alice\ops/.local/bin/srelens' --mcp-stdio`);
+  });
+
   it("uses PowerShell quoting for shell-active Windows executable paths", () => {
     const command = String.raw`C:\Apps\$(whoami)\O'Brien\srelens.exe`;
     const config = mcpClientConfig("claude-code", "stdio", { command, platform: "windows" });

--- a/packages/core/src/lib/mcpClients.test.ts
+++ b/packages/core/src/lib/mcpClients.test.ts
@@ -54,9 +54,19 @@ describe("mcpClientConfig", () => {
 
   it("uses PowerShell quoting for shell-active Windows executable paths", () => {
     const command = String.raw`C:\Apps\$(whoami)\O'Brien\srelens.exe`;
-    const snippet = mcpClientConfig("claude-code", "stdio", { command, platform: "windows" }).snippet;
+    const config = mcpClientConfig("claude-code", "stdio", { command, platform: "windows" });
+    const snippet = config.snippet;
+    expect(snippet).toMatch(/^& \{ claude mcp add/);
     expect(snippet).toContain(String.raw`-- 'C:\Apps\$(whoami)\O''Brien\srelens.exe' --mcp-stdio`);
     expect(snippet).not.toContain(String.raw`-- "C:\Apps`);
+    expect(config.hint).toMatch(/PowerShell/i);
+  });
+
+  it("labels ordinary Windows paths as PowerShell-only instead of emitting cmd syntax", () => {
+    const command = String.raw`C:\Program Files\srelens\srelens.exe`;
+    const config = mcpClientConfig("claude-code", "stdio", { command, platform: "windows" });
+    expect(config.snippet).toBe(String.raw`& { claude mcp add srelens -- 'C:\Program Files\srelens\srelens.exe' --mcp-stdio }`);
+    expect(config.hint).toMatch(/PowerShell/i);
   });
 
   it("emits a url entry with a bearer header for JSON tools over http", () => {

--- a/packages/core/src/lib/mcpClients.test.ts
+++ b/packages/core/src/lib/mcpClients.test.ts
@@ -42,7 +42,14 @@ describe("mcpClientConfig", () => {
     const command = String.raw`C:\Program Files\srelens\srelens.exe`;
     expect(JSON.parse(mcpClientConfig("cursor", "stdio", { command }).snippet).mcpServers.srelens.command).toBe(command);
     expect(mcpClientConfig("codex", "stdio", { command }).snippet).toContain(String.raw`command = "C:\\Program Files\\srelens\\srelens.exe"`);
-    expect(mcpClientConfig("claude-code", "stdio", { command }).snippet).toContain(`-- "${command}" --mcp-stdio`);
+    expect(mcpClientConfig("claude-code", "stdio", { command }).snippet).toContain(String.raw`-- "C:\\Program Files\\srelens\\srelens.exe" --mcp-stdio`);
+  });
+
+  it("shell-escapes command substitution characters in executable paths", () => {
+    const command = String.raw`/Applications/Srelens $(touch /tmp/unsafe) ` + "`whoami`";
+    const snippet = mcpClientConfig("claude-code", "stdio", { command }).snippet;
+    expect(snippet).toContain(String.raw`\$(touch /tmp/unsafe)`);
+    expect(snippet).toContain("\\`whoami\\`");
   });
 
   it("emits a url entry with a bearer header for JSON tools over http", () => {

--- a/packages/core/src/lib/mcpClients.ts
+++ b/packages/core/src/lib/mcpClients.ts
@@ -48,7 +48,10 @@ function mcpServersJson(entry: Record<string, unknown>): string {
 }
 
 function quoteShellCommand(command: string, platform: "unix" | "windows"): string {
-  if (/^[A-Za-z0-9_./:\\-]+$/.test(command)) return command;
+  const safeUnquoted = platform === "windows"
+    ? /^[A-Za-z0-9_./:\\-]+$/
+    : /^[A-Za-z0-9_./:-]+$/;
+  if (safeUnquoted.test(command)) return command;
   return platform === "windows"
     ? `'${command.replace(/'/g, "''")}'`
     : `'${command.split("'").join("'\\''")}'`;

--- a/packages/core/src/lib/mcpClients.ts
+++ b/packages/core/src/lib/mcpClients.ts
@@ -72,11 +72,16 @@ export function mcpClientConfig(
   const hint = MCP_TOOLS.find((t) => t.id === tool)?.hint ?? "";
 
   if (tool === "claude-code") {
-    const snippet =
+    const invocation =
       transport === "stdio"
         ? `claude mcp add srelens -- ${shellCommand} --mcp-stdio`
         : `claude mcp add --transport http srelens ${url} --header "Authorization: ${authValue}"`;
-    return { format: "shell", snippet, hint };
+    const windowsStdio = transport === "stdio" && opts.platform === "windows";
+    return {
+      format: "shell",
+      snippet: windowsStdio ? `& { ${invocation} }` : invocation,
+      hint: windowsStdio ? "Run the PowerShell command in PowerShell." : hint,
+    };
   }
 
   if (tool === "codex") {

--- a/packages/core/src/lib/mcpClients.ts
+++ b/packages/core/src/lib/mcpClients.ts
@@ -60,7 +60,7 @@ export function mcpClientConfig(
 ): McpClientConfig {
   const url = opts.url || DEFAULT_URL;
   const command = opts.command || "srelens";
-  const shellCommand = /^[A-Za-z0-9_./:\\-]+$/.test(command) ? command : `"${command.replace(/"/g, '\\"')}"`;
+  const shellCommand = /^[A-Za-z0-9_./:\\-]+$/.test(command) ? command : `"${command.replace(/[\\"$`]/g, "\\$&")}"`;
   const authValue = transport === "http" ? (opts.token ? `Bearer ${opts.token}` : NO_TOKEN_PLACEHOLDER) : "";
   const hint = MCP_TOOLS.find((t) => t.id === tool)?.hint ?? "";
 

--- a/packages/core/src/lib/mcpClients.ts
+++ b/packages/core/src/lib/mcpClients.ts
@@ -51,7 +51,7 @@ function quoteShellCommand(command: string, platform: "unix" | "windows"): strin
   if (/^[A-Za-z0-9_./:\\-]+$/.test(command)) return command;
   return platform === "windows"
     ? `'${command.replace(/'/g, "''")}'`
-    : `"${command.replace(/[\\"$`]/g, "\\$&")}"`;
+    : `'${command.split("'").join("'\\''")}'`;
 }
 
 /**

--- a/packages/core/src/lib/mcpClients.ts
+++ b/packages/core/src/lib/mcpClients.ts
@@ -56,16 +56,18 @@ function mcpServersJson(entry: Record<string, unknown>): string {
 export function mcpClientConfig(
   tool: McpTool,
   transport: McpTransport,
-  opts: { url?: string; token?: string | null },
+  opts: { url?: string; token?: string | null; command?: string },
 ): McpClientConfig {
   const url = opts.url || DEFAULT_URL;
+  const command = opts.command || "srelens";
+  const shellCommand = /^[A-Za-z0-9_./:\\-]+$/.test(command) ? command : `"${command.replace(/"/g, '\\"')}"`;
   const authValue = transport === "http" ? (opts.token ? `Bearer ${opts.token}` : NO_TOKEN_PLACEHOLDER) : "";
   const hint = MCP_TOOLS.find((t) => t.id === tool)?.hint ?? "";
 
   if (tool === "claude-code") {
     const snippet =
       transport === "stdio"
-        ? "claude mcp add srelens -- srelens --mcp-stdio"
+        ? `claude mcp add srelens -- ${shellCommand} --mcp-stdio`
         : `claude mcp add --transport http srelens ${url} --header "Authorization: ${authValue}"`;
     return { format: "shell", snippet, hint };
   }
@@ -73,7 +75,7 @@ export function mcpClientConfig(
   if (tool === "codex") {
     const snippet =
       transport === "stdio"
-        ? `[mcp_servers.srelens]\ncommand = "srelens"\nargs = ["--mcp-stdio"]`
+        ? `[mcp_servers.srelens]\ncommand = ${JSON.stringify(command)}\nargs = ["--mcp-stdio"]`
         : `[mcp_servers.srelens]\nurl = "${url}"\n\n[mcp_servers.srelens.headers]\nAuthorization = "${authValue}"`;
     return { format: "toml", snippet, hint };
   }
@@ -81,7 +83,7 @@ export function mcpClientConfig(
   // JSON mcpServers tools: Claude Desktop, Cursor, Antigravity, generic.
   const entry =
     transport === "stdio"
-      ? { command: "srelens", args: ["--mcp-stdio"] }
+      ? { command, args: ["--mcp-stdio"] }
       : { url, headers: { Authorization: authValue } };
   return { format: "json", snippet: mcpServersJson(entry), hint };
 }

--- a/packages/core/src/lib/mcpClients.ts
+++ b/packages/core/src/lib/mcpClients.ts
@@ -47,6 +47,13 @@ function mcpServersJson(entry: Record<string, unknown>): string {
   return JSON.stringify({ mcpServers: { srelens: entry } }, null, 2);
 }
 
+function quoteShellCommand(command: string, platform: "unix" | "windows"): string {
+  if (/^[A-Za-z0-9_./:\\-]+$/.test(command)) return command;
+  return platform === "windows"
+    ? `'${command.replace(/'/g, "''")}'`
+    : `"${command.replace(/[\\"$`]/g, "\\$&")}"`;
+}
+
 /**
  * Config for connecting `tool` to srelens over `transport`. `opts.token` is
  * the current MCP bearer token (or `null`/absent if none has been generated
@@ -56,11 +63,11 @@ function mcpServersJson(entry: Record<string, unknown>): string {
 export function mcpClientConfig(
   tool: McpTool,
   transport: McpTransport,
-  opts: { url?: string; token?: string | null; command?: string },
+  opts: { url?: string; token?: string | null; command?: string; platform?: "unix" | "windows" },
 ): McpClientConfig {
   const url = opts.url || DEFAULT_URL;
   const command = opts.command || "srelens";
-  const shellCommand = /^[A-Za-z0-9_./:\\-]+$/.test(command) ? command : `"${command.replace(/[\\"$`]/g, "\\$&")}"`;
+  const shellCommand = quoteShellCommand(command, opts.platform ?? "unix");
   const authValue = transport === "http" ? (opts.token ? `Bearer ${opts.token}` : NO_TOKEN_PLACEHOLDER) : "";
   const hint = MCP_TOOLS.find((t) => t.id === tool)?.hint ?? "";
 

--- a/packages/core/src/lib/mcpSecurity.test.ts
+++ b/packages/core/src/lib/mcpSecurity.test.ts
@@ -91,3 +91,11 @@ describe("mcpSecurity", () => {
     await expect(vaultLock()).rejects.toThrow("no master password");
   });
 });
+
+it("reports prompt diagnostics read failures to callers that need a reliable result", async () => {
+  const { readPromptIssues } = await import("./mcpSecurity");
+  invoke.mockRejectedValueOnce(new Error("vault locked"));
+  await expect(readPromptIssues()).rejects.toThrow("vault locked");
+  invoke.mockResolvedValueOnce([{ file: "broken.md", problem: "invalid frontmatter" }]);
+  await expect(readPromptIssues()).resolves.toEqual([{ file: "broken.md", problem: "invalid frontmatter" }]);
+});

--- a/packages/core/src/lib/mcpSecurity.ts
+++ b/packages/core/src/lib/mcpSecurity.ts
@@ -175,10 +175,15 @@ export interface PromptIssue {
   problem: string;
 }
 
+/** Read prompt diagnostics without hiding a transport failure as an empty list. */
+export async function readPromptIssues(): Promise<PromptIssue[]> {
+  return invoke<PromptIssue[]>("mcp_prompt_issues");
+}
+
 /** Returns [] rather than throwing: no prompts directory is not an error. */
 export async function promptIssues(): Promise<PromptIssue[]> {
   try {
-    return await invoke<PromptIssue[]>("mcp_prompt_issues");
+    return await readPromptIssues();
   } catch {
     return [];
   }

--- a/packages/ui-next/src/screens/Settings.test.tsx
+++ b/packages/ui-next/src/screens/Settings.test.tsx
@@ -406,6 +406,7 @@ describe("Settings", () => {
       paint();
       const note = screen.getByTestId("no-agent-server");
       expect(note.textContent).toMatch(/desktop/i);
+      expect(note.className).toContain("px-3");
       expect(screen.getAllByTestId("no-agent-server")).toHaveLength(1);
       // And not in the rail: this is an absence WITHIN a section that is still
       // drawn, not an absent entry — the footnote by the nav is the report for

--- a/packages/ui-next/src/screens/Settings.test.tsx
+++ b/packages/ui-next/src/screens/Settings.test.tsx
@@ -209,6 +209,9 @@ describe("Settings", () => {
     expect(await screen.findByText(/never without confirmation/i)).toBeTruthy();
     expect(screen.getByText(/drops in-flight requests/i)).toBeTruthy();
     expect(screen.getByText(/every capability call/i)).toBeTruthy();
+    const nested = screen.getByText("Providers").closest(".card")?.parentElement;
+    expect(nested?.className).toContain("settings-agent-groups");
+    expect(nested?.className).not.toContain("gap-4");
   });
 
   it("shows one section at a time", async () => {

--- a/packages/ui-next/src/screens/Settings.tsx
+++ b/packages/ui-next/src/screens/Settings.tsx
@@ -157,7 +157,7 @@ export function Settings({ ported, onSwitchToClassic, onLocked }: SettingsProps)
         // `AgentAccess` genuinely does stay: it calls `gatedCapabilityIds` and
         // `isTauri` and no backend command at all.
         return (
-          <div className="flex flex-col gap-4">
+          <div className="settings-agent flex flex-col">
             <AgentAccess />
             {desktop ? (
               <>
@@ -286,7 +286,7 @@ export function Settings({ ported, onSwitchToClassic, onLocked }: SettingsProps)
           // The one Tab stop into the pane's own content, so a reader arrowing
           // to a section can Tab straight into it.
           tabIndex={0}
-          className={`scroll min-h-0 min-w-0 flex-1${active === "updates" || active === "clusters" ? "" : " p-3"}`}
+          className={`scroll min-h-0 min-w-0 flex-1${active === "updates" || active === "clusters" || active === "agent" ? "" : " p-3"}`}
         >
           {pane(active)}
           {desktop && updatesOpened && (

--- a/packages/ui-next/src/screens/Settings.tsx
+++ b/packages/ui-next/src/screens/Settings.tsx
@@ -172,7 +172,7 @@ export function Settings({ ported, onSwitchToClassic, onLocked }: SettingsProps)
                  the whole point is that nothing is asked to. */
               <p
                 data-testid="no-agent-server"
-                className="text-[0.75rem] leading-relaxed text-muted"
+                className="px-3 py-3 text-[0.75rem] leading-relaxed text-muted"
               >
                 The agent, the MCP server and its audit trail live in the srelens desktop app.
                 Provider keys, model lists, the agent CLIs, starting the loopback server and

--- a/packages/ui-next/src/screens/settings/AgentPane.tsx
+++ b/packages/ui-next/src/screens/settings/AgentPane.tsx
@@ -345,7 +345,7 @@ export function AgentPane() {
   const keyed = keyStatusRead.kind === "ready" ? keyStatusRead.value : null;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="settings-agent-groups flex flex-col">
       <Panel
         title="Providers"
         description="srelens's own agent talks directly to a provider with your API key. The key is written to the OS keychain and never read back — only whether one is set is shown here."

--- a/packages/ui-next/src/screens/settings/AuditPane.test.tsx
+++ b/packages/ui-next/src/screens/settings/AuditPane.test.tsx
@@ -207,4 +207,17 @@ describe("AuditPane", () => {
     expect(screen.queryByText("/prompts/broken.md")).toBeNull();
   });
 
+  it("keeps refresh available when one diagnostics read fails and its sibling is stuck", async () => {
+    core.readPromptIssues.mockRejectedValue(new Error("prompt unavailable"));
+    core.auditTail.mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup(); render(<AuditPane />);
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(/prompt unavailable/i);
+    const refresh = screen.getByRole("button", { name: "Refresh" });
+    expect((refresh as HTMLButtonElement).disabled).toBe(false);
+    await user.click(refresh);
+    expect(core.readPromptIssues).toHaveBeenCalledTimes(2);
+    expect(core.auditTail).toHaveBeenCalledTimes(2);
+  });
+
 });

--- a/packages/ui-next/src/screens/settings/AuditPane.test.tsx
+++ b/packages/ui-next/src/screens/settings/AuditPane.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 const core = vi.hoisted(() => ({
   auditTail: vi.fn(),
+  readPromptIssues: vi.fn(),
 }));
 vi.mock("@srelens/core", async (orig) => ({
   ...(await orig<typeof import("@srelens/core")>()),
@@ -42,6 +43,7 @@ describe("AuditPane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     core.auditTail.mockResolvedValue([DENIED, ALLOWED]);
+    core.readPromptIssues.mockResolvedValue([]);
   });
 
   it("says how much of the trail it is showing", async () => {
@@ -193,4 +195,16 @@ describe("AuditPane", () => {
     expect(headers).toContain("Transport");
     expect(headers).not.toContain("Client");
   });
+  it("shows prompt file diagnostics and refreshes them independently of the audit result", async () => {
+    core.readPromptIssues.mockResolvedValue([{ file: "/prompts/broken.md", problem: "Invalid frontmatter" }]);
+    core.auditTail.mockRejectedValue(new Error("audit unavailable"));
+    const user = userEvent.setup(); render(<AuditPane />);
+    expect(await screen.findByText("/prompts/broken.md")).toBeTruthy();
+    expect(screen.getByText(/Invalid frontmatter/)).toBeTruthy();
+    core.readPromptIssues.mockResolvedValue([]);
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    await screen.findByRole("button", { name: "Refresh" });
+    expect(screen.queryByText("/prompts/broken.md")).toBeNull();
+  });
+
 });

--- a/packages/ui-next/src/screens/settings/AuditPane.tsx
+++ b/packages/ui-next/src/screens/settings/AuditPane.tsx
@@ -251,10 +251,10 @@ export function AuditPane() {
         <Button
           variant="secondary"
           size="sm"
-          disabled={loading || issuesLoading}
+          disabled={(loading || issuesLoading) && error === null && issuesError === null}
           onClick={() => setNonce((n) => n + 1)}
         >
-          {loading || issuesLoading ? "Reading…" : "Refresh"}
+          {(loading || issuesLoading) && error === null && issuesError === null ? "Reading…" : "Refresh"}
         </Button>
       </div>
       {issuesError !== null && <FailureAlert tone="sev" title="Prompt file diagnostics could not be read" error={issuesError} />}

--- a/packages/ui-next/src/screens/settings/AuditPane.tsx
+++ b/packages/ui-next/src/screens/settings/AuditPane.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { auditTail, describeError, type AuditEntry } from "@srelens/core";
+import { auditTail, describeError, readPromptIssues, type PromptIssue, type AuditEntry } from "@srelens/core";
 import { Button, LoadingState, Panel, Section, Table, toneColor, type Column, type Tone } from "@srelens/ui-kit";
-import { FailureState } from "../../lib/errorCopy";
+import { FailureAlert, FailureState } from "../../lib/errorCopy";
 
 /**
  * §23's `Audit` pane: every capability call an MCP-connected agent has made,
@@ -196,6 +196,19 @@ export function AuditPane() {
    * supersedes it instead of racing it.
    */
   const [nonce, setNonce] = useState(0);
+  const [issues, setIssues] = useState<PromptIssue[]>([]);
+  const [issuesError, setIssuesError] = useState<unknown>(null);
+  const [issuesLoading, setIssuesLoading] = useState(true);
+  useEffect(() => {
+    let cancelled = false;
+    setIssuesLoading(true);
+    readPromptIssues().then(rows => {
+      if (!cancelled) { setIssues(rows); setIssuesError(null); }
+    }).catch(error => {
+      if (!cancelled) { setIssues([]); setIssuesError(error); }
+    }).finally(() => { if (!cancelled) setIssuesLoading(false); });
+    return () => { cancelled = true; };
+  }, [nonce]);
 
   useEffect(() => {
     let cancelled = false;
@@ -238,12 +251,19 @@ export function AuditPane() {
         <Button
           variant="secondary"
           size="sm"
-          disabled={loading}
+          disabled={loading || issuesLoading}
           onClick={() => setNonce((n) => n + 1)}
         >
-          {loading ? "Reading…" : "Refresh"}
+          {loading || issuesLoading ? "Reading…" : "Refresh"}
         </Button>
       </div>
+      {issuesError !== null && <FailureAlert tone="sev" title="Prompt file diagnostics could not be read" error={issuesError} />}
+      {!issuesLoading && issues.length > 0 && <div className="mt-3 border-y border-rule py-2 text-[0.75rem]">
+        <p className="font-medium">{issues.length} prompt {issues.length === 1 ? "file" : "files"} could not be loaded</p>
+        <ul className="mt-1 space-y-1">{issues.map(issue => <li key={`${issue.file}:${issue.problem}`}>
+          <code className="block overflow-x-auto whitespace-nowrap">{issue.file}</code><span className="text-muted">{issue.problem}</span>
+        </li>)}</ul>
+      </div>}
       {loading ? (
         <LoadingState label="Reading the audit trail" />
       ) : error !== null ? (

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { McpClientSetup } from "./McpClientSetup";
@@ -6,11 +6,13 @@ const core = vi.hoisted(() => ({ installSrelensCli: vi.fn(), srelensCliStatus: v
 vi.mock("@srelens/core", async original => ({ ...await original<object>(), ...core }));
 const URL = "http://127.0.0.1:9411/mcp";
 const TOKEN = "a".repeat(64);
+const PLATFORM = navigator.platform;
 beforeEach(() => {
   vi.clearAllMocks();
   core.srelensCliStatus.mockResolvedValue({ installed: false, path: "/home/user/.local/bin/srelens", links_to: null, on_path: false });
   core.installSrelensCli.mockResolvedValue("/home/user/.local/bin/srelens");
 });
+afterEach(() => Object.defineProperty(navigator, "platform", { configurable: true, value: PLATFORM }));
 it("installs the CLI and refreshes its PATH status", async () => {
   const user = userEvent.setup(); render(<McpClientSetup url={URL} token={TOKEN} />);
   await screen.findByRole("button", { name: "Install srelens CLI" });
@@ -50,4 +52,36 @@ it("reports installation failure and allows retry", async () => {
   expect((await screen.findByRole("alert")).textContent).toMatch(/permission denied/i);
   await user.click(screen.getByRole("button", { name: "Install srelens CLI" }));
   expect(core.installSrelensCli).toHaveBeenCalledTimes(2);
+});
+it("generates Windows stdio config with the absolute desktop executable", async () => {
+  Object.defineProperty(navigator, "platform", { configurable: true, value: "Win32" });
+  const executable = String.raw`C:\Program Files\srelens\srelens.exe`;
+  core.srelensCliStatus.mockResolvedValue({ installed: true, path: executable, links_to: null, on_path: false });
+  render(<McpClientSetup url={URL} token={TOKEN} />);
+  expect(await screen.findAllByText(new RegExp(executable.replace(/[\\]/g, "\\\\")))).not.toHaveLength(0);
+  await userEvent.selectOptions(screen.getByLabelText("MCP client"), "cursor");
+  expect(JSON.parse(screen.getByTestId("mcp-client-config").textContent!).mcpServers.srelens.command).toBe(executable);
+  expect(screen.queryByRole("button", { name: /Install srelens CLI/ })).toBeNull();
+});
+it("reports failed HTTP prerequisites and retries them instead of claiming the server is stopped", async () => {
+  const retryStatus = vi.fn(); const retryToken = vi.fn();
+  const user = userEvent.setup();
+  render(<McpClientSetup url={null} token={null} statusError={new Error("status denied")} tokenError={new Error("token denied")}
+    onRetryStatus={retryStatus} onRetryToken={retryToken} />);
+  await user.selectOptions(screen.getByLabelText("Transport"), "http");
+  expect(screen.getByText(/status denied/)).toBeTruthy();
+  expect(screen.getByText(/token denied/)).toBeTruthy();
+  expect(screen.queryByText(/Start the MCP server/)).toBeNull();
+  await user.click(screen.getByRole("button", { name: "Retry server status" }));
+  await user.click(screen.getByRole("button", { name: "Retry bearer token" }));
+  expect(retryStatus).toHaveBeenCalledOnce(); expect(retryToken).toHaveBeenCalledOnce();
+});
+it("reveals the usable HTTP configuration when clipboard copying fails", async () => {
+  vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(new Error("clipboard denied"));
+  const user = userEvent.setup(); render(<McpClientSetup url={URL} token={TOKEN} />);
+  await user.selectOptions(screen.getByLabelText("Transport"), "http");
+  expect(screen.getByTestId("mcp-client-config").textContent).not.toContain(TOKEN);
+  await user.click(screen.getByRole("button", { name: "Copy configuration" }));
+  expect(screen.getByRole("alert").textContent).toMatch(/copy (?:it )?manually/);
+  expect(screen.getByTestId("mcp-client-config").textContent).toContain(TOKEN);
 });

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -60,6 +60,13 @@ it("reports installation failure and allows retry", async () => {
   await user.click(screen.getByRole("button", { name: "Install srelens CLI" }));
   expect(core.installSrelensCli).toHaveBeenCalledTimes(2);
 });
+it("does not offer installation after CLI status could not be read", async () => {
+  core.srelensCliStatus.mockRejectedValue(new Error("status unavailable"));
+  render(<McpClientSetup url={URL} token={TOKEN} />);
+  const install = await screen.findByRole("button", { name: "Install srelens CLI" });
+  expect((install as HTMLButtonElement).disabled).toBe(true);
+  expect(screen.getByRole("alert").textContent).toMatch(/status unavailable/i);
+});
 it("generates Windows stdio config with the absolute desktop executable", async () => {
   Object.defineProperty(navigator, "platform", { configurable: true, value: "Win32" });
   const executable = String.raw`C:\Program Files\srelens\srelens.exe`;
@@ -91,4 +98,7 @@ it("reveals the usable HTTP configuration when clipboard copying fails", async (
   await user.click(screen.getByRole("button", { name: "Copy configuration" }));
   expect(screen.getByRole("alert").textContent).toMatch(/copy (?:it )?manually/);
   expect(screen.getByTestId("mcp-client-config").textContent).toContain(TOKEN);
+  await user.click(screen.getByRole("button", { name: "Hide configuration token" }));
+  expect(screen.queryByRole("alert")).toBeNull();
+  expect(screen.getByTestId("mcp-client-config").textContent).not.toContain(TOKEN);
 });

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -85,9 +85,26 @@ it("generates Windows stdio config with the absolute desktop executable", async 
   core.srelensCliStatus.mockResolvedValue({ installed: true, path: executable, links_to: null, on_path: false });
   render(<McpClientSetup url={URL} token={TOKEN} />);
   expect(await screen.findAllByText(new RegExp(executable.replace(/[\\]/g, "\\\\")))).not.toHaveLength(0);
+  const reportedPath = screen.getAllByText(executable).find(element => element.tagName === "CODE")!;
+  expect(reportedPath.className).toMatch(/overflow-x-auto/);
+  expect(reportedPath.className).toMatch(/whitespace-nowrap/);
   await userEvent.selectOptions(screen.getByLabelText("MCP client"), "cursor");
   expect(JSON.parse(screen.getByTestId("mcp-client-config").textContent!).mcpServers.srelens.command).toBe(executable);
   expect(screen.queryByRole("button", { name: /Install srelens CLI/ })).toBeNull();
+});
+it("keeps the transient installed path on one horizontally scrollable line", async () => {
+  const executable = "/home/user/My CLI/srelens";
+  let finishStatus!: (value: object) => void;
+  core.installSrelensCli.mockResolvedValue(executable);
+  core.srelensCliStatus
+    .mockResolvedValueOnce({ installed: false, path: executable, links_to: null, on_path: false })
+    .mockImplementationOnce(() => new Promise(resolve => { finishStatus = resolve; }));
+  const user = userEvent.setup(); render(<McpClientSetup url={URL} token={TOKEN} />);
+  await user.click(await screen.findByRole("button", { name: "Install srelens CLI" }));
+  const path = await screen.findByText(executable);
+  expect(path.className).toMatch(/overflow-x-auto/);
+  expect(path.className).toMatch(/whitespace-nowrap/);
+  finishStatus({ installed: true, path: executable, links_to: executable, on_path: true });
 });
 it("reports failed HTTP prerequisites and retries them instead of claiming the server is stopped", async () => {
   const retryStatus = vi.fn(); const retryToken = vi.fn();

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { McpClientSetup } from "./McpClientSetup";
+const core = vi.hoisted(() => ({ installSrelensCli: vi.fn(), srelensCliStatus: vi.fn() }));
+vi.mock("@srelens/core", async original => ({ ...await original<object>(), ...core }));
+const URL = "http://127.0.0.1:9411/mcp";
+const TOKEN = "a".repeat(64);
+beforeEach(() => {
+  vi.clearAllMocks();
+  core.srelensCliStatus.mockResolvedValue({ installed: false, path: "/home/user/.local/bin/srelens", links_to: null, on_path: false });
+  core.installSrelensCli.mockResolvedValue("/home/user/.local/bin/srelens");
+});
+it("installs the CLI and refreshes its PATH status", async () => {
+  const user = userEvent.setup(); render(<McpClientSetup url={URL} token={TOKEN} />);
+  await screen.findByRole("button", { name: "Install srelens CLI" });
+  core.srelensCliStatus.mockResolvedValue({ installed: true, path: "/home/user/.local/bin/srelens", on_path: false });
+  await user.click(screen.getByRole("button", { name: "Install srelens CLI" }));
+  expect(core.installSrelensCli).toHaveBeenCalledOnce();
+  expect(await screen.findByRole("button", { name: "Reinstall srelens CLI" })).toBeTruthy();
+  expect(screen.getByText(/Add.*to PATH/).textContent).toContain("/home/user/.local/bin");
+});
+it("generates current HTTP config, masks its token, and copies the usable value", async () => {
+  const user = userEvent.setup();
+  const copy = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+  const view = render(<McpClientSetup url={URL} token={TOKEN} />);
+  await user.selectOptions(screen.getByLabelText("MCP client"), "cursor");
+  await user.selectOptions(screen.getByLabelText("Transport"), "http");
+  expect(screen.getByTestId("mcp-client-config").textContent).toContain(URL);
+  expect(screen.getByTestId("mcp-client-config").textContent).not.toContain(TOKEN);
+  await user.click(screen.getByRole("button", { name: "Copy configuration" }));
+  expect(JSON.parse(copy.mock.calls[0][0]).mcpServers.srelens.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  view.rerender(<McpClientSetup url="http://127.0.0.1:9511/mcp" token={"b".repeat(64)} />);
+  await user.click(screen.getByRole("button", { name: "Copy configuration" }));
+  expect(copy.mock.lastCall?.[0]).toContain("9511");
+  expect(copy.mock.lastCall?.[0]).toContain("b".repeat(64));
+});
+it("requires a known URL and token for HTTP config, while stdio stays available", async () => {
+  const user = userEvent.setup(); render(<McpClientSetup url={null} token={null} />);
+  await user.selectOptions(screen.getByLabelText("Transport"), "http");
+  expect((screen.getByRole("button", { name: "Copy configuration" }) as HTMLButtonElement).disabled).toBe(true);
+  await user.selectOptions(screen.getByLabelText("Transport"), "stdio");
+  expect(screen.getByTestId("mcp-client-config").textContent).toContain("--mcp-stdio");
+  expect((screen.getByRole("button", { name: "Copy configuration" }) as HTMLButtonElement).disabled).toBe(false);
+});
+it("reports installation failure and allows retry", async () => {
+  core.installSrelensCli.mockRejectedValueOnce(new Error("permission denied"));
+  const user = userEvent.setup(); render(<McpClientSetup url={URL} token={TOKEN} />);
+  await user.click(await screen.findByRole("button", { name: "Install srelens CLI" }));
+  expect((await screen.findByRole("alert")).textContent).toMatch(/permission denied/i);
+  await user.click(screen.getByRole("button", { name: "Install srelens CLI" }));
+  expect(core.installSrelensCli).toHaveBeenCalledTimes(2);
+});

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -60,6 +60,18 @@ it("reports installation failure and allows retry", async () => {
   await user.click(screen.getByRole("button", { name: "Install srelens CLI" }));
   expect(core.installSrelensCli).toHaveBeenCalledTimes(2);
 });
+it("rechecks CLI status after a failed reinstall invalidates the old target", async () => {
+  core.srelensCliStatus
+    .mockResolvedValueOnce({ installed: true, path: "/home/user/.local/bin/srelens", links_to: null, on_path: true })
+    .mockResolvedValueOnce({ installed: false, path: "/home/user/.local/bin/srelens", links_to: null, on_path: false });
+  core.installSrelensCli.mockRejectedValueOnce(new Error("link failed"));
+  const user = userEvent.setup(); render(<McpClientSetup url={URL} token={TOKEN} />);
+  await user.click(await screen.findByRole("button", { name: "Reinstall srelens CLI" }));
+  expect(await screen.findByRole("button", { name: "Install srelens CLI" })).toBeTruthy();
+  expect(core.srelensCliStatus).toHaveBeenCalledTimes(2);
+  expect((screen.getByRole("button", { name: "Copy configuration" }) as HTMLButtonElement).disabled).toBe(true);
+  expect(screen.getByRole("alert").textContent).toMatch(/link failed/i);
+});
 it("does not offer installation after CLI status could not be read", async () => {
   core.srelensCliStatus.mockRejectedValue(new Error("status unavailable"));
   render(<McpClientSetup url={URL} token={TOKEN} />);

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -90,6 +90,22 @@ it("reports failed HTTP prerequisites and retries them instead of claiming the s
   await user.click(screen.getByRole("button", { name: "Retry bearer token" }));
   expect(retryStatus).toHaveBeenCalledOnce(); expect(retryToken).toHaveBeenCalledOnce();
 });
+it("shows a failed prerequisite while the sibling read is still loading", async () => {
+  const retryStatus = vi.fn(); const retryToken = vi.fn();
+  const user = userEvent.setup();
+  const view = render(<McpClientSetup url={null} token={null} statusError={new Error("status denied")} tokenLoading
+    onRetryStatus={retryStatus} />);
+  await user.selectOptions(screen.getByLabelText("Transport"), "http");
+  expect(screen.getByText(/status denied/)).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Retry server status" })).toBeTruthy();
+  expect(screen.getByRole("status").textContent).toMatch(/Checking/);
+
+  view.rerender(<McpClientSetup url={null} token={null} tokenError={new Error("token denied")} statusLoading
+    onRetryToken={retryToken} />);
+  expect(screen.getByText(/token denied/)).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Retry bearer token" })).toBeTruthy();
+  expect(screen.getByRole("status").textContent).toMatch(/Checking/);
+});
 it("reveals the usable HTTP configuration when clipboard copying fails", async () => {
   vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(new Error("clipboard denied"));
   const user = userEvent.setup(); render(<McpClientSetup url={URL} token={TOKEN} />);

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -102,6 +102,19 @@ it("reports failed HTTP prerequisites and retries them instead of claiming the s
   await user.click(screen.getByRole("button", { name: "Retry bearer token" }));
   expect(retryStatus).toHaveBeenCalledOnce(); expect(retryToken).toHaveBeenCalledOnce();
 });
+it("exposes server read retries while stdio remains selected", async () => {
+  const retryStatus = vi.fn(); const retryToken = vi.fn();
+  const user = userEvent.setup();
+  render(<McpClientSetup url={null} token={null} statusError={new Error("status denied")} tokenError={new Error("token denied")}
+    onRetryStatus={retryStatus} onRetryToken={retryToken} />);
+
+  expect((screen.getByLabelText("Transport") as HTMLSelectElement).value).toBe("stdio");
+  expect(screen.getByText(/status denied/)).toBeTruthy();
+  expect(screen.getByText(/token denied/)).toBeTruthy();
+  await user.click(screen.getByRole("button", { name: "Retry server status" }));
+  await user.click(screen.getByRole("button", { name: "Retry bearer token" }));
+  expect(retryStatus).toHaveBeenCalledOnce(); expect(retryToken).toHaveBeenCalledOnce();
+});
 it("shows a failed prerequisite while the sibling read is still loading", async () => {
   const retryStatus = vi.fn(); const retryToken = vi.fn();
   const user = userEvent.setup();

--- a/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.test.tsx
@@ -37,12 +37,19 @@ it("generates current HTTP config, masks its token, and copies the usable value"
   expect(copy.mock.lastCall?.[0]).toContain("9511");
   expect(copy.mock.lastCall?.[0]).toContain("b".repeat(64));
 });
-it("requires a known URL and token for HTTP config, while stdio stays available", async () => {
+it("requires known connection details before enabling either transport", async () => {
   const user = userEvent.setup(); render(<McpClientSetup url={null} token={null} />);
   await user.selectOptions(screen.getByLabelText("Transport"), "http");
   expect((screen.getByRole("button", { name: "Copy configuration" }) as HTMLButtonElement).disabled).toBe(true);
   await user.selectOptions(screen.getByLabelText("Transport"), "stdio");
-  expect(screen.getByTestId("mcp-client-config").textContent).toContain("--mcp-stdio");
+  expect(screen.queryByTestId("mcp-client-config")).toBeNull();
+  expect((screen.getByRole("button", { name: "Copy configuration" }) as HTMLButtonElement).disabled).toBe(true);
+});
+it("uses an installed Unix CLI's absolute path even when it is not on PATH", async () => {
+  const executable = "/home/user/.local/bin/srelens";
+  core.srelensCliStatus.mockResolvedValue({ installed: true, path: executable, links_to: "/Applications/srelens", on_path: false });
+  render(<McpClientSetup url={URL} token={TOKEN} />);
+  expect((await screen.findByTestId("mcp-client-config")).textContent).toContain(executable);
   expect((screen.getByRole("button", { name: "Copy configuration" }) as HTMLButtonElement).disabled).toBe(false);
 });
 it("reports installation failure and allows retry", async () => {

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { installSrelensCli, srelensCliStatus, mcpClientConfig, MCP_TOOLS, type CliStatus, type McpTool, type McpTransport } from "@srelens/core";
+import { Button, Field, Panel, Select } from "@srelens/ui-kit";
+import { FailureAlert } from "../../lib/errorCopy";
+
+export function McpClientSetup({ url, token }: { url: string | null; token: string | null }) {
+  const [cli, setCli] = useState<CliStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [readError, setReadError] = useState<unknown>(null);
+  const [installError, setInstallError] = useState<unknown>(null);
+  const [installedAt, setInstalledAt] = useState("");
+  const [nonce, setNonce] = useState(0);
+  const [tool, setTool] = useState<McpTool>("claude-code");
+  const [transport, setTransport] = useState<McpTransport>("stdio");
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    srelensCliStatus().then(status => {
+      if (!cancelled) { setCli(status); setReadError(null); }
+    }).catch(error => { if (!cancelled) { setCli(null); setReadError(error); } })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [nonce]);
+  useEffect(() => { setCopyState("idle"); setRevealed(false); }, [url, token, tool, transport]);
+
+  async function install() {
+    setBusy(true); setInstallError(null); setInstalledAt("");
+    try { setInstalledAt(await installSrelensCli()); setNonce(n => n + 1); }
+    catch (error) { setInstallError(error); }
+    finally { setBusy(false); }
+  }
+  const ready = transport === "stdio" || (!!url && !!token);
+  const config = mcpClientConfig(tool, transport, { url: url ?? undefined, token });
+  const preview = mcpClientConfig(tool, transport, { url: url ?? undefined, token: token && !revealed ? "<hidden token>" : token });
+  async function copy() {
+    if (!ready) return;
+    try { await navigator.clipboard.writeText(config.snippet); setCopyState("copied"); }
+    catch { setCopyState("failed"); }
+  }
+  return <>
+    <Panel title="srelens CLI" description="Install the srelens command so MCP clients can start a stdio connection.">
+      {loading ? <p role="status" className="text-[0.75rem] text-muted">Checking CLI installation…</p> :
+        cli && <p className="text-[0.75rem] text-muted">{cli.installed ? <>Installed at <code>{cli.path}</code></> : "The srelens CLI is not installed."}</p>}
+      <div className="mt-2 flex flex-wrap gap-2">
+        <Button variant="secondary" disabled={loading || busy} onClick={() => void install()}>
+          {busy ? "Installing…" : cli?.installed ? "Reinstall srelens CLI" : "Install srelens CLI"}
+        </Button>
+        {readError !== null && <Button variant="ghost" disabled={loading || busy} onClick={() => setNonce(n => n + 1)}>Retry status</Button>}
+      </div>
+      {cli?.installed && !cli.on_path && <p className="mt-2 text-[0.75rem] text-muted">Add <code>{cli.path.replace(/[/\\][^/\\]+$/, "")}</code> to PATH, then restart your MCP client.</p>}
+      {installedAt && !cli?.installed && <p role="status" className="mt-2 text-[0.75rem]">CLI installed at <code>{installedAt}</code>.</p>}
+      {readError !== null && <FailureAlert tone="sev" title="Could not check the CLI installation" error={readError} />}
+      {installError !== null && <FailureAlert tone="sev" title="Could not install the srelens CLI" error={installError} />}
+    </Panel>
+    <Panel title="Connect a client">
+      <div className="flex flex-wrap gap-3">
+        <Field label="MCP client"><Select value={tool} onValueChange={value => setTool(value as McpTool)} options={MCP_TOOLS.map(t => ({ value: t.id, label: t.label }))} /></Field>
+        <Field label="Transport"><Select value={transport} onValueChange={value => setTransport(value as McpTransport)} options={[{ value: "stdio", label: "stdio" }, { value: "http", label: "HTTP" }]} /></Field>
+      </div>
+      <p className="mt-2 text-[0.75rem] text-muted">{preview.hint}</p>
+      {transport === "http" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">Start the MCP server to obtain its address and bearer token.</p> :
+        <pre data-testid="mcp-client-config" className="scroll mt-2 whitespace-pre border-y border-rule py-2 text-[0.75rem]"><code>{preview.snippet}</code></pre>}
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <Button variant="secondary" disabled={!ready} onClick={() => void copy()}>Copy configuration</Button>
+        {transport === "http" && ready && <>
+          <Button variant="ghost" onClick={() => setRevealed(value => !value)}>{revealed ? "Hide configuration token" : "Reveal configuration token"}</Button>
+          <span className="text-[0.6875rem] text-muted">Copy includes the bearer token.</span>
+        </>}
+        {copyState === "copied" && <span role="status" className="text-[0.75rem]">Configuration copied.</span>}
+        {copyState === "failed" && <span role="alert" className="text-[0.75rem]">Could not copy. Select the configuration and copy it manually.</span>}
+      </div>
+    </Panel>
+  </>;
+}

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -84,6 +84,12 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
         <Field label="Transport"><Select value={transport} onValueChange={value => setTransport(value as McpTransport)} options={[{ value: "stdio", label: "stdio" }, { value: "http", label: "HTTP" }]} /></Field>
       </div>
       <p className="mt-2 text-[0.75rem] text-muted">{preview.hint}</p>
+      {transport !== "http" && (statusError !== undefined || tokenError !== undefined) && <div className="mt-2 space-y-2">
+        {statusError !== undefined && <><FailureAlert tone="sev" title="The MCP server status could not be read" error={statusError} />
+          {onRetryStatus && <Button variant="ghost" onClick={onRetryStatus}>Retry server status</Button>}</>}
+        {tokenError !== undefined && <><FailureAlert tone="sev" title="The MCP bearer token could not be read" error={tokenError} />
+          {onRetryToken && <Button variant="ghost" onClick={onRetryToken}>Retry bearer token</Button>}</>}
+      </div>}
       {transport === "http" && (statusError !== undefined || tokenError !== undefined) ? <div className="mt-2 space-y-2">
           {statusError !== undefined && <><FailureAlert tone="sev" title="The MCP server status could not be read" error={statusError} />
             {onRetryStatus && <Button variant="ghost" onClick={onRetryStatus}>Retry server status</Button>}</>}

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -48,8 +48,9 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
   }
   const command = cli?.installed && cli.path ? cli.path : undefined;
   const ready = transport === "stdio" ? (!loading && readError === null && !!command) : (!statusLoading && !tokenLoading && statusError === undefined && tokenError === undefined && !!url && !!token);
-  const config = mcpClientConfig(tool, transport, { url: url ?? undefined, token, command });
-  const preview = mcpClientConfig(tool, transport, { url: url ?? undefined, token: token && !revealed ? "<hidden token>" : token, command });
+  const platform = windows ? "windows" : "unix";
+  const config = mcpClientConfig(tool, transport, { url: url ?? undefined, token, command, platform });
+  const preview = mcpClientConfig(tool, transport, { url: url ?? undefined, token: token && !revealed ? "<hidden token>" : token, command, platform });
   async function copy() {
     if (!ready) return;
     try { await navigator.clipboard.writeText(config.snippet); setCopyState("copied"); }
@@ -77,13 +78,14 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
         <Field label="Transport"><Select value={transport} onValueChange={value => setTransport(value as McpTransport)} options={[{ value: "stdio", label: "stdio" }, { value: "http", label: "HTTP" }]} /></Field>
       </div>
       <p className="mt-2 text-[0.75rem] text-muted">{preview.hint}</p>
-      {transport === "http" && (statusLoading || tokenLoading) ? <p role="status" className="mt-2 text-[0.75rem] text-muted">Checking the MCP server address and bearer token…</p> :
-        transport === "http" && (statusError !== undefined || tokenError !== undefined) ? <div className="mt-2 space-y-2">
+      {transport === "http" && (statusError !== undefined || tokenError !== undefined) ? <div className="mt-2 space-y-2">
           {statusError !== undefined && <><FailureAlert tone="sev" title="The MCP server status could not be read" error={statusError} />
             {onRetryStatus && <Button variant="ghost" onClick={onRetryStatus}>Retry server status</Button>}</>}
           {tokenError !== undefined && <><FailureAlert tone="sev" title="The MCP bearer token could not be read" error={tokenError} />
             {onRetryToken && <Button variant="ghost" onClick={onRetryToken}>Retry bearer token</Button>}</>}
-        </div> : transport === "http" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">Start the MCP server to obtain its address and bearer token.</p> :
+          {(statusLoading || tokenLoading) && <p role="status" className="text-[0.75rem] text-muted">Checking the remaining MCP server details…</p>}
+        </div> : transport === "http" && (statusLoading || tokenLoading) ? <p role="status" className="mt-2 text-[0.75rem] text-muted">Checking the MCP server address and bearer token…</p> :
+        transport === "http" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">Start the MCP server to obtain its address and bearer token.</p> :
         transport === "stdio" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">{windows ? "The desktop executable path is required before a Windows stdio configuration can be generated." : "Install the srelens CLI before generating a stdio configuration."}</p> :
         <pre data-testid="mcp-client-config" className="scroll mt-2 whitespace-pre border-y border-rule py-2 text-[0.75rem]"><code>{preview.snippet}</code></pre>}
       <div className="mt-2 flex flex-wrap items-center gap-2">

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -43,7 +43,13 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
   async function install() {
     setBusy(true); setInstallError(null); setInstalledAt("");
     try { setInstalledAt(await installSrelensCli()); setNonce(n => n + 1); }
-    catch (error) { setInstallError(error); }
+    catch (error) {
+      // Installation can remove an existing target before replacement. Do
+      // not keep presenting the pre-install status after a mutating failure.
+      setCli(null);
+      setInstallError(error);
+      setNonce(n => n + 1);
+    }
     finally { setBusy(false); }
   }
   const command = cli?.installed && cli.path ? cli.path : undefined;

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -46,8 +46,8 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
     catch (error) { setInstallError(error); }
     finally { setBusy(false); }
   }
-  const command = windows ? cli?.path || undefined : undefined;
-  const ready = transport === "stdio" ? (!windows || !!command) : (!statusLoading && !tokenLoading && statusError === undefined && tokenError === undefined && !!url && !!token);
+  const command = cli?.installed && cli.path ? cli.path : undefined;
+  const ready = transport === "stdio" ? (!loading && readError === null && !!command) : (!statusLoading && !tokenLoading && statusError === undefined && tokenError === undefined && !!url && !!token);
   const config = mcpClientConfig(tool, transport, { url: url ?? undefined, token, command });
   const preview = mcpClientConfig(tool, transport, { url: url ?? undefined, token: token && !revealed ? "<hidden token>" : token, command });
   async function copy() {
@@ -84,7 +84,7 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
           {tokenError !== undefined && <><FailureAlert tone="sev" title="The MCP bearer token could not be read" error={tokenError} />
             {onRetryToken && <Button variant="ghost" onClick={onRetryToken}>Retry bearer token</Button>}</>}
         </div> : transport === "http" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">Start the MCP server to obtain its address and bearer token.</p> :
-        transport === "stdio" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">The desktop executable path is required before a Windows stdio configuration can be generated.</p> :
+        transport === "stdio" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">{windows ? "The desktop executable path is required before a Windows stdio configuration can be generated." : "Install the srelens CLI before generating a stdio configuration."}</p> :
         <pre data-testid="mcp-client-config" className="scroll mt-2 whitespace-pre border-y border-rule py-2 text-[0.75rem]"><code>{preview.snippet}</code></pre>}
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <Button variant="secondary" disabled={!ready} onClick={() => void copy()}>Copy configuration</Button>

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -61,7 +61,7 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
         cli && <p className="text-[0.75rem] text-muted">{windows ? (cli.path ? <>Using <code>{cli.path}</code></> : "The desktop executable could not be located.") :
           cli.installed ? <>Installed at <code>{cli.path}</code></> : "The srelens CLI is not installed."}</p>}
       <div className="mt-2 flex flex-wrap gap-2">
-        {!windows && <Button variant="secondary" disabled={loading || busy} onClick={() => void install()}>
+        {!windows && <Button variant="secondary" disabled={loading || busy || readError !== null} onClick={() => void install()}>
           {busy ? "Installing…" : cli?.installed ? "Reinstall srelens CLI" : "Install srelens CLI"}
         </Button>}
         {readError !== null && <Button variant="ghost" disabled={loading || busy} onClick={() => setNonce(n => n + 1)}>Retry status</Button>}
@@ -89,7 +89,7 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <Button variant="secondary" disabled={!ready} onClick={() => void copy()}>Copy configuration</Button>
         {transport === "http" && ready && <>
-          <Button variant="ghost" onClick={() => setRevealed(value => !value)}>{revealed ? "Hide configuration token" : "Reveal configuration token"}</Button>
+          <Button variant="ghost" onClick={() => { setRevealed(value => !value); if (copyState === "failed") setCopyState("idle"); }}>{revealed ? "Hide configuration token" : "Reveal configuration token"}</Button>
           <span className="text-[0.6875rem] text-muted">Copy includes the bearer token.</span>
         </>}
         {copyState === "copied" && <span role="status" className="text-[0.75rem]">Configuration copied.</span>}

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -3,7 +3,19 @@ import { installSrelensCli, srelensCliStatus, mcpClientConfig, MCP_TOOLS, type C
 import { Button, Field, Panel, Select } from "@srelens/ui-kit";
 import { FailureAlert } from "../../lib/errorCopy";
 
-export function McpClientSetup({ url, token }: { url: string | null; token: string | null }) {
+interface McpClientSetupProps {
+  url: string | null;
+  token: string | null;
+  statusLoading?: boolean;
+  tokenLoading?: boolean;
+  statusError?: unknown;
+  tokenError?: unknown;
+  onRetryStatus?: () => void;
+  onRetryToken?: () => void;
+}
+
+export function McpClientSetup({ url, token, statusLoading = false, tokenLoading = false,
+  statusError, tokenError, onRetryStatus, onRetryToken }: McpClientSetupProps) {
   const [cli, setCli] = useState<CliStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
@@ -15,6 +27,7 @@ export function McpClientSetup({ url, token }: { url: string | null; token: stri
   const [transport, setTransport] = useState<McpTransport>("stdio");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const [revealed, setRevealed] = useState(false);
+  const windows = /win/i.test(navigator.platform ?? "");
 
   useEffect(() => {
     let cancelled = false;
@@ -33,25 +46,27 @@ export function McpClientSetup({ url, token }: { url: string | null; token: stri
     catch (error) { setInstallError(error); }
     finally { setBusy(false); }
   }
-  const ready = transport === "stdio" || (!!url && !!token);
-  const config = mcpClientConfig(tool, transport, { url: url ?? undefined, token });
-  const preview = mcpClientConfig(tool, transport, { url: url ?? undefined, token: token && !revealed ? "<hidden token>" : token });
+  const command = windows ? cli?.path || undefined : undefined;
+  const ready = transport === "stdio" ? (!windows || !!command) : (!statusLoading && !tokenLoading && statusError === undefined && tokenError === undefined && !!url && !!token);
+  const config = mcpClientConfig(tool, transport, { url: url ?? undefined, token, command });
+  const preview = mcpClientConfig(tool, transport, { url: url ?? undefined, token: token && !revealed ? "<hidden token>" : token, command });
   async function copy() {
     if (!ready) return;
     try { await navigator.clipboard.writeText(config.snippet); setCopyState("copied"); }
-    catch { setCopyState("failed"); }
+    catch { if (transport === "http") setRevealed(true); setCopyState("failed"); }
   }
   return <>
-    <Panel title="srelens CLI" description="Install the srelens command so MCP clients can start a stdio connection.">
+    <Panel title="srelens CLI" description={windows ? "Windows MCP clients start the installed desktop executable directly." : "Install the srelens command so MCP clients can start a stdio connection."}>
       {loading ? <p role="status" className="text-[0.75rem] text-muted">Checking CLI installation…</p> :
-        cli && <p className="text-[0.75rem] text-muted">{cli.installed ? <>Installed at <code>{cli.path}</code></> : "The srelens CLI is not installed."}</p>}
+        cli && <p className="text-[0.75rem] text-muted">{windows ? (cli.path ? <>Using <code>{cli.path}</code></> : "The desktop executable could not be located.") :
+          cli.installed ? <>Installed at <code>{cli.path}</code></> : "The srelens CLI is not installed."}</p>}
       <div className="mt-2 flex flex-wrap gap-2">
-        <Button variant="secondary" disabled={loading || busy} onClick={() => void install()}>
+        {!windows && <Button variant="secondary" disabled={loading || busy} onClick={() => void install()}>
           {busy ? "Installing…" : cli?.installed ? "Reinstall srelens CLI" : "Install srelens CLI"}
-        </Button>
+        </Button>}
         {readError !== null && <Button variant="ghost" disabled={loading || busy} onClick={() => setNonce(n => n + 1)}>Retry status</Button>}
       </div>
-      {cli?.installed && !cli.on_path && <p className="mt-2 text-[0.75rem] text-muted">Add <code>{cli.path.replace(/[/\\][^/\\]+$/, "")}</code> to PATH, then restart your MCP client.</p>}
+      {!windows && cli?.installed && !cli.on_path && <p className="mt-2 text-[0.75rem] text-muted">Add <code>{cli.path.replace(/[/\\][^/\\]+$/, "")}</code> to PATH, then restart your MCP client.</p>}
       {installedAt && !cli?.installed && <p role="status" className="mt-2 text-[0.75rem]">CLI installed at <code>{installedAt}</code>.</p>}
       {readError !== null && <FailureAlert tone="sev" title="Could not check the CLI installation" error={readError} />}
       {installError !== null && <FailureAlert tone="sev" title="Could not install the srelens CLI" error={installError} />}
@@ -62,7 +77,14 @@ export function McpClientSetup({ url, token }: { url: string | null; token: stri
         <Field label="Transport"><Select value={transport} onValueChange={value => setTransport(value as McpTransport)} options={[{ value: "stdio", label: "stdio" }, { value: "http", label: "HTTP" }]} /></Field>
       </div>
       <p className="mt-2 text-[0.75rem] text-muted">{preview.hint}</p>
-      {transport === "http" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">Start the MCP server to obtain its address and bearer token.</p> :
+      {transport === "http" && (statusLoading || tokenLoading) ? <p role="status" className="mt-2 text-[0.75rem] text-muted">Checking the MCP server address and bearer token…</p> :
+        transport === "http" && (statusError !== undefined || tokenError !== undefined) ? <div className="mt-2 space-y-2">
+          {statusError !== undefined && <><FailureAlert tone="sev" title="The MCP server status could not be read" error={statusError} />
+            {onRetryStatus && <Button variant="ghost" onClick={onRetryStatus}>Retry server status</Button>}</>}
+          {tokenError !== undefined && <><FailureAlert tone="sev" title="The MCP bearer token could not be read" error={tokenError} />
+            {onRetryToken && <Button variant="ghost" onClick={onRetryToken}>Retry bearer token</Button>}</>}
+        </div> : transport === "http" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">Start the MCP server to obtain its address and bearer token.</p> :
+        transport === "stdio" && !ready ? <p className="mt-2 text-[0.75rem] text-muted">The desktop executable path is required before a Windows stdio configuration can be generated.</p> :
         <pre data-testid="mcp-client-config" className="scroll mt-2 whitespace-pre border-y border-rule py-2 text-[0.75rem]"><code>{preview.snippet}</code></pre>}
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <Button variant="secondary" disabled={!ready} onClick={() => void copy()}>Copy configuration</Button>
@@ -71,7 +93,7 @@ export function McpClientSetup({ url, token }: { url: string | null; token: stri
           <span className="text-[0.6875rem] text-muted">Copy includes the bearer token.</span>
         </>}
         {copyState === "copied" && <span role="status" className="text-[0.75rem]">Configuration copied.</span>}
-        {copyState === "failed" && <span role="alert" className="text-[0.75rem]">Could not copy. Select the configuration and copy it manually.</span>}
+        {copyState === "failed" && <span role="alert" className="text-[0.75rem]">Could not copy. The usable configuration is revealed above; select it and copy manually.</span>}
       </div>
     </Panel>
   </>;

--- a/packages/ui-next/src/screens/settings/McpClientSetup.tsx
+++ b/packages/ui-next/src/screens/settings/McpClientSetup.tsx
@@ -65,8 +65,8 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
   return <>
     <Panel title="srelens CLI" description={windows ? "Windows MCP clients start the installed desktop executable directly." : "Install the srelens command so MCP clients can start a stdio connection."}>
       {loading ? <p role="status" className="text-[0.75rem] text-muted">Checking CLI installation…</p> :
-        cli && <p className="text-[0.75rem] text-muted">{windows ? (cli.path ? <>Using <code>{cli.path}</code></> : "The desktop executable could not be located.") :
-          cli.installed ? <>Installed at <code>{cli.path}</code></> : "The srelens CLI is not installed."}</p>}
+        cli && <p className="text-[0.75rem] text-muted">{windows ? (cli.path ? <>Using <code className="block max-w-full overflow-x-auto whitespace-nowrap font-mono">{cli.path}</code></> : "The desktop executable could not be located.") :
+          cli.installed ? <>Installed at <code className="block max-w-full overflow-x-auto whitespace-nowrap font-mono">{cli.path}</code></> : "The srelens CLI is not installed."}</p>}
       <div className="mt-2 flex flex-wrap gap-2">
         {!windows && <Button variant="secondary" disabled={loading || busy || readError !== null} onClick={() => void install()}>
           {busy ? "Installing…" : cli?.installed ? "Reinstall srelens CLI" : "Install srelens CLI"}
@@ -74,7 +74,7 @@ export function McpClientSetup({ url, token, statusLoading = false, tokenLoading
         {readError !== null && <Button variant="ghost" disabled={loading || busy} onClick={() => setNonce(n => n + 1)}>Retry status</Button>}
       </div>
       {!windows && cli?.installed && !cli.on_path && <p className="mt-2 text-[0.75rem] text-muted">Add <code>{cli.path.replace(/[/\\][^/\\]+$/, "")}</code> to PATH, then restart your MCP client.</p>}
-      {installedAt && !cli?.installed && <p role="status" className="mt-2 text-[0.75rem]">CLI installed at <code>{installedAt}</code>.</p>}
+      {installedAt && !cli?.installed && <p role="status" className="mt-2 text-[0.75rem]">CLI installed at <code className="block max-w-full overflow-x-auto whitespace-nowrap font-mono">{installedAt}</code>.</p>}
       {readError !== null && <FailureAlert tone="sev" title="Could not check the CLI installation" error={readError} />}
       {installError !== null && <FailureAlert tone="sev" title="Could not install the srelens CLI" error={installError} />}
     </Panel>

--- a/packages/ui-next/src/screens/settings/McpServer.test.tsx
+++ b/packages/ui-next/src/screens/settings/McpServer.test.tsx
@@ -17,6 +17,8 @@ vi.mock("@srelens/core", async (orig) => ({
   ...core,
 }));
 
+vi.mock("./McpClientSetup", () => ({ McpClientSetup: () => null }));
+
 import { McpServer } from "./McpServer";
 import { mcpAutoStartSettled, mcpAutoStartStarting, resetMcpAutoStart } from "../../lib/mcpAutoStart";
 
@@ -106,7 +108,7 @@ describe("McpServer", () => {
   it("offers no client list, and says why", async () => {
     render(<McpServer />);
     expect(screen.queryByText(/claude code|cursor/i)).toBeNull();
-    expect(await screen.findByText(/which clients are connected/i)).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Connected clients" })).toBeNull();
   });
 
   it("hides the token again once the reader is done looking", async () => {
@@ -750,4 +752,33 @@ describe("McpServer", () => {
       expect(stray.map((n) => n.textContent)).toEqual([]);
     });
   });
+  it("saves a stopped server's port without starting it", async () => {
+    core.mcpHttpStatus.mockResolvedValue(null);
+    const user = userEvent.setup(); render(<McpServer />);
+    await screen.findByRole("button", { name: "Start server" });
+    await user.clear(screen.getByLabelText("MCP server port"));
+    await user.type(screen.getByLabelText("MCP server port"), "9522");
+    await user.click(screen.getByRole("button", { name: "Save port" }));
+    expect(core.startMcpHttp).not.toHaveBeenCalled();
+    expect(core.saveMcpSettings).toHaveBeenCalledWith({ enabled: false, port: 9522 });
+    expect(address()).toContain("9522");
+  });
+
+  it("confirms a running server's port change and reconciles a failed restart", async () => {
+    const user = userEvent.setup(); render(<McpServer />);
+    await screen.findByRole("button", { name: "Stop server" });
+    await user.clear(screen.getByLabelText("MCP server port"));
+    await user.type(screen.getByLabelText("MCP server port"), "9522");
+    await user.click(screen.getByRole("button", { name: "Save port" }));
+    expect(core.startMcpHttp).not.toHaveBeenCalled();
+    core.startMcpHttp.mockRejectedValueOnce(new Error("address already in use"));
+    core.mcpHttpStatus.mockResolvedValue(null);
+    await user.click(screen.getByRole("button", { name: "Change port and restart" }));
+    expect(core.startMcpHttp).toHaveBeenCalledWith(9522);
+    expect(await screen.findByRole("button", { name: "Start server" })).toBeTruthy();
+    expect(core.saveMcpSettings).toHaveBeenLastCalledWith({ enabled: false, port: PORT });
+    expect(screen.getByRole("alert").textContent).toContain("address already in use");
+    expect(address()).toContain(String(PORT));
+  });
+
 });

--- a/packages/ui-next/src/screens/settings/McpServer.tsx
+++ b/packages/ui-next/src/screens/settings/McpServer.tsx
@@ -233,6 +233,8 @@ export function McpServer() {
   /** The running server's own URL, or `null` for "not running" — the value
    *  `mcpHttpStatus()` actually returns, kept rather than reduced to a flag. */
   const [statusRead, setStatusRead] = useState<Read<string | null>>(LOADING);
+  const [tokenNonce, setTokenNonce] = useState(0);
+  const [statusNonce, setStatusNonce] = useState(0);
   const [revealed, setRevealed] = useState(false);
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState<unknown>(null);
@@ -301,7 +303,7 @@ export function McpServer() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [tokenNonce]);
 
   // Re-taken when the shell's auto-start settles. See the note above
   // `useMcpAutoStart` for the race: this pane's read can answer `null` with
@@ -324,7 +326,7 @@ export function McpServer() {
     return () => {
       cancelled = true;
     };
-  }, [shellSettled]);
+  }, [shellSettled, statusNonce]);
 
   const token = tokenRead.kind === "ready" ? tokenRead.value : null;
   const hasToken = tokenRead.kind === "ready" && tokenRead.value !== null;
@@ -613,7 +615,12 @@ export function McpServer() {
         />
       )}
     </Panel>
-    <McpClientSetup url={address} token={token} />
+    <McpClientSetup url={address} token={token}
+      statusLoading={statusRead.kind === "loading"} tokenLoading={tokenRead.kind === "loading"}
+      statusError={statusRead.kind === "error" ? statusRead.error : undefined}
+      tokenError={tokenRead.kind === "error" ? tokenRead.error : undefined}
+      onRetryStatus={() => { setStatusRead(LOADING); setStatusNonce(value => value + 1); }}
+      onRetryToken={() => { setTokenRead(LOADING); setTokenNonce(value => value + 1); }} />
     </>
   );
 }

--- a/packages/ui-next/src/screens/settings/McpServer.tsx
+++ b/packages/ui-next/src/screens/settings/McpServer.tsx
@@ -10,8 +10,9 @@ import {
   startMcpHttp,
   stopMcpHttp,
 } from "@srelens/core";
-import { Badge, Button, ConfirmDialog, Panel, SubHead } from "@srelens/ui-kit";
+import { Badge, Button, ConfirmDialog, Field, Panel, SubHead, TextInput } from "@srelens/ui-kit";
 import { FailureAlert } from "../../lib/errorCopy";
+import { McpClientSetup } from "./McpClientSetup";
 import { useMcpAutoStart } from "../../lib/mcpAutoStart";
 
 /**
@@ -151,14 +152,7 @@ import { useMcpAutoStart } from "../../lib/mcpAutoStart";
  * still loading or refused. A question is the last place to assert a fact from
  * nothing.
  *
- * **No port editor** (#374). Changing the port is a second, differently-shaped
- * job — validate, persist, and restart a listener that may be serving an agent
- * mid-call — and this pane has no control for it, so it makes no claim that it
- * has one. The persisted value is read and honoured; classic is where it is
- * still set.
- *
- * **`Clients` is not drawn** (#369): `mcpClientConfig` generates configuration
- * *for* a client to paste elsewhere; srelens does not track who connects.
+ * Port edits are applied explicitly, with confirmation before restarting a listener.
  */
 
 /**
@@ -248,11 +242,12 @@ export function McpServer() {
     null,
   );
 
-  /** Read ONCE, at mount: the port a start uses and a stopped server's address
-   *  is composed from. Not re-read per render — nothing in this tree writes it,
-   *  and a value that changed between the address on screen and the number
-   *  handed to `startMcpHttp` would be two different claims. */
-  const [port] = useState(() => loadMcpSettings().port);
+  const [port, setPort] = useState(() => loadMcpSettings().port);
+  const [portDraft, setPortDraft] = useState(() => String(port));
+  const [portQuestion, setPortQuestion] = useState<number | null>(null);
+  const [portError, setPortError] = useState<unknown>(null);
+  const nextPort = Number(portDraft);
+  const validPort = /^\d+$/.test(portDraft) && Number.isInteger(nextPort) && nextPort >= 1 && nextPort <= 65535;
 
   /** Bumped by anything that authoritatively establishes `statusRead` — the
    * fetch below starting, and the direct sets in `start()`, `stop()` and
@@ -349,6 +344,27 @@ export function McpServer() {
   function establishStatus(url: string | null) {
     statusSeq.current += 1;
     setStatusRead({ kind: "ready", value: url });
+  }
+
+  async function changePort(target: number) {
+    setBusy(true); setPortError(null);
+    // A restart may stop the existing listener before failing to bind.
+    // Invalidate earlier reads and re-read status if the restart fails.
+    statusSeq.current += 1;
+    try {
+      if (running) establishStatus(await startMcpHttp(target));
+      setPort(target); setPortDraft(String(target));
+      saveMcpSettings({ enabled: running, port: target });
+    } catch (error) {
+      setPortError(error);
+      try {
+        const live = await mcpHttpStatus();
+        establishStatus(live);
+        saveMcpSettings({ enabled: live !== null, port });
+      } catch (statusError) {
+        setStatusRead({ kind: "error", error: statusError });
+      }
+    } finally { setBusy(false); setPortQuestion(null); }
   }
 
   async function copyToken() {
@@ -454,6 +470,7 @@ export function McpServer() {
   }
 
   return (
+    <>
     <Panel
       title={
         <span className="flex flex-wrap items-center gap-2">
@@ -503,6 +520,18 @@ export function McpServer() {
           </div>
         </>
       )}
+
+      <div className="mt-3 flex flex-wrap items-end gap-2">
+        <Field label="MCP server port" error={validPort ? undefined : "Choose a whole number from 1 to 65535."}>
+          <TextInput type="number" value={portDraft} onValueChange={setPortDraft} disabled={busy || shellStarting} invalid={!validPort} className="w-28" />
+        </Field>
+        <Button variant="secondary" disabled={!validPort || nextPort === port || busy || shellStarting || statusRead.kind !== "ready"}
+          onClick={() => running ? setPortQuestion(nextPort) : void changePort(nextPort)}>Save port</Button>
+      </div>
+      {portError !== null && <FailureAlert tone="sev" title="Could not change the MCP server port" error={portError} />}
+      {portQuestion !== null && <ConfirmDialog title="Change MCP server port?"
+        message={`Restart the MCP server on port ${portQuestion}? Active requests will be interrupted. Update your clients to use the new address.`}
+        confirmLabel="Change port and restart" busy={busy} onConfirm={() => void changePort(portQuestion)} onCancel={() => setPortQuestion(null)} />}
 
       {serverError !== null && (
         <FailureAlert
@@ -566,14 +595,6 @@ export function McpServer() {
         <FailureAlert tone="sev" title="The MCP server's token could not be updated" error={actionError} />
       )}
 
-      {/* #369: mcpClientConfig GENERATES config FOR a client to paste
-          elsewhere; srelens never learns who used it, so a `Clients` list
-          (§23 draws one) would be a claim this pane cannot back. */}
-      <p className="mt-3 text-[0.75rem] leading-relaxed text-muted">
-        srelens cannot say which clients are connected right now — it only generates configuration for a client to
-        paste elsewhere, and never learns who used it.
-      </p>
-
       {asking !== null && (
         <ConfirmDialog
           title={asking === "rotate" ? "Rotate the bearer token?" : "Revoke the bearer token?"}
@@ -592,5 +613,7 @@ export function McpServer() {
         />
       )}
     </Panel>
+    <McpClientSetup url={address} token={token} />
+    </>
   );
 }

--- a/packages/ui-next/src/styles/next.css
+++ b/packages/ui-next/src/styles/next.css
@@ -24,3 +24,10 @@
     border-bottom: 1px solid var(--rule);
   }
 }
+
+/* Agent settings form one scrollable region, divided by hairlines. */
+.settings-agent > .card {
+  border-radius: 0;
+  border-width: 0 0 1px;
+  box-shadow: none;
+}

--- a/packages/ui-next/src/styles/next.css
+++ b/packages/ui-next/src/styles/next.css
@@ -26,7 +26,8 @@
 }
 
 /* Agent settings form one scrollable region, divided by hairlines. */
-.settings-agent > .card {
+.settings-agent > .card,
+.settings-agent > .settings-agent-groups > .card {
   border-radius: 0;
   border-width: 0 0 1px;
   box-shadow: none;


### PR DESCRIPTION
Restore the MCP setup controls that were available in classic settings: editing the HTTP port, installing or reinstalling the srelens CLI, generating client configuration for stdio/HTTP, and showing prompt-file load diagnostics.

Port changes validate before saving and confirm before restarting a running server. A failed restart re-reads the actual listener state and retains the previous configured port. Client configuration follows the current URL and token, hides the token in its preview, and copies the usable configuration. Prompt diagnostics refresh independently alongside the audit trail. Agent settings use flush sections divided by hairlines.

Validation: 6,114 frontend tests passed with 93.37% line coverage; 30 targeted tests passed after the final layout adjustment; all four package typechecks and the production build passed. Rust workspace: 2,084 passed, 13 ignored. Browser checks at 1100×900 and 570×800 exercised port changes, failed restart, CLI installation, configuration copying, token masking, and prompt diagnostics.

Stacked on #474.
