### PR TITLE
fix(release): homebrew and aur run after a stable publish again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1290,7 +1290,13 @@ jobs:
   # archives are attached.
   homebrew:
     needs: [version, tui-publish, publish-release]
-    if: ${{ github.ref_name == 'main' && needs.publish-release.result == 'success' && needs.version.outputs.release == 'true' }}
+    # `!cancelled()` first, and it is load-bearing. Without a status function
+    # GitHub applies an implicit `success()`, which is false whenever ANY job in
+    # the transitive `needs` chain was skipped -- and release-notes, upstream of
+    # updater-manifest and publish-release, is skipped on main by design. v0.11.0
+    # published and neither the tap nor AUR heard about it. The conditions that
+    # follow are the ones that actually decide.
+    if: ${{ !cancelled() && github.ref_name == 'main' && needs.publish-release.result == 'success' && needs.version.outputs.release == 'true' }}
     permissions:
       contents: read
     uses: ./.github/workflows/homebrew-publish.yml
@@ -1302,7 +1308,13 @@ jobs:
     # Also needs publish-release: updpkgsums fetches the release assets over
     # plain HTTPS, which only works once the release is out of draft.
     needs: [version, build, publish-release]
-    if: ${{ github.ref_name == 'main' && needs.publish-release.result == 'success' && needs.version.outputs.release == 'true' }}
+    # `!cancelled()` first, and it is load-bearing. Without a status function
+    # GitHub applies an implicit `success()`, which is false whenever ANY job in
+    # the transitive `needs` chain was skipped -- and release-notes, upstream of
+    # updater-manifest and publish-release, is skipped on main by design. v0.11.0
+    # published and neither the tap nor AUR heard about it. The conditions that
+    # follow are the ones that actually decide.
+    if: ${{ !cancelled() && github.ref_name == 'main' && needs.publish-release.result == 'success' && needs.version.outputs.release == 'true' }}
     # The called workflow declares `contents: read` for itself; the AUR push
     # authenticates with its own SSH deploy key, not GITHUB_TOKEN. Repeated
     # here because a reusable workflow cannot be granted more than its caller


### PR DESCRIPTION
Closes #484.

v0.11.0 published with all 43 assets and `publish-release` green, but `homebrew` and `aur` were skipped, so the tap and AUR stayed at 0.10.0. v0.10.0 the day before ran both.

**Cause.** Their `if` had no status function, so GitHub applied the implicit `success()`, which is false whenever *any* job in the transitive `needs` chain was skipped. Since #470, `release-notes` (skipped on main by design) sits upstream of `updater-manifest` → `publish-release`. `publish-release` survives that with `always()`; the two jobs behind it did not, and their own conditions were never evaluated.

**Fix.** `!cancelled() &&` now leads both conditions, with a comment saying why it is load-bearing. The checks that follow (`main`, `publish-release` succeeded, `release == 'true'`) keep deciding. `!cancelled()` rather than `always()` so a cancelled run does not publish.

**0.11.0 itself** was pushed to the tap and AUR by dispatching `homebrew-publish.yml` and `aur-publish.yml` for `0.11.0` on main (runs 34365760684 and 34365764281).

Note for #462: the `winget` job it adds sits behind `publish-release` too and will need the same `!cancelled()`.