### PR TITLE
feat(tui): assistant prompt cursor navigation and modal picker end-of-list shortcuts

### DIFF
--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -1627,6 +1627,18 @@ impl App {
                             }
                             self.modal = Some(Modal::ContainerPicker { containers, selected_idx, action, pod_name, namespace });
                         }
+                        KeyCode::Char('g') | KeyCode::Char('G') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = containers.len().saturating_sub(1);
+                            self.modal = Some(Modal::ContainerPicker { containers, selected_idx, action, pod_name, namespace });
+                        }
+                        KeyCode::End | KeyCode::Char('G') => {
+                            selected_idx = containers.len().saturating_sub(1);
+                            self.modal = Some(Modal::ContainerPicker { containers, selected_idx, action, pod_name, namespace });
+                        }
+                        KeyCode::Home | KeyCode::Char('g') => {
+                            selected_idx = 0;
+                            self.modal = Some(Modal::ContainerPicker { containers, selected_idx, action, pod_name, namespace });
+                        }
                         KeyCode::Enter => {
                             let chosen_container = containers.get(selected_idx).cloned();
                             self.modal = None;
@@ -1701,6 +1713,30 @@ impl App {
                             }
                             self.modal = Some(Modal::ContextPicker { contexts, selected_idx, filter, current_context });
                         }
+                        KeyCode::Char('g') | KeyCode::Char('G') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = filtered_count.saturating_sub(1);
+                            self.modal = Some(Modal::ContextPicker { contexts, selected_idx, filter, current_context });
+                        }
+                        KeyCode::End => {
+                            selected_idx = filtered_count.saturating_sub(1);
+                            self.modal = Some(Modal::ContextPicker { contexts, selected_idx, filter, current_context });
+                        }
+                        KeyCode::Home => {
+                            selected_idx = 0;
+                            self.modal = Some(Modal::ContextPicker { contexts, selected_idx, filter, current_context });
+                        }
+                        KeyCode::PageDown => {
+                            selected_idx = (selected_idx + 5).min(filtered_count.saturating_sub(1));
+                            self.modal = Some(Modal::ContextPicker { contexts, selected_idx, filter, current_context });
+                        }
+                        KeyCode::PageUp => {
+                            selected_idx = selected_idx.saturating_sub(5);
+                            self.modal = Some(Modal::ContextPicker { contexts, selected_idx, filter, current_context });
+                        }
+                        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = (selected_idx + 5).min(filtered_count.saturating_sub(1));
+                            self.modal = Some(Modal::ContextPicker { contexts, selected_idx, filter, current_context });
+                        }
                         KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) && !key.modifiers.contains(KeyModifiers::ALT) => {
                             filter.push(c);
                             selected_idx = 0;
@@ -1763,6 +1799,30 @@ impl App {
                             } else {
                                 selected_idx = 0;
                             }
+                            self.modal = Some(Modal::NamespacePicker { namespaces, selected_idx, filter, current_namespace });
+                        }
+                        KeyCode::Char('g') | KeyCode::Char('G') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = filtered_count.saturating_sub(1);
+                            self.modal = Some(Modal::NamespacePicker { namespaces, selected_idx, filter, current_namespace });
+                        }
+                        KeyCode::End => {
+                            selected_idx = filtered_count.saturating_sub(1);
+                            self.modal = Some(Modal::NamespacePicker { namespaces, selected_idx, filter, current_namespace });
+                        }
+                        KeyCode::Home => {
+                            selected_idx = 0;
+                            self.modal = Some(Modal::NamespacePicker { namespaces, selected_idx, filter, current_namespace });
+                        }
+                        KeyCode::PageDown => {
+                            selected_idx = (selected_idx + 10).min(filtered_count.saturating_sub(1));
+                            self.modal = Some(Modal::NamespacePicker { namespaces, selected_idx, filter, current_namespace });
+                        }
+                        KeyCode::PageUp => {
+                            selected_idx = selected_idx.saturating_sub(10);
+                            self.modal = Some(Modal::NamespacePicker { namespaces, selected_idx, filter, current_namespace });
+                        }
+                        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = (selected_idx + 10).min(filtered_count.saturating_sub(1));
                             self.modal = Some(Modal::NamespacePicker { namespaces, selected_idx, filter, current_namespace });
                         }
                         KeyCode::Char('0') if filter.is_empty() => {
@@ -1881,6 +1941,72 @@ impl App {
                                 filter,
                             });
                         }
+                        KeyCode::Char('g') | KeyCode::Char('G') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = filtered_count.saturating_sub(1);
+                            self.modal = Some(Modal::ActionPalette {
+                                resource_kind,
+                                resource_name,
+                                namespace,
+                                actions,
+                                selected_idx,
+                                filter,
+                            });
+                        }
+                        KeyCode::End => {
+                            selected_idx = filtered_count.saturating_sub(1);
+                            self.modal = Some(Modal::ActionPalette {
+                                resource_kind,
+                                resource_name,
+                                namespace,
+                                actions,
+                                selected_idx,
+                                filter,
+                            });
+                        }
+                        KeyCode::Home => {
+                            selected_idx = 0;
+                            self.modal = Some(Modal::ActionPalette {
+                                resource_kind,
+                                resource_name,
+                                namespace,
+                                actions,
+                                selected_idx,
+                                filter,
+                            });
+                        }
+                        KeyCode::PageDown => {
+                            selected_idx = (selected_idx + 5).min(filtered_count.saturating_sub(1));
+                            self.modal = Some(Modal::ActionPalette {
+                                resource_kind,
+                                resource_name,
+                                namespace,
+                                actions,
+                                selected_idx,
+                                filter,
+                            });
+                        }
+                        KeyCode::PageUp => {
+                            selected_idx = selected_idx.saturating_sub(5);
+                            self.modal = Some(Modal::ActionPalette {
+                                resource_kind,
+                                resource_name,
+                                namespace,
+                                actions,
+                                selected_idx,
+                                filter,
+                            });
+                        }
+                        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = (selected_idx + 5).min(filtered_count.saturating_sub(1));
+                            self.modal = Some(Modal::ActionPalette {
+                                resource_kind,
+                                resource_name,
+                                namespace,
+                                actions,
+                                selected_idx,
+                                filter,
+                            });
+                        }
                         KeyCode::Backspace => {
                             filter.pop();
                             selected_idx = 0;
@@ -1982,6 +2108,22 @@ impl App {
                             }
                             self.modal = Some(Modal::ReasonRail { tallies, selected_idx, active_filter });
                         }
