### PR TITLE
fix(settings): persist application preferences in the backend

### DIFF
--- a/apps/desktop/src/design.switch.test.ts
+++ b/apps/desktop/src/design.switch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock, setTitleMock, notifyErrorMock } = vi.hoisted(() => ({
+const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock, setTitleMock, notifyErrorMock, flushMock } = vi.hoisted(() => ({
+  flushMock: vi.fn(),
   isTauriMock: vi.fn(),
   isApplePlatformMock: vi.fn(),
   setTitleBarStyleMock: vi.fn(),
@@ -9,6 +10,7 @@ const { isTauriMock, isApplePlatformMock, setTitleBarStyleMock, setTitleMock, no
 }));
 vi.mock("@srelens/core", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@srelens/core")>()),
+  flushSettingsWrites: (options: unknown) => flushMock(options),
   isTauri: () => isTauriMock(),
   isApplePlatform: (platform?: string) => isApplePlatformMock(platform),
   notify: { error: notifyErrorMock, success: vi.fn(), info: vi.fn() },
@@ -25,6 +27,7 @@ let originalLocation: Location;
 beforeEach(() => {
   localStorage.clear();
   reload.mockClear();
+  flushMock.mockReset().mockResolvedValue(undefined);
   setTitleBarStyleMock.mockReset().mockResolvedValue(undefined);
   setTitleMock.mockReset().mockResolvedValue(undefined);
   isApplePlatformMock.mockReset().mockReturnValue(true);
@@ -108,4 +111,21 @@ describe("switchDesign", () => {
     expect(setTitleBarStyleMock).not.toHaveBeenCalled();
     expect(reload).toHaveBeenCalledTimes(1);
   });
+});
+
+it("waits for the backend commit before reloading the selected design", async () => {
+  let commit!: () => void;
+  flushMock.mockReturnValueOnce(new Promise<void>(resolve => { commit = resolve; }));
+  const switching = switchDesign("next");
+  expect(reload).not.toHaveBeenCalled();
+  expect(flushMock).toHaveBeenCalledWith({ throwOnError: true });
+  commit();
+  expect((await switching).ok).toBe(true);
+  expect(reload).toHaveBeenCalledOnce();
+});
+it("keeps the current design when the backend rejects the preference", async () => {
+  flushMock.mockRejectedValueOnce(new Error("disk full"));
+  expect((await switchDesign("next")).ok).toBe(false);
+  expect(reload).not.toHaveBeenCalled();
+  expect(setTitleBarStyleMock).not.toHaveBeenCalled();
 });

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { settingsStorage } from "@srelens/core";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { DESIGN_KEY, PORTED_SCREENS, loadDesign, saveDesign } from "./design";
 
 beforeEach(() => localStorage.clear());
@@ -94,4 +95,12 @@ describe("the list of ported screens", () => {
       "Settings",
     ]);
   });
+});
+
+it("stores the design choice through the shared backend settings adapter", () => {
+  const write = vi.spyOn(settingsStorage, "setItem").mockImplementation(() => {});
+  expect(saveDesign("next")).toBe(true);
+  expect(write).toHaveBeenCalledWith(DESIGN_KEY, "next");
+  expect(localStorage.getItem(DESIGN_KEY)).toBeNull();
+  write.mockRestore();
 });

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -1,4 +1,4 @@
-import { isApplePlatform, isTauri, K8S_KIND, type ResourceKind } from "@srelens/core";
+import { settingsStorage, flushSettingsWrites, isApplePlatform, isTauri, K8S_KIND, type ResourceKind } from "@srelens/core";
 // theme.ts imports only settingsStorage, so this does not drag the classic
 // stylesheet into the new design's chunk.
 import { applyTheme, getInitialTheme, resolvedThemeMode } from "./ui/theme";
