### PR TITLE
docs(readme): take the one-line installers out of the install table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,21 @@ Download the latest release for your platform from
 | macOS | `.dmg` for Apple Silicon and Intel | Developer ID signed and notarized |
 | Linux | `.AppImage`, `.deb`, `.rpm` | AppImage supports the in-app updater |
 | Windows | `.exe`, `.msi` | Windows may show a SmartScreen prompt while code signing remains on the roadmap |
-| Terminal UI | Linux: `( f="$(mktemp)" && trap 'rm -f "$f"' EXIT && curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" && sh "$f" )`; macOS: `brew install srelens/tap/srelens-tui`; or `srelens-tui-<version>-<target>.tar.gz` / `.zip` | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
+| Terminal UI | `srelens-tui-<version>-<target>.tar.gz` / `.zip`, or the one-liners below | A single binary for Linux (glibc and static musl), macOS and Windows, on x86-64 and arm64; macOS builds on a stable release are signed and notarized |
+
+The terminal UI also installs in one line. Linux:
+
+```bash
+( f="$(mktemp)" && trap 'rm -f "$f"' EXIT &&
+  curl -fsSL https://raw.githubusercontent.com/srelens/srelens/main/packaging/install/install.sh -o "$f" &&
+  sh "$f" )
+```
+
+macOS:
+
+```bash
+brew install srelens/tap/srelens-tui
+```
 
 See the [installation guide](docs/INSTALL.md) for platform-specific installation,
 first-launch, updating, verification, and uninstall instructions.


### PR DESCRIPTION
Closes #477.

The Terminal UI row of the install table carried the whole Linux one-line installer (mktemp, trap, long URL) and the brew command inside one cell, which rendered as a paragraph-shaped block. The cell now names the archives and points below the table, where the Linux and macOS one-liners sit as code blocks — the Linux one in the same three-line shape `docs/INSTALL.md` uses.