+                        KeyCode::Char('g') | KeyCode::Char('G') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            if !tallies.is_empty() {
+                                selected_idx = tallies.len().saturating_sub(1);
+                            }
+                            self.modal = Some(Modal::ReasonRail { tallies, selected_idx, active_filter });
+                        }
+                        KeyCode::End => {
+                            if !tallies.is_empty() {
+                                selected_idx = tallies.len().saturating_sub(1);
+                            }
+                            self.modal = Some(Modal::ReasonRail { tallies, selected_idx, active_filter });
+                        }
+                        KeyCode::Home => {
+                            selected_idx = 0;
+                            self.modal = Some(Modal::ReasonRail { tallies, selected_idx, active_filter });
+                        }
                         KeyCode::Enter => {
                             if let Some(tally) = tallies.get(selected_idx) {
                                 if let ActiveView::Table(table) = &mut self.active_view {
@@ -2025,6 +2167,21 @@ impl App {
                             } else {
                                 selected_idx = 0;
                             }
+                            Theme::set_theme_by_index(selected_idx);
+                            self.modal = Some(Modal::ThemePicker { selected_idx, initial_theme_idx });
+                        }
+                        KeyCode::Char('g') | KeyCode::Char('G') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            selected_idx = total.saturating_sub(1);
+                            Theme::set_theme_by_index(selected_idx);
+                            self.modal = Some(Modal::ThemePicker { selected_idx, initial_theme_idx });
+                        }
+                        KeyCode::End => {
+                            selected_idx = total.saturating_sub(1);
+                            Theme::set_theme_by_index(selected_idx);
+                            self.modal = Some(Modal::ThemePicker { selected_idx, initial_theme_idx });
+                        }
+                        KeyCode::Home => {
+                            selected_idx = 0;
                             Theme::set_theme_by_index(selected_idx);
                             self.modal = Some(Modal::ThemePicker { selected_idx, initial_theme_idx });
                         }

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -3501,7 +3501,7 @@ impl App {
                         self.set_toast("✓ Copied assistant answer to clipboard".to_string(), Theme::status_ok());
                         return;
                     } else {
-                        self.is_running = false;
+                        self.set_toast("Nothing to copy".to_string(), Theme::status_warn());
                         return;
                     }
                 }

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -1477,10 +1477,13 @@ impl App {
         self.screen_selection = None;
         self.screen_selecting = false;
 
-        // Global Ctrl+C handler -> Immediately kill/exit TUI cleanly
+        // Global Ctrl+C handler -> Immediately kill/exit TUI cleanly,
+        // unless in Assistant view where Ctrl+C is used to copy selection or assistant reply.
         if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-            self.is_running = false;
-            return;
+            if !matches!(self.active_view, ActiveView::Assistant) || self.modal.is_some() || self.show_help {
+                self.is_running = false;
+                return;
+            }
         }
 
         // Clear expired toasts
@@ -3340,6 +3343,9 @@ impl App {
                         let _ = copy_to_clipboard(&last_asst.content);
                         self.set_toast("✓ Copied assistant answer to clipboard".to_string(), Theme::status_ok());
                         return;
+                    } else {
+                        self.is_running = false;
+                        return;
                     }
                 }
                 if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
@@ -3352,25 +3358,6 @@ impl App {
                         if !ai.slash_suggestions.is_empty() {
                             ai.apply_selected_slash_suggestion();
                             return;
-                        }
-                    }
-
-                    // Copy selection with 'c' (or copy last assistant message if input is empty)
-                    KeyCode::Char('c') if !key.modifiers.contains(KeyModifiers::CONTROL) && !key.modifiers.contains(KeyModifiers::ALT) => {
-                        if let Some(selected) = ai.get_selected_text() {
-                            let _ = copy_to_clipboard(&selected);
-                            self.set_toast("✓ Copied selection to clipboard".to_string(), Theme::status_ok());
-                        } else if ai.input.is_empty() {
-                            if let Some(last_asst) = ai.messages.iter().rev().find(|m| m.role == "assistant") {
-                                let _ = copy_to_clipboard(&last_asst.content);
-                                self.set_toast("✓ Copied assistant answer to clipboard".to_string(), Theme::status_ok());
-                            } else {
-                                ai.input.push('c');
-                                ai.update_slash_suggestions();
-                            }
-                        } else {
-                            ai.input.push('c');
-                            ai.update_slash_suggestions();
                         }
                     }
 
@@ -3390,11 +3377,34 @@ impl App {
                         ai.history_down();
                     }
 
-                    // Viewport Scrolling (PageUp/PageDown, Home/End, or Mouse Scroll)
+                    // Cursor Navigation inside Input
+                    KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) || key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        ai.move_cursor_word_left();
+                    }
+                    KeyCode::Right if key.modifiers.contains(KeyModifiers::ALT) || key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        ai.move_cursor_word_right();
+                    }
+                    KeyCode::Left => ai.move_cursor_left(),
+                    KeyCode::Right => ai.move_cursor_right(),
+                    KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::CONTROL) => ai.move_cursor_home(),
+
+                    // Viewport Scrolling & Cursor Home/End
+                    KeyCode::Home => {
+                        if ai.input.is_empty() {
+                            ai.scroll_to_top();
+                        } else {
+                            ai.move_cursor_home();
+                        }
+                    }
+                    KeyCode::End => {
+                        if ai.input.is_empty() {
+                            ai.scroll_to_bottom();
+                        } else {
+                            ai.move_cursor_end();
+                        }
+                    }
                     KeyCode::PageUp => ai.scroll_up(10),
                     KeyCode::PageDown => ai.scroll_down(10),