@@ -6,8 +6,7 @@ import { applyTheme, getInitialTheme, resolvedThemeMode } from "./ui/theme";
 /**
  * Which design the app renders.
  *
- * Read synchronously before React mounts, so it lives in localStorage rather
- * than the settings store, which is async. It describes the person using the
+ * Read from the settings mirror loaded before React mounts. It describes the person using the
  * app, not the cluster they are looking at, so it is not scoped to a context
  * or a workspace.
  *
@@ -24,7 +23,7 @@ export function loadDesign(): Design {
     // Anything unrecognised means classic. A preference written by a future
     // version must never leave someone on a design that does not exist, since
     // a blank window has no way back to Settings.
-    return localStorage.getItem(DESIGN_KEY) === "next" ? "next" : "classic";
+    return settingsStorage.getItem(DESIGN_KEY) === "next" ? "next" : "classic";
   } catch {
     // Storage throws in some privacy modes; a preference is not worth failing
     // to boot over.
@@ -35,7 +34,7 @@ export function loadDesign(): Design {
 /** Persist the choice. Returns false if storage refused it. */
 export function saveDesign(design: Design): boolean {
   try {
-    localStorage.setItem(DESIGN_KEY, design);
+    settingsStorage.setItem(DESIGN_KEY, design);
     return true;
   } catch {
     // Restricted or private storage. The caller must not reload on this: the
@@ -104,6 +103,11 @@ export async function switchDesign(design: Design): Promise<SwitchResult> {
     // lives in the classic tree, so a failure while leaving the new design
     // would have been invisible, and the button would have looked inert.
     return { ok: false, reason: "This device would not let srelens save the preference." };
+  }
+  try {
+    await flushSettingsWrites({ throwOnError: true });
+  } catch {
+    return { ok: false, reason: "The settings backend could not save the design preference." };
   }
   if (design === "classic" && isTauri() && drawsOwnChrome()) {
     try {

--- a/crates/server/src/api_settings.rs
+++ b/crates/server/src/api_settings.rs
@@ -1,9 +1,6 @@
-//! Per-user settings API: `GET`/`PUT`/`DELETE /api/settings/:key`. Backs
-//! saved port-forwards (and future per-user preferences) on the web; the
-//! desktop app persists the equivalent state in its durable settings file
-//! (`crates/registry/src/settings.rs`) instead. Web preferences OTHER than
-//! these rows stay in the browser's `localStorage`, so they are scoped to a
-//! browser profile rather than to an account.
+//! Per-user settings API: GET /api/settings loads the account's preferences;
+//! GET/PUT/DELETE /api/settings/:key read and update individual values.
+//! Desktop uses its durable settings file; web uses these SQLite rows.
 //!
 //! Values are opaque JSON, stored and returned verbatim in `value_json` —
 //! this route never inspects the shape, it just round-trips whatever the
@@ -27,6 +24,25 @@ fn validate_key(key: &str) -> Result<(), &'static str> {
         return Err("key must not be empty");
     }
     Ok(())
+}
+
+/// Load the signed-in account's settings before the frontend initializes its mirror.
+pub async fn list(
+    State(state): State<AppState>,
+    Extension(user): Extension<UserCtx>,
+) -> Response {
+    let rows = match state.db.list_settings(user.user_id).await {
+        Ok(rows) => rows,
+        Err(e) => return error(StatusCode::INTERNAL_SERVER_ERROR, &e),
+    };
+    let mut values = serde_json::Map::new();
+    for (key, raw) in rows {
+        match serde_json::from_str::<Value>(&raw) {
+            Ok(value) => { values.insert(key, value); }
+            Err(_) => return error(StatusCode::INTERNAL_SERVER_ERROR, "stored setting is not valid JSON"),
+        }
+    }
+    Json(json!({ "values": values })).into_response()
 }
 
 /// GET /api/settings/:key → `{"value": <json | null>}`. The stored
@@ -183,6 +199,7 @@ mod tests {
     async fn settings_routes_require_auth() {
         let state = state().await;
         for (method, uri) in [
+            ("GET", "/api/settings"),
             ("GET", "/api/settings/theme"),
             ("PUT", "/api/settings/theme"),
             ("DELETE", "/api/settings/theme"),
@@ -190,6 +207,19 @@ mod tests {
             let (status, _) = send(&state, method, uri, None, None).await;
             assert_eq!(status, StatusCode::UNAUTHORIZED, "{method} {uri}");
         }
+    }
+
+    #[tokio::test]
+    async fn lists_only_the_signed_in_users_settings() {
+        let state = state().await;
+        let cookie = login(&state).await;
+        let other = state.db.upsert_user("i", "other", "", "", 1).await.unwrap();
+        state.db.set_setting(other.id, "private", "42").await.unwrap();
+        send(&state, "PUT", "/api/settings/srelens.design", Some(&cookie), Some(json!("next"))).await;
+        send(&state, "PUT", "/api/settings/srelens.uiScale", Some(&cookie), Some(json!(120))).await;
+        let (status, body) = send(&state, "GET", "/api/settings", Some(&cookie), None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, json!({"values": {"srelens.design": "next", "srelens.uiScale": 120}}));
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -144,6 +144,7 @@ pub fn router(state: AppState) -> Router {
             "/api/command/:command",
             axum::routing::post(api_command::dispatch),
         )
+        .route("/api/settings", get(api_settings::list))
         .route(
             "/api/settings/:key",
             get(api_settings::get)

--- a/crates/server/src/stores.rs
+++ b/crates/server/src/stores.rs
@@ -260,6 +260,14 @@ impl Db {
         Ok(())
     }
 
+    pub async fn list_settings(&self, user_id: i64) -> Result<Vec<(String, String)>, String> {
+        sqlx::query_as("SELECT key, value_json FROM settings WHERE user_id = ?")
+            .bind(user_id)
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| e.to_string())
+    }
+
     pub async fn get_setting(&self, user_id: i64, key: &str) -> Result<Option<String>, String> {
         let row: Option<(String,)> =
             sqlx::query_as("SELECT value_json FROM settings WHERE user_id = ? AND key = ?")

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -140,6 +140,23 @@ The frontend side is identical in both cases and lives in `@srelens/core` (`pack
 
 `packages/core/src/transport/` is the only frontend code that knows which host it is running in. `transport.ts` picks `tauriTransport` or `webTransport` at load time based on `isTauri()`, and re-exports one interface (`invokeCapability`, `invokeCommand`, `on`, `subscribe`, …). Everything else — stores, components, tests — depends only on that interface. This is what makes the UI testable in jsdom *and* what makes web mode possible at all, so keep `@tauri-apps/api` imports confined to `packages/core/src/transport/`.
 
+### Persisting application settings
+
+Use `settingsStorage` from `@srelens/core` for every persistent preference,
+including the selected design. Application bootstrap awaits
+`initializeSettingsStorage()` before choosing the design or mounting React.
+The adapter reads a synchronous in-memory mirror and writes to the desktop
+settings file or the signed-in web user's SQLite settings. Web bootstrap loads
+`GET /api/settings`; writes use the existing per-key settings endpoints.
+
+Do not add direct browser-storage writes for preferences. Legacy browser values
+are imported from an explicit allowlist, and removed only after backend writes
+succeed. Backend settings take precedence over stale local copies. A backend
+initialization failure leaves the app readable but does not redirect writes to
+local storage. Before reloading after a preference change, await
+`flushSettingsWrites({ throwOnError: true })` and keep the current screen if it
+fails. Temporary navigation handoffs and unsaved editor drafts are not settings.
+
 ### Running the MCP server
 
 ```sh

--- a/packages/core/src/lib/settings.ts
+++ b/packages/core/src/lib/settings.ts
@@ -1,5 +1,5 @@
 // Small synchronous persisted-settings helpers. Desktop reads from an
-// in-memory mirror of settings.json; web mode falls back to localStorage.
+// in-memory mirror of backend settings (desktop file or per-user web database).
 
 import { settingsStorage } from "./settingsStorage";
 

--- a/packages/core/src/lib/settingsStorage.test.ts
+++ b/packages/core/src/lib/settingsStorage.test.ts
@@ -21,6 +21,7 @@ describe("desktop settings storage", () => {
 
   afterEach(() => {
     Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+    vi.unstubAllGlobals();
   });
 
   it("imports known localStorage values once and clears them after the file write", async () => {
@@ -154,7 +155,7 @@ describe("desktop settings storage", () => {
     await initializeSettingsStorage();
 
     expect(localStorage.getItem("srelens.uiScale")).toBe("125");
-    expect(settingsStorage.getItem("srelens.uiScale")).toBe("125");
+    expect(settingsStorage.getItem("srelens.uiScale")).toBeNull();
     expect(error).toHaveBeenCalled();
     error.mockRestore();
   });
@@ -237,16 +238,51 @@ describe("desktop settings storage", () => {
     warn.mockRestore();
   });
 
-  it("keeps the storage-shaped localStorage fallback in web mode", async () => {
+  it("loads web settings from the account backend and writes through without local copies", async () => {
     Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
-    vi.resetModules();
-    const { initializeSettingsStorage, settingsStorage } = await import("./settingsStorage");
-
+    const fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ values: { "srelens.uiScale": 125, "srelens.settingsMigrated": true } }) });
+    vi.stubGlobal("fetch", fetch);
+    const { initializeSettingsStorage, settingsStorage, flushSettingsWrites } = await import("./settingsStorage");
     await initializeSettingsStorage();
-    settingsStorage.setItem("theme", "dark");
-    expect(settingsStorage.getItem("theme")).toBe("dark");
-    settingsStorage.removeItem("theme");
-    expect(settingsStorage.getItem("theme")).toBeNull();
+    expect(settingsStorage.getItem("srelens.uiScale")).toBe("125");
+    settingsStorage.setItem("srelens.uiScale", "140");
+    settingsStorage.removeItem("srelens.uiScale");
+    await flushSettingsWrites();
+    expect(fetch).toHaveBeenCalledWith("/api/settings", expect.objectContaining({ credentials: "same-origin" }));
+    expect(fetch).toHaveBeenCalledWith("/api/settings/srelens.uiScale", expect.objectContaining({ method: "PUT", body: "140" }));
+    expect(fetch).toHaveBeenCalledWith("/api/settings/srelens.uiScale", expect.objectContaining({ method: "DELETE" }));
+    expect(localStorage.getItem("srelens.uiScale")).toBeNull();
     expect(invokeCapability).not.toHaveBeenCalled();
   });
+  it("imports newly covered settings even after the original migration completed", async () => {
+    localStorage.setItem("srelens.design", "next");
+    localStorage.setItem("srelens.next.appearance", '{"theme":"paper"}');
+    invokeCapability.mockResolvedValueOnce({schemaVersion: 1, localStorageMigrated: true, values: {}}).mockResolvedValue({saved:true});
+    const { initializeSettingsStorage, settingsStorage } = await import("./settingsStorage");
+    await initializeSettingsStorage();
+    expect(invokeCapability).toHaveBeenCalledWith("settings.set", { values: { "srelens.design": "next", "srelens.next.appearance": {theme:"paper"} } });
+    expect(settingsStorage.getItem("srelens.design")).toBe("next");
+    expect(localStorage.getItem("srelens.design")).toBeNull();
+  });
+  it("does not create local preferences when backend initialization fails", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    invokeCapability.mockRejectedValue(new Error("backend unavailable"));
+    const { initializeSettingsStorage, settingsStorage } = await import("./settingsStorage");
+    await initializeSettingsStorage();
+    expect(() => settingsStorage.setItem("srelens.uiScale", "140")).toThrow(/backend/i);
+    expect(localStorage.getItem("srelens.uiScale")).toBeNull();
+    error.mockRestore();
+  });
+});
+
+it("reports a rejected backend save to callers that must wait before reloading", async () => {
+  vi.resetModules(); localStorage.clear(); tauriWindow();
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  invokeCapability.mockReset().mockResolvedValueOnce({schemaVersion:1, localStorageMigrated:true, values:{}}).mockRejectedValue(new Error("disk full"));
+  const { initializeSettingsStorage, settingsStorage, flushSettingsWrites } = await import("./settingsStorage");
+  await initializeSettingsStorage();
+  settingsStorage.setItem("srelens.design", "next");
+  await expect(flushSettingsWrites({throwOnError:true})).rejects.toThrow("disk full");
+  expect(localStorage.getItem("srelens.design")).toBeNull();
+  error.mockRestore(); Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
 });

--- a/packages/core/src/lib/settingsStorage.ts
+++ b/packages/core/src/lib/settingsStorage.ts
@@ -1,17 +1,4 @@
-import { invokeCapability } from "../transport/transport";
-import { isTauri } from "../transport/platform";
-
-interface SettingsGetOutput {
-  schemaVersion: number;
-  localStorageMigrated: boolean;
-  values: Record<string, unknown>;
-}
-
-interface SettingsSetInput {
-  values?: Record<string, unknown>;
-  remove?: string[];
-  localStorageMigrated?: boolean;
-}
+import { readBackendSettings, writeBackendSettings, type SettingsSetInput } from "../transport/settingsTransport";
 
 // Every desktop preference that existed before the file store. Keeping this
 // list explicit prevents a broad localStorage sweep from importing unrelated
@@ -24,6 +11,20 @@ const MIGRATION_KEYS = [
   "srelens.workspaceLayout",
   "srelens.contextProfiles",
   NEXT_MARKS_KEY,
+  "srelens.design",
+  "srelens.restoreSession",
+  "srelens.openTabs",
+  "srelens.onboarded",
+  "srelens.releaseNotes",
+  "srelens.next.appearance",
+  "srelens.next.workspaces",
+  "srelens.next.columns",
+  "srelens.next.recentLogs",
+  "srelens.next.peekWidth",
+  "srelens.next.sectionFolds",
+  "srelens.next.namespaces",
+  "srelens.next.ambiguousContextProfiles",
+  "srelens.next.ambiguousContextOrder",
   "srelens.kubeconfigFiles",
   "srelens.hiddenColumns",
   "srelens.contextOrder",
@@ -41,7 +42,9 @@ const LEGACY_ALIASES: Record<string, string[]> = {
 };
 
 const values = new Map<string, unknown>();
-let fileBacked = false;
+let backendReady = false;
+let initializationAttempted = false;
+let lastWriteError: unknown;
 let writes: Promise<void> = Promise.resolve();
 
 function decode(raw: string): unknown {
@@ -65,137 +68,102 @@ function aliasesFor(key: string): string[] {
 function enqueue(input: SettingsSetInput): void {
   writes = writes
     .then(async () => {
-      await invokeCapability("settings.set", input);
+      await writeBackendSettings(input);
+      lastWriteError = undefined;
     })
     .catch((error) => {
+      lastWriteError = error;
       // Persistence remains best-effort at synchronous call sites, as it was
       // with localStorage, but failures are no longer silent.
       console.error("could not persist settings", error);
     });
 }
 
-/**
- * Load the desktop file before React initializes synchronous settings state.
- * On the first successful load, import known localStorage keys in one atomic
- * write and only then remove the old copies.
- */
+/** Load the backend before React initializes synchronous settings state. */
 export async function initializeSettingsStorage(): Promise<void> {
-  if (!isTauri()) return;
+  initializationAttempted = true;
+  backendReady = false;
+  values.clear();
   try {
-    const loaded = await invokeCapability<SettingsGetOutput>("settings.get", {});
-    values.clear();
+    const loaded = await readBackendSettings();
     Object.entries(loaded.values).forEach(([key, value]) => values.set(key, value));
+    backendReady = true;
 
-    if (!loaded.localStorageMigrated) {
-      const migrated: Record<string, unknown> = {};
-      // Reading the OLD store is optional work: a WebView with localStorage
-      // disabled throws from getItem, and letting that escape would abandon
-      // the file backend we just loaded successfully — falling back to the
-      // very storage that is unavailable, so nothing could persist at all.
-      let scanned = true;
-      try {
-        for (const key of MIGRATION_KEYS) {
-          if (values.has(key)) continue;
-          for (const candidate of [key, ...aliasesFor(key)]) {
-            const raw = localStorage.getItem(candidate);
-            if (raw === null) continue;
-            migrated[key] =
-              key === "fl-theme-v2" &&
-              candidate === "fl-theme" &&
-              (raw === "light" || raw === "dark")
-                ? { name: "slate", mode: raw }
-                : decode(raw);
-            break;
-          }
-        }
-      } catch (error) {
-        // The scan is all-or-nothing on purpose. Committing the migrated flag
-        // after a partial read would retire the one-time import for good, so a
-        // transient storage failure would strand the legacy preferences
-        // permanently. Leave the flag unset and retry on the next launch.
-        scanned = false;
-        console.warn("localStorage unreadable; deferring migration to a later launch", error);
-      }
-
-      if (scanned) {
-        await invokeCapability("settings.set", {
-          values: migrated,
-          localStorageMigrated: true,
-        } satisfies SettingsSetInput);
-        Object.entries(migrated).forEach(([key, value]) => values.set(key, value));
-
-        // Only reached once the import is committed, so a failed or deferred
-        // migration always leaves its localStorage data intact for the retry.
-        try {
-          for (const key of MIGRATION_KEYS) {
-            localStorage.removeItem(key);
-            for (const alias of aliasesFor(key)) localStorage.removeItem(alias);
-          }
-        } catch (error) {
-          console.warn(
-            "durable settings migrated but old localStorage could not be cleared",
-            error,
-          );
+    // Scan the explicit allowlist on upgrades too: earlier releases omitted
+    // new-design preferences. Backend values always win over old local copies.
+    const migrated: Record<string, unknown> = {};
+    let scanned = true;
+    try {
+      for (const key of MIGRATION_KEYS) {
+        if (values.has(key)) continue;
+        for (const candidate of [key, ...aliasesFor(key)]) {
+          const raw = localStorage.getItem(candidate);
+          if (raw === null) continue;
+          migrated[key] = key === "fl-theme-v2" && candidate === "fl-theme" && (raw === "light" || raw === "dark")
+            ? { name: "slate", mode: raw } : decode(raw);
+          break;
         }
       }
-    } else if (!values.has(NEXT_MARKS_KEY)) {
-      // `next.marks` was added to the allowlist after the original one-time
-      // migration shipped. Give already-migrated desktops a narrow follow-up
-      // import so their localStorage marks are not stranded behind the flag.
-      try {
-        const raw = localStorage.getItem(NEXT_MARKS_KEY);
-        if (raw !== null) {
-          const value = decode(raw);
-          await invokeCapability("settings.set", { values: { [NEXT_MARKS_KEY]: value } });
-          values.set(NEXT_MARKS_KEY, value);
-          try {
-            localStorage.removeItem(NEXT_MARKS_KEY);
-          } catch (error) {
-            console.warn("saved context marks migrated but localStorage could not be cleared", error);
-          }
-        }
-      } catch (error) {
-        // Keep the durable backend active and leave the old value for a later
-        // launch if either the legacy read or follow-up write is unavailable.
-        console.warn("could not run the saved context marks migration", error);
-      }
+    } catch (error) {
+      scanned = false;
+      console.warn("localStorage unreadable; deferring migration to a later launch", error);
     }
-    fileBacked = true;
+    if (!scanned) return;
+    try {
+      if (!loaded.localStorageMigrated || Object.keys(migrated).length > 0) {
+        await writeBackendSettings({ values: migrated, ...(!loaded.localStorageMigrated ? { localStorageMigrated: true } : {}) });
+        Object.entries(migrated).forEach(([key, value]) => values.set(key, value));
+      }
+    } catch (error) {
+      console.error("could not migrate legacy settings; keeping the backend active and legacy copies intact", error);
+      return;
+    }
+    // Remove copies only after the backend accepted the import. Clearing stale
+    // copies of existing backend keys also prevents resurrection after a reset.
+    try {
+      for (const key of MIGRATION_KEYS) {
+        localStorage.removeItem(key);
+        for (const alias of aliasesFor(key)) localStorage.removeItem(alias);
+      }
+    } catch (error) {
+      console.warn("durable settings migrated but old localStorage could not be cleared", error);
+    }
   } catch (error) {
-    // A corrupt/unwritable file must not prevent the app from opening.
-    fileBacked = false;
-    console.error("could not initialize durable settings; using localStorage", error);
+    console.error("could not initialize settings backend; settings writes are unavailable", error);
   }
 }
 
 /** Storage-shaped synchronous facade used by the existing settings helpers. */
 export const settingsStorage = {
   getItem(key: string): string | null {
-    if (!fileBacked) return localStorage.getItem(key);
+    if (!initializationAttempted) return localStorage.getItem(key);
     return values.has(key) ? encode(values.get(key)) : null;
   },
 
   setItem(key: string, raw: string): void {
-    if (!fileBacked) {
+    if (!initializationAttempted) {
       localStorage.setItem(key, raw);
       return;
     }
+    if (!backendReady) throw new Error("Settings backend is unavailable");
     const value = decode(raw);
     values.set(key, value);
     enqueue({ values: { [key]: value } });
   },
 
   removeItem(key: string): void {
-    if (!fileBacked) {
+    if (!initializationAttempted) {
       localStorage.removeItem(key);
       return;
     }
+    if (!backendReady) throw new Error("Settings backend is unavailable");
     values.delete(key);
     enqueue({ remove: [key] });
   },
 };
 
 /** Test seam for callers that need to observe queued write completion. */
-export async function flushSettingsWrites(): Promise<void> {
+export async function flushSettingsWrites(options: { throwOnError?: boolean } = {}): Promise<void> {
   await writes;
+  if (options.throwOnError && lastWriteError) throw lastWriteError;
 }

--- a/packages/core/src/transport/settingsTransport.ts
+++ b/packages/core/src/transport/settingsTransport.ts
@@ -1,0 +1,46 @@
+import { invokeCapability } from "./transport";
+import { isTauri } from "./platform";
+
+export interface SettingsGetOutput {
+  schemaVersion: number;
+  localStorageMigrated: boolean;
+  values: Record<string, unknown>;
+}
+export interface SettingsSetInput {
+  values?: Record<string, unknown>;
+  remove?: string[];
+  localStorageMigrated?: boolean;
+}
+const MIGRATED_KEY = "srelens.settingsMigrated";
+
+async function request(path: string, init: RequestInit = {}): Promise<Response> {
+  const response = await fetch(path, {
+    credentials: "same-origin",
+    ...init,
+    headers: { "Content-Type": "application/json", "x-srelens-csrf": "1" },
+  });
+  if (!response.ok) throw new Error(`Settings backend request failed (HTTP ${response.status})`);
+  return response;
+}
+
+export async function readBackendSettings(): Promise<SettingsGetOutput> {
+  if (isTauri()) return invokeCapability("settings.get", {});
+  const response = await request("/api/settings");
+  const { values } = await response.json() as { values: Record<string, unknown> };
+  return { schemaVersion: 1, localStorageMigrated: values[MIGRATED_KEY] === true, values };
+}
+
+export async function writeBackendSettings(input: SettingsSetInput): Promise<void> {
+  if (isTauri()) { await invokeCapability("settings.set", input); return; }
+  // Per-key writes preserve changes from other windows. Mark migration complete
+  // only after every import has succeeded; retries keep existing backend values.
+  for (const [key, value] of Object.entries(input.values ?? {})) {
+    await request(`/api/settings/${encodeURIComponent(key)}`, { method: "PUT", body: JSON.stringify(value) });
+  }
+  for (const key of input.remove ?? []) {
+    await request(`/api/settings/${encodeURIComponent(key)}`, { method: "DELETE" });
+  }
+  if (input.localStorageMigrated !== undefined) {
+    await request(`/api/settings/${MIGRATED_KEY}`, { method: "PUT", body: JSON.stringify(input.localStorageMigrated) });
+  }
+}

--- a/packages/ui-next/src/lib/workspace.test.tsx
+++ b/packages/ui-next/src/lib/workspace.test.tsx
@@ -17,7 +17,7 @@ beforeEach(() => { settingsStorage.removeItem("srelens.defaultNamespace"); ws.re
 
 describe("workspace view", () => {
   it("starts with no links and nothing expanded", () => {
-    expect(ws.getView()).toEqual({ links: {}, expanded: [], namespaces: {} });
+    expect(ws.getView()).toEqual({ links: {}, expanded: {}, namespaces: {} });
   });
 
   it("tells the hook when a link changes", () => {
@@ -42,16 +42,16 @@ describe("workspace view", () => {
   });
 
   it("toggles expansion", () => {
-    ws.toggleExpanded("workloads");
-    expect(ws.getView().expanded).toEqual(["workloads"]);
-    ws.toggleExpanded("workloads");
-    expect(ws.getView().expanded).toEqual([]);
+    ws.toggleExpanded("prod", "workloads");
+    expect(ws.getView().expanded.prod).toEqual(["workloads"]);
+    ws.toggleExpanded("prod", "workloads");
+    expect(ws.getView().expanded.prod).toEqual([]);
   });
 
   it("replaces expansion wholesale when told", () => {
-    ws.toggleExpanded("a");
-    ws.setExpanded(["b", "c"]);
-    expect(ws.getView().expanded).toEqual(["b", "c"]);
+    ws.toggleExpanded("prod", "a");
+    ws.setExpanded("prod", ["b", "c"]);
+    expect(ws.getView().expanded.prod).toEqual(["b", "c"]);
   });
 
   it("does not notify for a no-op", () => {
@@ -66,13 +66,13 @@ describe("workspace view", () => {
   });
 
   it("does not notify when setExpanded is handed the same list again", () => {
-    ws.setExpanded(["a", "b"]);
+    ws.setExpanded("prod", ["a", "b"]);
     let n = 0;
     const off = ws.subscribe(() => n++);
-    ws.setExpanded(["a", "b"]);
-    ws.setExpanded([...ws.getView().expanded]);
+    ws.setExpanded("prod", ["a", "b"]);
+    ws.setExpanded("prod", [...ws.getView().expanded.prod]);
     expect(n).toBe(0);
-    ws.setExpanded(["b", "a"]);
+    ws.setExpanded("prod", ["b", "a"]);
     expect(n).toBe(1);
     off();
   });
@@ -181,11 +181,11 @@ describe("persisted namespace selection", () => {
 
   it("loading namespaces leaves links and expanded exactly as they were", () => {
     ws.setLink("prod", "connected");
-    ws.toggleExpanded("workloads");
+    ws.toggleExpanded("prod", "workloads");
     const s = fakeStorage();
     ws.loadNamespaces(s);
     expect(ws.getView().links.prod).toEqual({ state: "connected" });
-    expect(ws.getView().expanded).toEqual(["workloads"]);
+    expect(ws.getView().expanded.prod).toEqual(["workloads"]);
   });
 
   it("reads a document that is not valid JSON, or not a map, as nothing stored", () => {
@@ -226,4 +226,41 @@ it("uses the default only for clusters without a choice, and preserves explicit 
   expect(result.current).toEqual([]);
   const other = renderHook(() => ws.useNamespaces("unseen"));
   expect(other.result.current).toEqual(["other"]);
+});
+
+describe("persisted sidebar groups", () => {
+  it("saves through the settings adapter and restores independent cluster choices", () => {
+    const s = fakeStorage();
+    const save = vi.spyOn(settingsStorage, "setItem").mockImplementation(s.setItem);
+    ws.toggleExpanded("stable-prod", "workloads");
+    ws.toggleExpanded("stable-stage", "network");
+    expect(save).toHaveBeenLastCalledWith(ws.EXPANDED_KEY, JSON.stringify({
+      "stable-prod": ["workloads"], "stable-stage": ["network"],
+    }));
+    ws.resetView();
+    ws.loadExpanded(s);
+    expect(ws.getView().expanded).toEqual({ "stable-prod": ["workloads"], "stable-stage": ["network"] });
+    save.mockRestore();
+  });
+
+  it("drops malformed entries without losing other clusters or live connection state", () => {
+    const s = fakeStorage();
+    s.setItem(ws.EXPANDED_KEY, JSON.stringify({ good: ["workloads"], bad: true, mixed: [3], closed: [] }));
+    ws.setLink("good", "connected");
+    ws.loadExpanded(s);
+    expect(ws.getView().expanded).toEqual({ good: ["workloads"], closed: [] });
+    expect(ws.getView().links.good.state).toBe("connected");
+    s.setItem(ws.EXPANDED_KEY, "invalid json");
+    ws.loadExpanded(s);
+    expect(ws.getView().expanded).toEqual({});
+  });
+
+  it("still allows navigation when storage is unavailable", () => {
+    const bad = { getItem: () => { throw Error("offline"); }, setItem: () => { throw Error("offline"); }, removeItem: () => {} };
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => ws.loadExpanded(bad)).not.toThrow();
+    expect(() => ws.toggleExpanded("prod", "workloads", bad)).not.toThrow();
+    expect(ws.getView().expanded.prod).toEqual(["workloads"]);
+    error.mockRestore();
+  });
 });

--- a/packages/ui-next/src/lib/workspace.ts
+++ b/packages/ui-next/src/lib/workspace.ts
@@ -38,16 +38,16 @@ export const LINK_TONE: Record<LinkState, Tone> = {
 export interface WorkspaceView {
   /** Per cluster. Derived from `ClusterInfo.reachable` and in-flight connects; never persisted. */
   links: Record<string, { state: LinkState; error?: string }>;
-  /** Which sidebar sections are open. Not persisted. */
-  expanded: string[];
+  /** Open sidebar groups per stable cluster ID, persisted through settingsStorage. */
+  expanded: Record<string, string[]>;
   /**
    * Namespace selection per cluster, keyed by `ClusterContext.stableId`, never
    * a display name — a context renamed in the kubeconfig keeps its selection.
    * One selection per cluster, shared by every screen looking at that
    * cluster, rather than one per tab. An empty array means "all namespaces",
    * and so does a cluster with no entry at all — a cluster is only ever added
-   * here when something narrows it, never seeded up front. Unlike `links` and
-   * `expanded`, this *is* persisted (`loadNamespaces`/`setNamespaces`,
+   * here when something narrows it, never seeded up front. This is persisted
+   * (`loadNamespaces`/`setNamespaces`,
    * through `settingsStorage`, the same as `marks.ts` and `columnPrefs.ts`):
    * a namespace selection is a standing choice about what a reader wants to
    * see, not a fact about this sitting.
@@ -55,20 +55,8 @@ export interface WorkspaceView {
   namespaces: Record<string, string[]>;
 }
 
-/**
- * What the current workspace looks like right now, as distinct from what it
- * contains. The tab store owns clusters, tabs and the active cluster and is
- * written to disk; this owns three things, kept for two different reasons.
- * `links` and `expanded` should not outlive the window — a cluster's
- * reachability is a fact about now and an expanded section is a fact about
- * this sitting — so neither is ever read from or written to storage.
- * `namespaces` is the odd one out: a namespace selection is a standing
- * choice about what a reader wants to see, so it alone survives a restart.
- * (It was added to this struct later and inherited non-persistence by
- * accident of where it lives rather than by that argument — see
- * `loadNamespaces` below for where it actually persists.)
- */
-const initial = (): WorkspaceView => ({ links: {}, expanded: [], namespaces: {} });
+/** Live connection status and the reader's persisted per-cluster choices. */
+const initial = (): WorkspaceView => ({ links: {}, expanded: {}, namespaces: {} });
 let view: WorkspaceView = initial();
 const listeners = new Set<() => void>();
 
@@ -83,42 +71,17 @@ function sameArray(a: readonly string[], b: readonly string[]): boolean {
 }
 
 function isInitial(v: WorkspaceView): boolean {
-  return Object.keys(v.links).length === 0 && v.expanded.length === 0 && Object.keys(v.namespaces).length === 0;
+  return Object.keys(v.links).length === 0 && Object.keys(v.expanded).length === 0 && Object.keys(v.namespaces).length === 0;
 }
 
 export function getView(): WorkspaceView {
   return view;
 }
 
-/**
- * Whether {@link seedExpandedOnce} has already run for this window's
- * lifetime. Module-level rather than a ref kept on `Nav`: a ref resets every
- * time the component remounts, so a ref-guarded seed cannot tell "nothing has
- * opened a group yet" from "the user just closed all of them" — both show up
- * as an empty `expanded` on the next mount. A flag that survives remounts is
- * what makes the two distinguishable. `resetView` clears it alongside the
- * rest of the view because tests use one call to `resetView` as "a fresh
- * window"; production never calls `resetView` at all.
- */
-let seeded = false;
-
 export function resetView(): void {
-  seeded = false;
   defaultSelection = readDefaultSelection();
   if (isInitial(view)) return;
   emit(initial());
-}
-
-/**
- * Seeds `expanded` with `ids`, but only the first time this is ever called
- * for the running window — not once per mount of whatever calls it. Everything
- * else about the sidebar's folds already works whether `Nav` is mounted once
- * or remounted a dozen times; this is the one piece of it that must not.
- */
-export function seedExpandedOnce(ids: string[]): void {
-  if (seeded) return;
-  seeded = true;
-  if (view.expanded.length === 0) setExpanded(ids);
 }
 
 export function subscribe(listener: () => void): () => void {
@@ -137,14 +100,32 @@ export function setLink(id: string, state: LinkState, error?: string): void {
   emit({ ...view, links: { ...view.links, [id]: entry } });
 }
 
-export function toggleExpanded(id: string): void {
-  const expanded = view.expanded.includes(id) ? view.expanded.filter((x) => x !== id) : [...view.expanded, id];
+export const EXPANDED_KEY = "srelens.next.navigationExpanded";
+
+/** Restore choices before mounting the sidebar. Missing clusters start collapsed. */
+export function loadExpanded(storage: Storage = settingsStorage): void {
+  let expanded: Record<string, string[]> = {};
+  try {
+    expanded = parseStoredClusterLists(storage.getItem(EXPANDED_KEY));
+  } catch (error) {
+    console.error("could not read the saved sidebar groups", error);
+  }
   emit({ ...view, expanded });
 }
 
-export function setExpanded(ids: string[]): void {
-  if (sameArray(view.expanded, ids)) return;
-  emit({ ...view, expanded: [...ids] });
+export function toggleExpanded(clusterId: string, id: string, storage: Storage = settingsStorage): void {
+  const current = view.expanded[clusterId] ?? [];
+  setExpanded(clusterId, current.includes(id) ? current.filter((x) => x !== id) : [...current, id], storage);
+}
+
+export function setExpanded(clusterId: string, ids: string[], storage: Storage = settingsStorage): void {
+  if (sameArray(view.expanded[clusterId] ?? [], ids)) return;
+  emit({ ...view, expanded: { ...view.expanded, [clusterId]: [...ids] } });
+  try {
+    storage.setItem(EXPANDED_KEY, JSON.stringify(view.expanded));
+  } catch (error) {
+    console.error("could not persist the sidebar groups", error);
+  }
 }
 
 export const NAMESPACES_KEY = "srelens.next.namespaces";
@@ -160,7 +141,9 @@ const isStringArray = (v: unknown): v is string[] => Array.isArray(v) && v.every
  * cluster's is not. An empty array is an explicit all-namespaces choice;
  * a missing entry follows the global default.
  */
-export function parseStoredNamespaces(raw: string | null): Record<string, string[]> {
+export const parseStoredNamespaces = parseStoredClusterLists;
+
+function parseStoredClusterLists(raw: string | null): Record<string, string[]> {
   if (!raw) return {};
   let doc: unknown;
   try {
@@ -169,11 +152,7 @@ export function parseStoredNamespaces(raw: string | null): Record<string, string
     return {};
   }
   if (!isRecord(doc)) return {};
-  const namespaces: Record<string, string[]> = {};
-  for (const [id, value] of Object.entries(doc)) {
-    if (isStringArray(value)) namespaces[id] = value;
-  }
-  return namespaces;
+  return Object.fromEntries(Object.entries(doc).filter((entry): entry is [string, string[]] => isStringArray(entry[1])));
 }
 
 function saveNamespaces(storage: Storage) {
@@ -190,13 +169,12 @@ function saveNamespaces(storage: Storage) {
  * Read the saved namespace selections once at boot — and in tests, as often
  * as they like.
  *
- * Guarded like every accessor in `marks.ts`/`columnPrefs.ts`: `settingsStorage`
- * falls back to raw `localStorage` when the backend file is unavailable, and
- * `localStorage` throws outright in a WebView with storage disabled. Boot
+ * Guarded like every accessor in `marks.ts`/`columnPrefs.ts`: the settings adapter
+ * can refuse reads if backend initialization failed. Boot
  * must survive it, so a refusing storage costs the remembered selections and
  * nothing else. Merged onto the current view rather than replacing it, so a
  * `links`/`expanded` set before boot finishes reading storage is not undone —
- * neither is ever written here, but both could in principle already be set.
+ * neither is written here, but both could already be set.
  */
 export function loadNamespaces(storage: Storage = settingsStorage): void {
   defaultSelection = readDefaultSelection();

--- a/packages/ui-next/src/shell/Nav.test.tsx
+++ b/packages/ui-next/src/shell/Nav.test.tsx
@@ -5,7 +5,7 @@ import type { ClusterContext, CrdRef } from "@srelens/core";
 import { Nav } from "./Nav";
 import { currentWorkspace, openTab, setState } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
-import { resetView, setLink } from "../lib/workspace";
+import { loadExpanded, resetView, setLink } from "../lib/workspace";
 
 // The CRD list is the one thing here that talks to a cluster. Mocked at the
 // module boundary — partially, so `RESOURCE_LABELS` and the rest of core stay
@@ -39,6 +39,7 @@ const CERTS: CrdRef = {
 
 beforeEach(() => {
   setState(defaultState([PROD]));
+  localStorage.clear();
   resetView();
   vi.clearAllMocks();
   listCrds.mockResolvedValue({ crds: [] });
@@ -53,6 +54,9 @@ describe("Nav", () => {
     // opposite of what a tab strip is for.
     render(<Nav contexts={[PROD]} />);
 
+    for (const group of ["Workloads", "Network", "Cluster"]) {
+      await userEvent.click(screen.getByRole("treeitem", { name: group }));
+    }
     for (const kind of ["Pods", "Deployments", "Services", "Nodes"]) {
       await userEvent.click(await screen.findByRole("treeitem", { name: kind }));
     }
@@ -67,6 +71,7 @@ describe("Nav", () => {
   it("lists a built-in kind and opens it in a tab of its own", async () => {
     render(<Nav contexts={[PROD]} />);
 
+    await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));
     await userEvent.click(await screen.findByRole("treeitem", { name: "Pods" }));
 
     const tab = tabFor("/k/pods");
@@ -100,6 +105,7 @@ describe("Nav", () => {
   it("opens an app screen from the Investigate group", async () => {
     render(<Nav contexts={[PROD]} />);
 
+    await userEvent.click(screen.getByRole("treeitem", { name: "Investigate" }));
     await userEvent.click(await screen.findByRole("treeitem", { name: "Incidents" }));
 
     expect(tabFor("/incidents")?.preview).toBeFalsy();
@@ -117,6 +123,7 @@ describe("Nav", () => {
     openTab("/k/deployments", { clusterName: PROD.name });
     render(<Nav contexts={[PROD]} />);
 
+    await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));
     const row = await screen.findByRole("treeitem", { name: "Deployments" });
     expect(row.getAttribute("aria-selected")).toBe("true");
     expect((await screen.findByRole("treeitem", { name: "Pods" })).getAttribute("aria-selected")).toBe("false");
@@ -133,7 +140,7 @@ describe("Nav", () => {
 
   it("filters the tree by the sidebar's search box", async () => {
     render(<Nav contexts={[PROD]} />);
-    await screen.findByRole("treeitem", { name: "Pods" });
+    await screen.findByRole("treeitem", { name: "Workloads" });
 
     await userEvent.type(screen.getByRole("searchbox", { name: "Filter resources" }), "secre");
 
@@ -147,6 +154,7 @@ describe("Nav", () => {
 
     // The built-ins are not RBAC-gated the way CRD discovery is: an ordinary
     // user who cannot list CRDs must still get Pods and the rest of the tree.
+    await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));
     expect(await screen.findByRole("treeitem", { name: "Pods" })).toBeTruthy();
 
     await userEvent.click(await screen.findByRole("treeitem", { name: "Custom resources" }));
@@ -162,7 +170,7 @@ describe("Nav", () => {
   it("asks the new cluster for its CRDs when the cluster changes", async () => {
     const other = ctx("staging");
     const { rerender } = render(<Nav contexts={[PROD, other]} />);
-    await screen.findByRole("treeitem", { name: "Pods" });
+    await screen.findByRole("treeitem", { name: "Workloads" });
 
     setState(defaultState([other]));
     rerender(<Nav contexts={[PROD, other]} />);
@@ -170,21 +178,49 @@ describe("Nav", () => {
     await vi.waitFor(() => expect(listCrds).toHaveBeenCalledWith("staging"));
   });
 
-  it("stays folded shut across a remount once the user has closed every group", async () => {
-    const { unmount } = render(<Nav contexts={[PROD]} />);
-    await screen.findByRole("treeitem", { name: "Pods" });
-
-    for (const label of ["Cluster", "Workloads", "Config", "Network", "Storage", "Access control", "Investigate"]) {
-      await userEvent.click(screen.getByRole("treeitem", { name: label }));
-    }
-    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
-
-    unmount();
+  it("starts every group collapsed for a cluster without saved preferences", () => {
     render(<Nav contexts={[PROD]} />);
-
-    // A remount must not read "every group closed" as "nothing has been
-    // seeded yet" and reopen all six — that is the state the user just put
-    // the sidebar in on purpose.
+    const groups = screen.getAllByRole("treeitem").filter((row) => row.hasAttribute("aria-expanded"));
+    expect(groups.length).toBeGreaterThan(0);
+    for (const row of groups) expect(row.getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
+  });
+
+  it("restores each cluster's groups after switching, renaming, and restarting", async () => {
+    const other = { ...ctx("prod-eu"), stableId: "another-context" };
+    const first = render(<Nav contexts={[PROD, other]} />);
+    await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));
+    expect(screen.getByRole("treeitem", { name: "Pods" })).toBeTruthy();
+
+    setState(defaultState([other]));
+    first.rerender(<Nav contexts={[PROD, other]} />);
+    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
+    await userEvent.click(screen.getByRole("treeitem", { name: "Network" }));
+    first.unmount();
+
+    resetView();
+    loadExpanded();
+    const renamed = { ...PROD, name: "renamed-prod" };
+    setState(defaultState([renamed]));
+    const restarted = render(<Nav contexts={[renamed, other]} />);
+    expect(screen.getByRole("treeitem", { name: "Pods" })).toBeTruthy();
+    expect(screen.queryByRole("treeitem", { name: "Services" })).toBeNull();
+
+    setState(defaultState([other]));
+    restarted.rerender(<Nav contexts={[renamed, other]} />);
+    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
+    expect(screen.getByRole("treeitem", { name: "Services" })).toBeTruthy();
+  });
+
+  it("keeps every group shut after closing the last one and restarting", async () => {
+    const { unmount } = render(<Nav contexts={[PROD]} />);
+    await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));
+    await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));
+    unmount();
+    resetView();
+    loadExpanded();
+    render(<Nav contexts={[PROD]} />);
+    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
+    expect(screen.getByRole("treeitem", { name: "Workloads" }).getAttribute("aria-expanded")).toBe("false");
   });
 });

--- a/packages/ui-next/src/shell/Nav.tsx
+++ b/packages/ui-next/src/shell/Nav.tsx
@@ -1,14 +1,14 @@
 import { symbolFor } from "../lib/markSymbols";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { listCrds, type ClusterContext, type CrdRef } from "@srelens/core";
 import { Mark, ResourceTree, Sidebar, StatusPill, type ResourceNode, type StatusKind } from "@srelens/ui-kit";
 import { saveNavigationWidth, setNavigationWidth, useNavigationWidth } from "../lib/navigationWidth";
 import { Icons } from "../lib/icons";
 import { useMark } from "../lib/marks";
 import { openTab, useActiveCluster, useTabs } from "../lib/tabsStore";
-import { crdNodes, glyph, INVESTIGATE, kindNodes, NAV_GROUPS, routeForNode } from "../lib/tree";
+import { crdNodes, glyph, INVESTIGATE, kindNodes, routeForNode } from "../lib/tree";
 import { useResource } from "../lib/useResource";
-import { seedExpandedOnce, toggleExpanded, useWorkspaceView, type LinkState } from "../lib/workspace";
+import { toggleExpanded, useWorkspaceView, type LinkState } from "../lib/workspace";
 
 /** The one leaf the "Custom resources" group holds when discovery has failed. */
 const CRD_ERROR_ID = "crd-error";
@@ -28,12 +28,6 @@ const LINK: Record<LinkState, { word: string; kind: StatusKind }> = {
 
 /** Before anything has probed the cluster there is nothing to claim about it. */
 const UNKNOWN = { word: "Unknown", kind: "neutral" } as const;
-
-/**
- * The groups that stand open the first time a window is used: everything the
- * tree builds with children, minus the two that ask to start shut.
- */
-const DEFAULT_EXPANDED = [...NAV_GROUPS.map((g) => g.id), "investigate"];
 
 /**
  * The id of the node the active tab is on, or `undefined` when the tab is on
@@ -70,14 +64,8 @@ function nodeForRoute(nodes: ResourceNode[], crds: CrdRef[], route: string): str
  * browsing, and browsing twenty kinds should not leave twenty tabs behind —
  * `openTab` promotes the preview as soon as the row is opened for real.
  *
- * And the folds are stored, not defaulted. The kit's tree takes `expanded` as
- * the whole truth when it is given at all, so an empty list would mean every
- * group shut on first launch; the workspace view is therefore seeded, once
- * ever for the window's lifetime (`seedExpandedOnce`, in `workspace.ts`) with
- * the groups that should stand open. Once ever rather than once per mount,
- * because "the user closed all six" is a state the sidebar has to be able to
- * stay in across a remount, and a per-mount guard cannot tell that state apart
- * from "nothing has opened anything yet" — both leave `expanded` empty.
+ * Groups start collapsed. Their open state is saved per stable cluster ID,
+ * so switching contexts or restarting restores that cluster's own choices.
  */
 export function Nav({ contexts }: NavProps) {
   const activeCluster = useActiveCluster();
@@ -129,10 +117,6 @@ export function Nav({ contexts }: NavProps) {
     ],
     [crds, crdChildren],
   );
-
-  useEffect(() => {
-    seedExpandedOnce(DEFAULT_EXPANDED);
-  }, []);
 
   const link = ctx ? (view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN) : UNKNOWN;
 
@@ -189,8 +173,8 @@ export function Nav({ contexts }: NavProps) {
             // The strip scrolls, so accumulating is affordable.
             if (next) openTab(next, { clusterName: ctx.name });
           }}
-          expanded={view.expanded}
-          onExpandedChange={toggleExpanded}
+          expanded={view.expanded[ctx.stableId] ?? []}
+          onExpandedChange={(id) => toggleExpanded(ctx.stableId, id)}
           query={query}
         />
       )}

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -183,7 +183,7 @@ import { ConsoleProvider, useConsole } from "../console";
 import { Window } from "./Window";
 import * as store from "../lib/tabsStore";
 import { resetProbes } from "../lib/probe";
-import { resetView } from "../lib/workspace";
+import { EXPANDED_KEY, resetView } from "../lib/workspace";
 import { defaultState, makeTab } from "../lib/tabs";
 import { defaultMark, getMark, setMark, MARKS_KEY } from "../lib/marks";
 import { contextFor, getContextsError, getContextsStatus, resetContexts } from "../lib/clusters";
@@ -259,6 +259,17 @@ async function booted() {
 }
 
 describe("Window boot", () => {
+  it("loads the cluster's saved sidebar groups before navigation mounts", async () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify({ prod: ["network"], offline: ["workloads"] }));
+    await booted();
+    expect(screen.getByRole("treeitem", { name: "Services" })).toBeDefined();
+    expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
+    await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));
+    expect(JSON.parse(localStorage.getItem(EXPANDED_KEY)!)).toEqual({
+      prod: ["network", "workloads"], offline: ["workloads"],
+    });
+  });
+
   it("builds a Default workspace from the contexts when nothing was saved", async () => {
     await booted();
     expect(store.getState().workspaces[0].name).toBe("Default");

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -21,7 +21,7 @@ import { getMark, loadMarks, useMark } from "../lib/marks";
 import { mcpAutoStartSettled, mcpAutoStartStarting } from "../lib/mcpAutoStart";
 import { loadPeekWidth } from "../lib/peekWidth";
 import { loadSectionFolds } from "../lib/sectionFolds";
-import { loadNamespaces } from "../lib/workspace";
+import { loadExpanded, loadNamespaces } from "../lib/workspace";
 import { defaultState, reconcile } from "../lib/tabs";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
 import {
@@ -174,9 +174,9 @@ export function Window({
       // unfolded — and the first unfold then spreads over an empty record and
       // erases every other kind's, exactly as `loadMarks` above describes.
       loadSectionFolds();
-      // And the namespace selection each cluster was narrowed to — unlike
-      // `links`/`expanded` on the same store, this one is persisted, and
-      // unread it costs the reader their picker choice on every launch.
+      // Restore each cluster's sidebar groups and namespace selection before
+      // rendering navigation, so the first toggle preserves other clusters.
+      loadExpanded();
       loadNamespaces();
       // And the subjects a bare `/logs` offers as a way in. Unread, that
       // screen has nothing to offer on the first visit of every launch — and


### PR DESCRIPTION
## What changed and why

Application settings now persist through the backend on both desktop and web. Web startup loads the signed-in user's SQLite preferences through `GET /api/settings`, and writes use the existing authenticated, CSRF-protected per-key endpoints. Desktop continues using its settings file.

The design selector now uses the shared settings adapter and waits for the backend save before reloading. A rejected save keeps the current screen. Backend initialization failures no longer redirect application preference writes into local storage.

Expand legacy migration to include design, appearance, workspaces, columns, context ambiguity markers, and the other existing preference keys. Run the missing-key import for already-migrated installations too. Backend values win over stale browser copies, and local copies are removed only after successful persistence.

Sidebar resource groups now start collapsed and persist their open state per stable cluster ID. Startup restores those choices before navigation mounts. Switching or renaming contexts preserves the correct groups; explicitly closing every group also survives a restart.

## Validation

- Added failing regressions for backend web settings, user isolation, design persistence, and missing legacy migrations; all now pass.
- `pnpm test`: 6,182 tests passed on the merged Vitest 4 dependency versions; 90.69% line coverage with unchanged coverage gates.
- `pnpm typecheck` and `pnpm build`: passed.
- `cargo test --workspace`: passed, including authenticated settings enumeration and account-isolation tests.
- Browser harness using the real settings adapter: context edits persist, design switching waits for backend storage before reload, and a fresh browser session loads the same preferences without local copies. Sidebar browser checks also verified collapsed defaults, cluster switching, restart restoration, and fresh-session backend reads.

## Compatibility and rollout

Based on `dev`, which includes the merged context-settings fixes (#474 via #470) and security updates (#479). Temporary navigation handoffs and unsaved editor drafts retain their existing transient handling. Existing users' preferences are imported into the backend; a failed import retains its legacy copies for retry.