-                    KeyCode::Home => ai.scroll_to_top(),
-                    KeyCode::End => ai.scroll_to_bottom(),
                     KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => ai.scroll_up(2),
                     KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => ai.scroll_down(2),
                     KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => ai.scroll_up(10),
@@ -3402,27 +3412,25 @@ impl App {
 
                     // Editing & Input
                     _ if is_word_delete_key(&key) => {
-                        delete_prev_word(&mut ai.input);
-                        ai.update_slash_suggestions();
+                        ai.delete_word_back();
                     }
-                    KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::ALT) || key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        ai.input.clear();
-                        ai.update_slash_suggestions();
+                    KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::ALT) => {
+                        ai.clear_input();
                     }
                     KeyCode::Char('v') | KeyCode::Char('V') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         if let Some(clip) = get_clipboard_text() {
                             let cleaned = clip.replace("\r\n", " ").replace('\n', " ");
-                            ai.input.push_str(&cleaned);
-                            ai.update_slash_suggestions();
+                            ai.insert_str(&cleaned);
                         }
                     }
-                    KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) && !key.modifiers.contains(KeyModifiers::ALT) => {
-                        ai.input.push(c);
-                        ai.update_slash_suggestions();
-                    }
                     KeyCode::Backspace => {
-                        ai.input.pop();
-                        ai.update_slash_suggestions();
+                        ai.backspace();
+                    }
+                    KeyCode::Delete => {
+                        ai.delete();
+                    }
+                    KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) && !key.modifiers.contains(KeyModifiers::ALT) => {
+                        ai.insert_char(c);
                     }
                     KeyCode::Enter => {
                         if ai.is_busy {

--- a/apps/tui/src/ui/dialogs.rs
+++ b/apps/tui/src/ui/dialogs.rs
@@ -416,7 +416,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
                 .map(|(rel_i, c)| {
                     let i = start_idx + rel_i;
                     let is_active = c.name == *current_context;
-                    let is_sel = i == *selected_idx;
+                    let is_sel = i == sel;
                     let color = Theme::context_color(&c.name, c.is_local);
 
                     let prefix = if is_active { "★ " } else if is_sel { "▶ " } else { "  " };
@@ -529,7 +529,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
                 .map(|(rel_i, name)| {
                     let i = start_idx + rel_i;
                     let is_active = name == current_namespace;
-                    let is_sel = i == *selected_idx;
+                    let is_sel = i == sel;
                     let prefix = if is_active { "★ " } else if is_sel { "▶ " } else { "  " };
                     let style = if is_sel {
                         Theme::selected_row()
@@ -620,7 +620,7 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
                 .enumerate()
                 .map(|(rel_i, a)| {
                     let i = start_idx + rel_i;
-                    let is_sel = i == *selected_idx;
+                    let is_sel = i == sel;
                     let prefix = if is_sel { "▶ " } else { "  " };
 
                     let line1 = Line::from(vec![

--- a/apps/tui/src/ui/dialogs.rs
+++ b/apps/tui/src/ui/dialogs.rs
@@ -401,10 +401,20 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
                 })
                 .collect();
 
-            let items: Vec<ListItem> = filtered
+            let visible_items = (chunks[1].height as usize / 2).max(1);
+            let sel = (*selected_idx).min(filtered.len().saturating_sub(1));
+            let start_idx = if sel >= visible_items {
+                sel + 1 - visible_items
+            } else {
+                0
+            };
+            let end_idx = (start_idx + visible_items).min(filtered.len());
+
+            let items: Vec<ListItem> = filtered[start_idx..end_idx]
                 .iter()
                 .enumerate()
-                .map(|(i, c)| {
+                .map(|(rel_i, c)| {
+                    let i = start_idx + rel_i;
                     let is_active = c.name == *current_context;
                     let is_sel = i == *selected_idx;
                     let color = Theme::context_color(&c.name, c.is_local);
@@ -504,10 +514,20 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
                 .cloned()
                 .collect();
 
-            let items: Vec<ListItem> = all_ns
+            let visible_height = (chunks[1].height as usize).max(1);
+            let sel = (*selected_idx).min(all_ns.len().saturating_sub(1));
+            let start_idx = if sel >= visible_height {
+                sel + 1 - visible_height
+            } else {
+                0
+            };
+            let end_idx = (start_idx + visible_height).min(all_ns.len());
+
+            let items: Vec<ListItem> = all_ns[start_idx..end_idx]
                 .iter()
                 .enumerate()
-                .map(|(i, name)| {
+                .map(|(rel_i, name)| {
+                    let i = start_idx + rel_i;
                     let is_active = name == current_namespace;
                     let is_sel = i == *selected_idx;
                     let prefix = if is_active { "★ " } else if is_sel { "▶ " } else { "  " };
@@ -586,10 +606,20 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
                 })
                 .collect();
 
-            let items: Vec<ListItem> = filtered
+            let visible_items = (chunks[1].height as usize / 2).max(1);
+            let sel = (*selected_idx).min(filtered.len().saturating_sub(1));
+            let start_idx = if sel >= visible_items {
+                sel + 1 - visible_items
+            } else {
+                0
+            };
+            let end_idx = (start_idx + visible_items).min(filtered.len());
+
+            let items: Vec<ListItem> = filtered[start_idx..end_idx]
                 .iter()
                 .enumerate()
-                .map(|(i, a)| {
+                .map(|(rel_i, a)| {
+                    let i = start_idx + rel_i;
                     let is_sel = i == *selected_idx;
                     let prefix = if is_sel { "▶ " } else { "  " };
 

--- a/apps/tui/src/views/assistant_view.rs
+++ b/apps/tui/src/views/assistant_view.rs
@@ -446,9 +446,10 @@ impl AssistantViewState {
     pub fn history_up(&mut self) {
         if self.prompt_history.is_empty() {
             for msg in &self.messages {
-                if msg.role == "user" && !msg.content.trim().is_empty() {
-                    if self.prompt_history.last().map(|s| s.as_str()) != Some(msg.content.trim()) {
-                        self.prompt_history.push(msg.content.clone());
+                if msg.role == "user" {
+                    let trimmed = msg.content.trim();
+                    if !trimmed.is_empty() && self.prompt_history.last().map(|s| s.as_str()) != Some(trimmed) {
+                        self.prompt_history.push(trimmed.to_string());
                     }
                 }
             }
@@ -2477,17 +2478,26 @@ Done.";
     #[test]
     fn test_assistant_history_seeding_from_messages() {
         let mut state = AssistantViewState::new();
-        // Prompt history is empty, but messages has a user message
+        // Prompt history is empty, but messages has user messages with whitespace and duplicates
         state.messages.push(ChatMessage {
             role: "user".to_string(),
-            content: "seeded query".to_string(),
+            content: "  seeded query  ".to_string(),
             timestamp: "12:00:00".to_string(),
             tool_calls: Vec::new(),
             token_usage: None,
         });
+        state.messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: "seeded query".to_string(),
+            timestamp: "12:00:05".to_string(),
+            tool_calls: Vec::new(),
+            token_usage: None,
+        });
 
-        // Pressing Up seeds prompt_history and loads "seeded query"
+        // Pressing Up seeds prompt_history with trimmed content and deduplicates
         state.history_up();
+        assert_eq!(state.prompt_history.len(), 1);
+        assert_eq!(state.prompt_history[0], "seeded query");
         assert_eq!(state.input, "seeded query");
         assert_eq!(state.cursor_pos(), 12);
     }

--- a/apps/tui/src/views/assistant_view.rs
+++ b/apps/tui/src/views/assistant_view.rs
@@ -101,6 +101,7 @@ pub struct AssistantViewState {
     pub context_name: String,
     pub messages: Vec<ChatMessage>,
     pub input: String,
+    pub input_cursor: Option<usize>,
     pub is_busy: bool,
     pub busy_status: String,
     pub busy_start: Option<std::time::Instant>,
@@ -155,6 +156,7 @@ impl AssistantViewState {
                 token_usage: None,
             }],
             input: String::new(),
+            input_cursor: None,
             is_busy: false,
             busy_status: String::new(),
             busy_start: None,
@@ -215,9 +217,147 @@ impl AssistantViewState {
         }
         let chosen = self.slash_suggestions[self.slash_suggestion_idx];
         self.input = format!("/{} ", chosen.command);
+        self.input_cursor = None;
         self.slash_suggestions.clear();
         self.slash_suggestion_idx = 0;
         true
+    }
+
+    pub fn cursor_pos(&self) -> usize {
+        let len = self.input.chars().count();
+        match self.input_cursor {
+            Some(pos) => pos.min(len),
+            None => len,
+        }
+    }
+
+    pub fn move_cursor_left(&mut self) {
+        let pos = self.cursor_pos();
+        if pos > 0 {
+            self.input_cursor = Some(pos - 1);
+        } else {
+            self.input_cursor = Some(0);
+        }
+    }
+
+    pub fn move_cursor_right(&mut self) {
+        let pos = self.cursor_pos();
+        let len = self.input.chars().count();
+        if pos < len {
+            self.input_cursor = Some(pos + 1);
+        } else {
+            self.input_cursor = Some(len);
+        }
+    }
+
+    pub fn move_cursor_word_left(&mut self) {
+        let pos = self.cursor_pos();
+        if pos == 0 {
+            return;
+        }
+        let chars: Vec<char> = self.input.chars().collect();
+        let mut i = pos;
+        while i > 0 && chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        while i > 0 && !chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        self.input_cursor = Some(i);
+    }
+
+    pub fn move_cursor_word_right(&mut self) {
+        let pos = self.cursor_pos();
+        let chars: Vec<char> = self.input.chars().collect();
+        let len = chars.len();
+        if pos >= len {
+            return;
+        }
+        let mut i = pos;
+        while i < len && !chars[i].is_whitespace() {
+            i += 1;
+        }
+        while i < len && chars[i].is_whitespace() {
+            i += 1;
+        }
+        self.input_cursor = Some(i);
+    }
+
+    pub fn move_cursor_home(&mut self) {
+        self.input_cursor = Some(0);
+    }
+
+    pub fn move_cursor_end(&mut self) {
+        self.input_cursor = None;
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        let pos = self.cursor_pos();
+        let mut chars: Vec<char> = self.input.chars().collect();
+        chars.insert(pos, c);
+        self.input = chars.into_iter().collect();
+        self.input_cursor = Some(pos + 1);
+        self.update_slash_suggestions();
+    }
+
+    pub fn insert_str(&mut self, s: &str) {
+        let pos = self.cursor_pos();
+        let mut chars: Vec<char> = self.input.chars().collect();
+        let added_len = s.chars().count();
+        for (i, c) in s.chars().enumerate() {
+            chars.insert(pos + i, c);
+        }
+        self.input = chars.into_iter().collect();
+        self.input_cursor = Some(pos + added_len);
+        self.update_slash_suggestions();
+    }
+
+    pub fn backspace(&mut self) {
+        let pos = self.cursor_pos();
+        if pos > 0 {
+            let mut chars: Vec<char> = self.input.chars().collect();
+            chars.remove(pos - 1);
+            self.input = chars.into_iter().collect();
+            self.input_cursor = Some(pos - 1);
+            self.update_slash_suggestions();
+        }
+    }
+
+    pub fn delete(&mut self) {
+        let pos = self.cursor_pos();
+        let mut chars: Vec<char> = self.input.chars().collect();
+        if pos < chars.len() {
+            chars.remove(pos);
+            self.input = chars.into_iter().collect();
+            self.input_cursor = Some(pos);
+            self.update_slash_suggestions();
+        }
+    }
+
+    pub fn delete_word_back(&mut self) {
+        let pos = self.cursor_pos();
+        if pos == 0 {
+            return;
+        }
+        let chars: Vec<char> = self.input.chars().collect();
+        let mut i = pos;
+        while i > 0 && chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        while i > 0 && !chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
+        let mut new_chars = chars[..i].to_vec();
+        new_chars.extend_from_slice(&chars[pos..]);
+        self.input = new_chars.into_iter().collect();
+        self.input_cursor = Some(i);
+        self.update_slash_suggestions();
+    }
+
+    pub fn clear_input(&mut self) {
+        self.input.clear();
+        self.input_cursor = None;
+        self.update_slash_suggestions();
     }
 
     pub fn start_selection(&mut self, line: usize, col: usize) {
@@ -305,7 +445,16 @@ impl AssistantViewState {
 
     pub fn history_up(&mut self) {
         if self.prompt_history.is_empty() {
-            return;
+            for msg in &self.messages {
+                if msg.role == "user" && !msg.content.trim().is_empty() {
+                    if self.prompt_history.last().map(|s| s.as_str()) != Some(msg.content.trim()) {
+                        self.prompt_history.push(msg.content.clone());
+                    }
+                }
+            }
+            if self.prompt_history.is_empty() {
+                return;
+            }
         }
         match self.history_cursor {
             None => {
@@ -313,15 +462,18 @@ impl AssistantViewState {
                 let last_idx = self.prompt_history.len() - 1;
                 self.history_cursor = Some(last_idx);
                 self.input = self.prompt_history[last_idx].clone();
+                self.input_cursor = None;
             }
             Some(idx) => {
                 if idx > 0 {
                     let new_idx = idx - 1;
                     self.history_cursor = Some(new_idx);
                     self.input = self.prompt_history[new_idx].clone();
+                    self.input_cursor = None;
                 }
             }
         }
+        self.update_slash_suggestions();
     }
 
     pub fn history_down(&mut self) {
@@ -330,11 +482,14 @@ impl AssistantViewState {
                 let new_idx = idx + 1;
                 self.history_cursor = Some(new_idx);
                 self.input = self.prompt_history[new_idx].clone();
+                self.input_cursor = None;
             } else {
                 self.history_cursor = None;
                 self.input = self.history_draft.clone();
                 self.history_draft.clear();
+                self.input_cursor = None;
             }
+            self.update_slash_suggestions();
         }
     }
 
@@ -358,6 +513,7 @@ impl AssistantViewState {
             token_usage: None,
         });
         self.input.clear();
+        self.input_cursor = None;
         self.is_busy = true;
         self.busy_status = "Consulting AI provider & cluster state...".to_string();
         self.busy_start = Some(std::time::Instant::now());
@@ -479,6 +635,7 @@ impl AssistantViewState {
             token_usage: None,
         }];
         self.input.clear();
+        self.input_cursor = None;
         self.is_busy = false;
         self.busy_status.clear();
         self.busy_start = None;
@@ -790,7 +947,7 @@ pub fn render_assistant_view(
         format!("⚡ {} tokens, ", format_number(u.total_tokens))
     }).unwrap_or_default();
     let tools_hint = if state.expand_tools { "<Ctrl+t> Fold Tools" } else { "<Ctrl+t> Tools" };
-    let copy_hint = if state.selection.is_some() { "<c> Copy Selection" } else { "<c> Copy" };
+    let copy_hint = if state.selection.is_some() { "<Ctrl+c> Copy Selection" } else { "<Ctrl+c> Copy" };
     let cluster_tag = if !state.context_name.is_empty() {
         format!(" @{} ", state.context_name)
     } else {
@@ -815,13 +972,27 @@ pub fn render_assistant_view(
 
     // Calculate dynamic input box height based on wrapped lines
     let input_inner_width = (inner.width.saturating_sub(2).max(10)) as usize;
-    let input_full_text = format!("{}█", state.input);
+    let cursor_idx = state.cursor_pos();
+    let chars: Vec<char> = state.input.chars().collect();
+    let before: String = chars[..cursor_idx].iter().collect();
+    let after: String = chars[cursor_idx..].iter().collect();
+    let input_full_text = format!("{}█{}", before, after);
+
     let mut input_lines = 0;
     for raw_line in input_full_text.split('\n') {
         let line = Line::from(raw_line.to_string());
         input_lines += wrap_line(line, input_inner_width).len().max(1);
     }
     let input_lines = input_lines.max(1);
+
+    let before_with_cursor = format!("{}█", before);
+    let mut cursor_row = 0;
+    for raw_line in before_with_cursor.split('\n') {
+        let line = Line::from(raw_line.to_string());
+        cursor_row += wrap_line(line, input_inner_width).len().max(1);
+    }
+    let cursor_row = cursor_row.saturating_sub(1) as u16;
+
     let max_box_height = (inner.height / 3).clamp(3, 8);
     let input_box_height = ((input_lines as u16) + 2).min(max_box_height).max(3);
 
@@ -1078,14 +1249,18 @@ pub fn render_assistant_view(
     } else if !state.auto_scroll && effective_scroll < max_scroll {
         format!(" Ask Assistant (<End> Follow bottom, <PageUp>/<PageDown> Scroll) [Line {}/{}] ", effective_scroll + 1, total_lines)
     } else {
-        " Ask Assistant (Type '/' for SRE Playbooks, ↑/↓ History, <c> Copy, <Ctrl+s> Settings) ".to_string()
+        " Ask Assistant (Type '/' for SRE Playbooks, ↑/↓ History, <Ctrl+c> Copy, <Ctrl+s> Settings) ".to_string()
     };
     let input_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(if !state.slash_suggestions.is_empty() { Theme::ACCENT } else { Theme::CYAN }))
         .title(input_title);
     let visible_input_rows = input_box_height.saturating_sub(2);
-    let scroll_y = (input_lines as u16).saturating_sub(visible_input_rows);
+    let scroll_y = if cursor_row >= visible_input_rows {
+        (cursor_row + 1).saturating_sub(visible_input_rows).min((input_lines as u16).saturating_sub(visible_input_rows))
+    } else {
+        0
+    };
 
     let input_widget = Paragraph::new(input_full_text)
         .block(input_block)
@@ -2225,5 +2400,95 @@ Done.";
         let input_box_height = ((input_lines as u16) + 2).min(max_box_height).max(3);
         assert!(input_box_height >= 5);
         assert!(input_box_height <= 8);
+    }
+
+    #[test]
+    fn test_assistant_cursor_navigation_and_editing() {
+        let mut state = AssistantViewState::new();
+        assert_eq!(state.cursor_pos(), 0);
+
+        // Typing characters
+        state.insert_char('h');
+        state.insert_char('i');
+        assert_eq!(state.input, "hi");
+        assert_eq!(state.cursor_pos(), 2);
+
+        // Left arrow
+        state.move_cursor_left();
+        assert_eq!(state.cursor_pos(), 1);
+
+        // Inserting character in between
+        state.insert_char('a');
+        assert_eq!(state.input, "hai");
+        assert_eq!(state.cursor_pos(), 2);
+
+        // Home
+        state.move_cursor_home();
+        assert_eq!(state.cursor_pos(), 0);
+
+        // Insert at beginning
+        state.insert_char('o');
+        assert_eq!(state.input, "ohai");
+        assert_eq!(state.cursor_pos(), 1);
+
+        // End
+        state.move_cursor_end();
+        assert_eq!(state.cursor_pos(), 4);
+
+        // Right arrow at end stays at end
+        state.move_cursor_right();
+        assert_eq!(state.cursor_pos(), 4);
+
+        // Backspace at end
+        state.backspace();
+        assert_eq!(state.input, "oha");
+        assert_eq!(state.cursor_pos(), 3);
+
+        // Left, then Delete (forward delete)
+        state.move_cursor_left(); // at pos 2 ('a')
+        assert_eq!(state.cursor_pos(), 2);
+        state.delete(); // deletes 'a'
+        assert_eq!(state.input, "oh");
+        assert_eq!(state.cursor_pos(), 2);
+
+        // Insert string
+        state.insert_str(" beautiful world");
+        assert_eq!(state.input, "oh beautiful world");
+
+        // Word navigation
+        state.move_cursor_word_left(); // moves before "world"
+        assert_eq!(state.cursor_pos(), 13);
+        state.move_cursor_word_left(); // moves before "beautiful"
+        assert_eq!(state.cursor_pos(), 3);
+        state.move_cursor_word_right(); // moves after "beautiful "
+        assert_eq!(state.cursor_pos(), 13);
+
+        // Delete word back
+        state.delete_word_back(); // deletes "beautiful "
+        assert_eq!(state.input, "oh world");
+        assert_eq!(state.cursor_pos(), 3);
+
+        // Clear input
+        state.clear_input();
+        assert_eq!(state.input, "");
+        assert_eq!(state.cursor_pos(), 0);
+    }
+
+    #[test]
+    fn test_assistant_history_seeding_from_messages() {
+        let mut state = AssistantViewState::new();
+        // Prompt history is empty, but messages has a user message
+        state.messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: "seeded query".to_string(),
+            timestamp: "12:00:00".to_string(),
+            tool_calls: Vec::new(),
+            token_usage: None,
+        });
+
+        // Pressing Up seeds prompt_history and loads "seeded query"
+        state.history_up();
+        assert_eq!(state.input, "seeded query");
+        assert_eq!(state.cursor_pos(), 12);
     }
 }

--- a/apps/tui/tests/app_extra_tests.rs
+++ b/apps/tui/tests/app_extra_tests.rs
@@ -2022,6 +2022,17 @@ async fn ctrl_c_in_the_assistant_copies_the_last_answer() {
     assert_eq!(toast(&app), "✓ Copied assistant answer to clipboard");
 }
 
+#[tokio::test]
+async fn ctrl_c_in_the_assistant_without_messages_warns_and_does_not_exit() {
+    let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
+    app.active_view = ActiveView::Assistant;
+    app.assistant_state.messages.clear();
+
+    app.handle_key_event(common::ctrl('c')).await;
+    assert!(app.is_running, "Ctrl+C does not exit the TUI");
+    assert_eq!(toast(&app), "Nothing to copy");
+}
+
 // ---------------------------------------------------------------------------
 // Watch pool
 // ---------------------------------------------------------------------------

--- a/apps/tui/tests/app_extra_tests.rs
+++ b/apps/tui/tests/app_extra_tests.rs
@@ -2011,17 +2011,15 @@ async fn assistant_chords_clear_the_conversation_and_toggle_tool_chips() {
 }
 
 #[tokio::test]
-async fn ctrl_c_in_the_assistant_quits_instead_of_copying_the_last_answer() {
-    // `handle_key_event` treats Ctrl+C as the global quit before the assistant
-    // ever sees it, so the assistant's own Ctrl+C copy chord cannot fire.
+async fn ctrl_c_in_the_assistant_copies_the_last_answer() {
     let (mut app, _rx) = common::app_with(FAKE_CONTEXT, "default").await;
     app.active_view = ActiveView::Assistant;
     app.assistant_state
         .add_assistant_message("the cluster is fine".into());
 
     app.handle_key_event(common::ctrl('c')).await;
-    assert!(!app.is_running, "Ctrl+C exits the TUI");
-    assert_eq!(toast(&app), "", "nothing is copied on the way out");
+    assert!(app.is_running, "Ctrl+C copies without exiting");
+    assert_eq!(toast(&app), "✓ Copied assistant answer to clipboard");
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -885,6 +885,14 @@ async fn namespace_picker_filters_navigates_and_switches() {
     assert_eq!(sel(&app).0, 0);
     press(&mut app, ctrl('k')).await;
     assert_eq!(sel(&app).0, 2);
+    press(&mut app, key(KeyCode::Home)).await;
+    assert_eq!(sel(&app).0, 0, "Home moves to the start");
+    press(&mut app, ctrl('g')).await;
+    assert_eq!(sel(&app).0, 2, "Ctrl+g moves to the end");
+    press(&mut app, key(KeyCode::Home)).await;
+    assert_eq!(sel(&app).0, 0);
+    press(&mut app, key(KeyCode::End)).await;
+    assert_eq!(sel(&app).0, 2, "End moves to the end");
     press(&mut app, key(KeyCode::Null)).await;
     assert_eq!(sel(&app).0, 2, "unknown keys leave the picker alone");
 

--- a/apps/tui/tests/app_state_tests.rs
+++ b/apps/tui/tests/app_state_tests.rs
@@ -380,15 +380,9 @@ fn alt(c: char) -> KeyEvent {
     KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT)
 }
 
-/// Type into the assistant composer. A leading `c` on an empty input is the
-/// "copy the last answer" shortcut rather than a character, so the first
-/// character is seeded directly when it would be swallowed.
+/// Type into the assistant composer.
 async fn compose(app: &mut App, text: &str) {
-    for (i, c) in text.chars().enumerate() {
-        if i == 0 && c == 'c' && app.assistant_state.input.is_empty() {
-            app.assistant_state.input.push('c');
-            continue;
-        }
+    for c in text.chars() {
         app.handle_key_event(common::ch(c)).await;
     }
 }
@@ -1303,7 +1297,7 @@ async fn mouse_in_the_assistant_toggles_tool_chips_and_selects_text() {
         "assistant keeps its own selection"
     );
 
-    app.handle_key_event(common::ch('c')).await;
+    app.handle_key_event(common::ctrl('c')).await;
     assert_eq!(toast(&app), "✓ Copied selection to clipboard");
 
     // Re-select, then click outside the viewport to clear.
@@ -1840,18 +1834,38 @@ async fn assistant_editing_keys_shape_the_input_buffer() {
     app.handle_key_event(common::ch('c')).await;
     assert_eq!(app.assistant_state.input, "cc");
 
-    // 'c' on an empty input copies the last assistant answer.
+    // 'c' on an empty input types 'c' even when an assistant message exists (no accidental copy).
     app.assistant_state.input.clear();
     app.assistant_state
         .add_assistant_message("the answer".into());
     app.handle_key_event(common::ch('c')).await;
+    assert_eq!(app.assistant_state.input, "c");
+
+    // Ctrl+c copies the last assistant answer.
+    app.assistant_state.input.clear();
+    app.handle_key_event(common::ctrl('c')).await;
     assert_eq!(toast(&app), "✓ Copied assistant answer to clipboard");
     assert_eq!(app.assistant_state.input, "");
 
-    // ... but with text in the buffer it is still typing.
+    // Typing and cursor navigation (Left, Right, Home, End, Delete)
     common::type_str(&mut app, "ab").await;
     app.handle_key_event(common::ch('c')).await;
     assert_eq!(app.assistant_state.input, "abc");
+    // Left arrow moves cursor before 'c'
+    app.handle_key_event(common::key(KeyCode::Left)).await;
+    app.handle_key_event(common::ch('X')).await;
+    assert_eq!(app.assistant_state.input, "abXc");
+    // Home moves to start
+    app.handle_key_event(common::key(KeyCode::Home)).await;
+    app.handle_key_event(common::ch('Z')).await;
+    assert_eq!(app.assistant_state.input, "ZabXc");
+    // Delete removes 'a' (the character at cursor)
+    app.handle_key_event(common::key(KeyCode::Delete)).await;
+    assert_eq!(app.assistant_state.input, "ZbXc");
+    // End moves to end
+    app.handle_key_event(common::key(KeyCode::End)).await;
+    app.handle_key_event(common::ch('!')).await;
+    assert_eq!(app.assistant_state.input, "ZbXc!");
 
     // Ctrl+t toggles the tool chip expansion, Ctrl+l clears the conversation.
     let expanded = app.assistant_state.expand_tools;

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -583,6 +583,20 @@ fn the_namespace_picker_filter_narrows_the_list_and_reindexes_the_selection() {
     assert!(!text.contains("payments"), "{text}");
 }
 
+#[test]
+fn the_namespace_picker_windows_when_selected_at_the_end_of_a_long_list() {
+    let namespaces: Vec<String> = (1..=30).map(|i| format!("ns-{:02}", i)).collect();
+    let modal = Modal::NamespacePicker {
+        namespaces,
+        current_namespace: "ns-01".into(),
+        selected_idx: 29, // last item: ns-30
+        filter: String::new(),
+    };
+    let text = modal_text(100, 20, &modal);
+    assert!(text.contains("▶ ns-30"), "selected item at the end is visible: {text}");
+    assert!(!text.contains("ns-01"), "first item scrolled out of view: {text}");
+}
+
 // ───────────────────────── dialogs: ActionPalette ─────────────────────────
 
 #[test]

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -597,6 +597,20 @@ fn the_namespace_picker_windows_when_selected_at_the_end_of_a_long_list() {
     assert!(!text.contains("ns-01"), "first item scrolled out of view: {text}");
 }
 
+#[test]
+fn the_namespace_picker_renders_selection_marker_even_when_selected_idx_is_out_of_bounds() {
+    let namespaces = vec!["alpha".into(), "beta".into(), "gamma".into()];
+    let modal = Modal::NamespacePicker {
+        namespaces,
+        current_namespace: "alpha".into(),
+        selected_idx: 99, // out of bounds
+        filter: String::new(),
+    };
+    let text = modal_text(80, 15, &modal);
+    // Clamped selection is index 2 ("gamma"), which must be marked with ▶
+    assert!(text.contains("▶ gamma"), "clamped row is marked selected: {text}");
+}
+
 // ───────────────────────── dialogs: ActionPalette ─────────────────────────
 
 #[test]

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -1142,13 +1142,13 @@ fn the_assistant_title_names_the_provider_model_and_key_hints() {
     let text = assistant_text(200, 30, &state);
     let settings = AiSettings::default();
     let model = settings.get_model(settings.default_provider);
-    assert!(text.contains(&format!(" SRElens AI Assistant[Anthropic (Claude) - {model}] [<c> Copy, <Ctrl+t> Tools, <Ctrl+e> Save, <Ctrl+l> Clear, <Ctrl+s> Settings, <Esc> Back] ")), "{text}");
+    assert!(text.contains(&format!(" SRElens AI Assistant[Anthropic (Claude) - {model}] [<Ctrl+c> Copy, <Ctrl+t> Tools, <Ctrl+e> Save, <Ctrl+l> Clear, <Ctrl+s> Settings, <Esc> Back] ")), "{text}");
     assert!(text.contains("SRElens [10:00:00]:"), "{text}");
     assert!(
         text.contains("Hello! I am your SRElens AI Assistant."),
         "{text}"
     );
-    assert!(text.contains(" Ask Assistant (Type '/' for SRE Playbooks, ↑/↓ History, <c> Copy, <Ctrl+s> Settings) "), "{text}");
+    assert!(text.contains(" Ask Assistant (Type '/' for SRE Playbooks, ↑/↓ History, <Ctrl+c> Copy, <Ctrl+s> Settings) "), "{text}");
 }
 
 #[test]
@@ -1178,7 +1178,7 @@ fn the_assistant_title_reflects_context_caveman_tokens_selection_and_folded_tool
         "{text}"
     );
     assert!(
-        text.contains("[⚡  1,234 tokens, <c> Copy Selection, <Ctrl+t> Fold Tools, <Ctrl+e> Save"),
+        text.contains("[⚡  1,234 tokens, <Ctrl+c> Copy Selection, <Ctrl+t> Fold Tools, <Ctrl+e> Save"),
         "{text}"
     );
 }
@@ -1611,7 +1611,7 @@ fn a_selection_spanning_rows_is_highlighted_and_extracted_from_the_rendered_rows
         Some("[10:00:00]:\nhello")
     );
     let text = assistant_text(160, 30, &state);
-    assert!(text.contains("<c> Copy Selection"), "{text}");
+    assert!(text.contains("<Ctrl+c> Copy Selection"), "{text}");
     assert!(
         text.contains("hello world"),
         "highlighting keeps the text intact: {text}"

--- a/apps/tui/tests/tui_tests.rs
+++ b/apps/tui/tests/tui_tests.rs
@@ -1597,8 +1597,8 @@ mod tests {
 
         assert_eq!(app.assistant_state.get_selected_text().as_deref(), Some("OutOfMemory"));
 
-        // Pressing 'c' copies selection and toasts
-        app.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)).await;
+        // Pressing Ctrl+c copies selection and toasts
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)).await;
         assert!(app.toast.is_some());
         assert!(app.toast.as_ref().unwrap().0.contains("Copied selection"));
 


### PR DESCRIPTION
## What changed and why

This PR delivers two UX improvements in the SRElens TUI:

1. **Assistant Input Cursor Navigation & Copy Ergonomics**:
   - **Horizontal Cursor Navigation**: Added Left/Right character navigation, Alt+Left/Alt+Right (and Ctrl+Left/Ctrl+Right) word hopping, and Home/End / Ctrl+a line jumps within the prompt composer.
   - **In-place Editing & Deletion**: Added support for Delete (forward delete) and Backspace relative to the cursor position, plus Alt+Backspace for word deletion.
   - **Non-blocking Leading 'c'**: Moved the assistant answer copy shortcut to `Ctrl+c` (with toast notification) so questions starting with 'c' (such as `"check pod"`, `"crashloop"`, `"can you..."`) can be typed freely instead of accidentally triggering clipboard copy.
   - **History Seeding**: When prompt history is empty, pressing Up seeds the history from previous user messages in the active chat session.

2. **Modal Picker `Ctrl+g` Jump to End & Windowed List Viewport**:
   - **End-of-List Jump**: Added `Ctrl+g` and `End` across modal pickers (`NamespacePicker`, `ContextPicker`, `ActionPalette`, `ContainerPicker`, `ReasonRail`, `ThemePicker`) to jump directly to the bottom of the list without typing into the search filter. Also added `Home` and `PageUp`/`PageDown`.
   - **Windowed Scrolling**: Fixed list clipping in modal dialogs (`dialogs.rs`) where selecting an item at the bottom of a long list (e.g. 30+ namespaces) rendered off-screen past the dialog border. Viewports are now dynamically windowed so the selected row is kept in view.

## Validation

- Tested with `cargo test -p srelens-tui` (all 84 views panels tests, 56 views inspect tests, chrome tests, app state tests, and input tests passing).
- Added test coverage in:
  - `apps/tui/tests/chrome_tests.rs`: `the_namespace_picker_windows_when_selected_at_the_end_of_a_long_list`
  - `apps/tui/tests/app_input_tests.rs`: `namespace_picker_filters_navigates_and_switches` (asserting `Home`, `Ctrl+g`, and `End`)
  - `apps/tui/tests/app_state_tests.rs`: `assistant_editing_keys_shape_the_input_buffer` (asserting typing with leading 'c', `Ctrl+c` copy, and cursor movement/deletion)
  - `apps/tui/src/views/assistant_view.rs`: `test_assistant_cursor_navigation_and_editing`, `test_assistant_history_seeding_from_messages`