### PR TITLE
feat(ui): add app home and default cluster overview

### DIFF
--- a/apps/desktop/src/components/AssistantSettingsSection.test.tsx
+++ b/apps/desktop/src/components/AssistantSettingsSection.test.tsx
@@ -56,10 +56,13 @@ describe("AssistantSettingsSection", () => {
   });
 
   it("expands only the default provider initially, and one row at a time", async () => {
+    // Provider labels render before the asynchronous settings response.
+    const settings = { defaultProvider: "anthropic", models: {}, baseUrls: {}, maxTokens: 4096 };
+    llm.llmGetSettings.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve(settings), 30)));
     render(<AssistantSettingsSection />);
     await screen.findByText("Anthropic");
     // Only the default (Anthropic) row is open → exactly one key input.
-    expect(screen.getAllByPlaceholderText(/paste api key/i)).toHaveLength(1);
+    expect(await screen.findAllByPlaceholderText(/paste api key/i)).toHaveLength(1);
 
     // Opening Gemini collapses Anthropic — still exactly one key input.
     fireEvent.click(screen.getByRole("button", { name: /google gemini/i }));
@@ -95,7 +98,7 @@ describe("AssistantSettingsSection", () => {
     await screen.findByText("Anthropic");
 
     // The default (Anthropic) row is the expanded one.
-    fireEvent.change(screen.getByPlaceholderText(/paste api key/i), { target: { value: "sk-ant-123" } });
+    fireEvent.change(await screen.findByPlaceholderText(/paste api key/i), { target: { value: "sk-ant-123" } });
     fireEvent.click(screen.getByRole("button", { name: /save key/i }));
 
     await waitFor(() => expect(llm.llmSetKey).toHaveBeenCalledWith("anthropic", "sk-ant-123"));
@@ -109,13 +112,13 @@ describe("AssistantSettingsSection", () => {
     render(<AssistantSettingsSection />);
     await screen.findByText("Anthropic");
 
-    fireEvent.click(screen.getByRole("button", { name: /fetch models/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /fetch models/i }));
     expect(await screen.findByText("Claude Opus 4.8")).toBeTruthy();
   });
 
   it("picking a radio changes the default provider saved with settings", async () => {
     render(<AssistantSettingsSection />);
-    await screen.findByText("Anthropic");
+    await screen.findByRole("button", { name: /anthropic/i, expanded: true });
     fireEvent.click(screen.getByRole("radio", { name: /use google gemini as the default/i }));
     fireEvent.click(screen.getByRole("button", { name: /save settings/i }));
     await waitFor(() =>

--- a/apps/desktop/src/design.test.ts
+++ b/apps/desktop/src/design.test.ts
@@ -56,6 +56,7 @@ describe("the list of ported screens", () => {
     // so the two cannot disagree about what has been ported. A screen is added
     // here in the PR that ports it.
     expect(PORTED_SCREENS.map((s) => s.route)).toEqual([
+      "/",
       "/applog",
       "/notes",
       "/agent",
@@ -77,6 +78,7 @@ describe("the list of ported screens", () => {
 
   it("gives every screen a name to show, since the route is not user-facing", () => {
     expect(PORTED_SCREENS.map((s) => s.name)).toEqual([
+      "Home",
       "Application log",
       "Release notes",
       "Agent",

--- a/apps/desktop/src/design.ts
+++ b/apps/desktop/src/design.ts
@@ -291,6 +291,7 @@ export function toggleNextDesignTheme(): void {
  * so they cannot drift. A screen is added here in the PR that ports it.
  */
 export const PORTED_SCREENS: ReadonlyArray<{ route: string; name: string }> = [
+  { route: "/", name: "Home" },
   { route: "/applog", name: "Application log" },
   { route: "/notes", name: "Release notes" },
   // The full view of the one agent run this window holds — the transcript,

--- a/packages/ui-next/src/index.test.tsx
+++ b/packages/ui-next/src/index.test.tsx
@@ -46,15 +46,15 @@ describe("NextApp", () => {
   it("renders the window, with a tab strip and a home tab", async () => {
     render(<NextApp onExit={() => null} />);
     expect(await screen.findByRole("tablist")).toBeDefined();
-    expect(screen.getByRole("tab", { name: /Control room/ })).toBeDefined();
+    expect(screen.getByRole("tab", { name: /Home/ })).toBeDefined();
   });
 
   it("the Placeholder's way back to classic is the onExit the app supplied", async () => {
-    // Settings does not exist in this tree yet, so the Placeholder's button is
-    // the only exit — it has to be wired to the app's switch, not to nothing.
+    // Unported routes still offer the host's way back to classic.
     const onExit = vi.fn(() => null);
     render(<NextApp onExit={onExit} />);
     await screen.findByRole("tablist");
+    act(() => openTab("/incidents"));
     await userEvent.click(screen.getByRole("button", { name: /open in classic/i }));
     expect(onExit).toHaveBeenCalledTimes(1);
   });
@@ -64,6 +64,7 @@ describe("NextApp", () => {
     // be invisible and the button would look inert. (#314 review)
     render(<NextApp onExit={() => "storage refused the preference"} />);
     await screen.findByRole("tablist");
+    act(() => openTab("/incidents"));
     await userEvent.click(screen.getByRole("button", { name: /open in classic/i }));
     expect(screen.getByRole("alert").textContent).toContain("storage refused");
   });
@@ -76,6 +77,7 @@ describe("NextApp", () => {
     // structure that prevents it is what gets pinned here.
     render(<NextApp onExit={() => "storage refused the preference"} />);
     await screen.findByRole("tablist");
+    act(() => openTab("/incidents"));
     await userEvent.click(screen.getByRole("button", { name: /open in classic/i }));
 
     const alert = screen.getByRole("alert");
@@ -100,6 +102,7 @@ describe("NextApp", () => {
     // on passing after the way in was deleted.
     render(<NextApp onExit={() => null} />);
     await screen.findByRole("tablist");
+    act(() => openTab("/incidents"));
     await userEvent.click(screen.getByRole("button", { name: /component gallery/i }));
     expect(await screen.findByRole("heading", { name: /design system/i })).toBeDefined();
     // The gallery replaces the window rather than rendering inside it. Asked
@@ -127,7 +130,7 @@ describe("NextApp", () => {
     window.dispatchEvent(new HashChangeEvent("hashchange"));
     await screen.findByRole("tablist");
     expect(screen.getAllByRole("tab").map((t) => t.textContent)).toEqual([
-      expect.stringContaining("Control room"),
+      expect.stringContaining("Home"),
       expect.stringContaining("Pods"),
     ]);
     expect(currentWorkspace().tabs.map((t) => t.id)).toEqual(before);
@@ -170,7 +173,7 @@ describe("NextApp", () => {
     await screen.findByRole("heading", { name: /design system/i });
     expect(windowHost.hidden).toBe(true);
     expect(within(windowHost).queryByRole("tablist", { hidden: true })).toBeNull();
-    expect(windowHost.textContent).toContain("is not in the new design yet");
+    expect(windowHost.textContent).toContain("Your Kubernetes workspace");
 
     window.location.hash = "";
     window.dispatchEvent(new HashChangeEvent("hashchange"));
@@ -188,7 +191,8 @@ describe("NextApp", () => {
     });
     render(<NextApp onExit={onExit} />);
     await screen.findByRole("tablist");
+    act(() => openTab("/incidents"));
     await userEvent.click(screen.getByRole("button", { name: /open in classic/i }));
-    expect(onExit).toHaveBeenCalledWith("/", "prod");
+    expect(onExit).toHaveBeenCalledWith("/incidents", "prod");
   });
 });

--- a/packages/ui-next/src/index.test.tsx
+++ b/packages/ui-next/src/index.test.tsx
@@ -173,7 +173,7 @@ describe("NextApp", () => {
     await screen.findByRole("heading", { name: /design system/i });
     expect(windowHost.hidden).toBe(true);
     expect(within(windowHost).queryByRole("tablist", { hidden: true })).toBeNull();
-    expect(windowHost.textContent).toContain("Your Kubernetes workspace");
+    expect(windowHost.textContent).toContain("Choose a cluster to open its overview.");
 
     window.location.hash = "";
     window.dispatchEvent(new HashChangeEvent("hashchange"));

--- a/packages/ui-next/src/lib/openCluster.ts
+++ b/packages/ui-next/src/lib/openCluster.ts
@@ -1,5 +1,22 @@
 import type { ClusterContext } from "@srelens/core";
-import { currentWorkspace, openTab, setActiveCluster, setWorkspaceClusters } from "./tabsStore";
+import { currentWorkspace, openTab, setActiveCluster, setClusterPaused, setWorkspaceClusters } from "./tabsStore";
+import { invalidateProbe, probeCluster } from "./probe";
+
+/** Pause one workspace's reading and invalidate any observation already out. */
+export function pauseCluster(workspaceId: string, clusterId: string): void {
+  setClusterPaused(workspaceId, clusterId, true);
+  invalidateProbe(workspaceId, clusterId);
+}
+
+/** Resume a paused cluster and begin its explicit reachability read. */
+export function reconnectCluster(context: ClusterContext): void {
+  const workspace = currentWorkspace();
+  const wasPaused = workspace.pausedClusters?.includes(context.stableId) === true;
+  setClusterPaused(workspace.id, context.stableId, false);
+  // Opening a cluster that is already connected joins its reading; only a
+  // reconnect must bypass the observation invalidated by Disconnect.
+  void probeCluster(context, undefined, undefined, { workspaceId: workspace.id, fresh: wasPaused });
+}
 
 /**
  * Open a cluster: put it in this workspace, focus it, and open its overview.
@@ -28,6 +45,7 @@ export function openCluster(context: ClusterContext): void {
   if (!workspace.clusters.includes(id)) {
     setWorkspaceClusters(workspace.id, [...workspace.clusters, id]);
   }
+  reconnectCluster(context);
   // By NAME as well as by stableId, and the name is not spare: the workspace
   // stores the id (#265), while the strip's labels — and core's `list*` and
   // `watchResource` — are all in terms of the context name. `setActiveCluster`

--- a/packages/ui-next/src/lib/pausedContext.ts
+++ b/packages/ui-next/src/lib/pausedContext.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { getContexts, useContexts } from "./clusters";
+import { isClusterPaused, useTabs } from "./tabsStore";
+
+/** Capability calls use context names; pause preferences use stable ids. */
+export function isContextPaused(name: string): boolean {
+  return getContexts().some(context => context.name === name && isClusterPaused(context.stableId));
+}
+
+/** Hide immediately, then forget a dialog whose captured target was paused. */
+export function useDismissOnPause(name: string | undefined, dismiss: () => void): boolean {
+  const contexts = useContexts();
+  const { workspace } = useTabs();
+  const paused = contexts.some(context => context.name === name && workspace.pausedClusters?.includes(context.stableId));
+  useEffect(() => {
+    if (paused) dismiss();
+  }, [paused, dismiss]);
+  return paused;
+}

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { probeCluster, getInfo, useInfo, useInfos, getProbe, useProbe, useProbes, resetProbes } from "./probe";
+import { invalidateProbe, probeCluster, getInfo, useInfo, useInfos, getProbe, useProbe, useProbes, resetProbes } from "./probe";
 import { getView, resetView } from "./workspace";
+import { defaultState } from "./tabs";
+import { currentWorkspace, setClusterPaused, setState, switchWorkspace } from "./tabsStore";
 
 const ctx = {
   name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false,
   sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
 };
 
-beforeEach(() => { resetView(); resetProbes(); });
+beforeEach(() => { resetView(); resetProbes(); setState(defaultState([ctx])); });
 
 describe("probeCluster", () => {
   it("marks connecting, then connected with the version", async () => {
@@ -176,6 +178,100 @@ describe("useProbes", () => {
  * whatever order they finish, and the loser is not recoverable from here.
  */
 describe("one read per cluster", () => {
+  it("discards a disconnected read and reconnects with a fresh one", async () => {
+    const settles: ((value: unknown) => void)[] = [];
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settles.push(resolve as never); }));
+    const workspaceId = currentWorkspace().id;
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId });
+    setClusterPaused(workspaceId, ctx.stableId, true);
+    invalidateProbe(workspaceId, ctx.stableId);
+    setClusterPaused(workspaceId, ctx.stableId, false);
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId, fresh: true });
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    settles[0]({ context: ctx.name, reachable: true });
+    await first;
+    expect(getProbe(ctx.stableId).state).toBe("unread");
+
+    settles[1]({ context: ctx.name, reachable: true });
+    await second;
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
+  it("keeps a probe owned by its starting workspace when another workspace pauses", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const pausedWorkspace = "paused";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: pausedWorkspace, name: "Paused", pausedClusters: [ctx.stableId] });
+    setState(state);
+    const reading = probeCluster(ctx, vi.fn().mockResolvedValue({ context: ctx.name, reachable: true }) as never, () => 0, { workspaceId: firstWorkspace });
+    switchWorkspace(pausedWorkspace);
+    await reading;
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
+  it("does not join a read invalidated by another workspace", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const secondWorkspace = "second";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: secondWorkspace, name: "Second", pausedClusters: [] });
+    setState(state);
+    const settles: ((value: unknown) => void)[] = [];
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settles.push(resolve as never); }));
+
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId: firstWorkspace });
+    setClusterPaused(firstWorkspace, ctx.stableId, true);
+    invalidateProbe(firstWorkspace, ctx.stableId);
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId: secondWorkspace });
+
+    expect(second).not.toBe(first);
+    expect(connect).toHaveBeenCalledTimes(2);
+    settles[0]({ context: ctx.name, reachable: true });
+    await first;
+    expect(getProbe(ctx.stableId).state).toBe("unread");
+    settles[1]({ context: ctx.name, reachable: true });
+    await second;
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
+  it("joins a valid cross-workspace read even when reconnect asks fresh", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const secondWorkspace = "second";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: secondWorkspace, name: "Second", pausedClusters: [] });
+    setState(state);
+    let settle!: (value: unknown) => void;
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settle = resolve as never; }));
+
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId: firstWorkspace });
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId: secondWorkspace, fresh: true });
+
+    expect(second).toBe(first);
+    expect(connect).toHaveBeenCalledTimes(1);
+    settle({ context: ctx.name, reachable: true });
+    await second;
+  });
+
+  it("keeps a joined read when its initiating workspace disconnects", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const secondWorkspace = "second";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: secondWorkspace, name: "Second", pausedClusters: [] });
+    setState(state);
+    let settle!: (value: unknown) => void;
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settle = resolve as never; }));
+
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId: firstWorkspace });
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId: secondWorkspace });
+    setClusterPaused(firstWorkspace, ctx.stableId, true);
+    invalidateProbe(firstWorkspace, ctx.stableId);
+    settle({ context: ctx.name, reachable: true });
+    await second;
+
+    expect(second).toBe(first);
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
   it("joins the read already out rather than starting a second", async () => {
     let settle!: (v: unknown) => void;
     const connect = vi.fn(() => new Promise<never>((r) => { settle = r as never; }));

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -13,6 +13,20 @@ const ctx = {
 beforeEach(() => { resetView(); resetProbes(); setState(defaultState([ctx])); });
 
 describe("probeCluster", () => {
+  it.each([false, true])("restores the last observation when the only participant disconnects (previous: %s)", async (previous) => {
+    if (previous) await probeCluster(ctx, vi.fn().mockResolvedValue({ context: ctx.name, reachable: true }));
+    const before = getView().links.prod;
+    let settle!: (value: never) => void;
+    const pending = probeCluster(ctx, () => new Promise(resolve => { settle = resolve; }));
+    const workspace = currentWorkspace().id;
+    setClusterPaused(workspace, ctx.stableId, true);
+    invalidateProbe(workspace, ctx.stableId);
+    expect(getView().links.prod).toEqual(before);
+    settle({ context: ctx.name, reachable: true } as never);
+    await pending;
+    expect(getView().links.prod).toEqual(before);
+  });
+
   it("marks connecting, then connected with the version", async () => {
     let resolve!: (v: unknown) => void;
     const connect = vi.fn(() => new Promise<never>((r) => { resolve = r as never; }));
@@ -192,6 +206,7 @@ describe("one read per cluster", () => {
     settles[0]({ context: ctx.name, reachable: true });
     await first;
     expect(getProbe(ctx.stableId).state).toBe("unread");
+    expect(getView().links.prod.state).toBe("connecting");
 
     settles[1]({ context: ctx.name, reachable: true });
     await second;

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from "react";
 import { connectCluster, describeError, type ClusterContext, type ClusterInfo } from "@srelens/core";
 import { setLink } from "./workspace";
+import { currentWorkspace, isClusterPaused } from "./tabsStore";
 
 let infos: Record<string, ClusterInfo> = {};
 
@@ -11,7 +12,7 @@ let infos: Record<string, ClusterInfo> = {};
  * `infos`, so `getInfo`/`useInfo`/`useInfos` and their callers — the rail, the
  * status strip, Overview, Toolbox — stay untouched.
  */
-export type ProbeState = "unread" | "reachable" | "unreachable";
+export type ProbeState = "unread" | "reachable" | "unreachable" | "paused";
 
 export interface Probe {
   state: ProbeState;
@@ -47,7 +48,7 @@ const emit = () => { for (const l of listeners) l(); };
 
 export function getInfo(stableId: string): ClusterInfo | undefined { return infos[stableId]; }
 export function getProbe(stableId: string): Probe { return probes[stableId] ?? UNREAD; }
-export function resetProbes(): void { infos = {}; probes = {}; reading.clear(); emit(); }
+export function resetProbes(): void { infos = {}; probes = {}; reading.clear(); pauseGenerations.clear(); emit(); }
 function subscribe(l: () => void) { listeners.add(l); return () => listeners.delete(l); }
 export function useProbe(stableId: string | null): Probe {
   return useSyncExternalStore(subscribe, () => (stableId ? (probes[stableId] ?? UNREAD) : UNREAD), () => UNREAD);
@@ -108,7 +109,34 @@ export function useInfos(): Record<string, ClusterInfo> {
  * {@link resetProbes} clears this along with the answers, so a test that leaves
  * a read hanging does not leave the next one joined to it.
  */
-const reading = new Map<string, Promise<void>>();
+interface Reading {
+  promise: Promise<void>;
+  /** Every workspace that is entitled to use this result. */
+  participants: Map<string, number>;
+}
+
+const reading = new Map<string, Reading>();
+const pauseGenerations = new Map<string, number>();
+
+function pauseKey(workspaceId: string, clusterId: string) {
+  return `${workspaceId}\u0000${clusterId}`;
+}
+
+function participantIsValid(clusterId: string, workspaceId: string, generation: number): boolean {
+  return !isClusterPaused(clusterId, workspaceId) &&
+    generation === (pauseGenerations.get(pauseKey(workspaceId, clusterId)) ?? 0);
+}
+
+/** Invalidate a workspace's in-flight reading when its reader disconnects. */
+export function invalidateProbe(workspaceId: string, clusterId: string): void {
+  const key = pauseKey(workspaceId, clusterId);
+  pauseGenerations.set(key, (pauseGenerations.get(key) ?? 0) + 1);
+}
+
+interface ProbeOptions {
+  workspaceId?: string;
+  fresh?: boolean;
+}
 
 /**
  * Read one cluster: connect to it, time the round trip, and record what came
@@ -136,19 +164,37 @@ export function probeCluster(
   ctx: ClusterContext,
   connect: typeof connectCluster = connectCluster,
   now: () => number = Date.now,
+  options: ProbeOptions = {},
 ): Promise<void> {
+  const workspaceId = options.workspaceId ?? currentWorkspace().id;
+  if (isClusterPaused(ctx.stableId, workspaceId)) return Promise.resolve();
+  const generation = pauseGenerations.get(pauseKey(workspaceId, ctx.stableId)) ?? 0;
   const running = reading.get(ctx.stableId);
-  if (running) return running;
-  const run = read(ctx, connect, now).finally(() => {
+  // A pause invalidates only its own workspace's observation. Another
+  // workspace may still use a simultaneous connection, but it must not join a
+  // read whose owner has since invalidated it: that read will deliberately
+  // discard its result, leaving the joining workspace stuck on Connecting.
+  const runningIsValid = running &&
+    [...running.participants].some(([id, participantGeneration]) =>
+      participantIsValid(ctx.stableId, id, participantGeneration));
+  // A reconnect only needs a fresh read when the prior one was invalidated.
+  // A valid read owned by another workspace is safe to share, and avoids two
+  // accepted writes racing each other.
+  if (runningIsValid) {
+    running.participants.set(workspaceId, generation);
+    return running.promise;
+  }
+  const participants = new Map([[workspaceId, generation]]);
+  const run = read(ctx, connect, now, participants).finally(() => {
     // **By identity, not by key.** A read that {@link resetProbes} forgot
     // still lands, and deleting by key alone would clear whatever is under
     // that key by then — which is the CURRENT read. That silently reopens the
     // guard and the next caller starts a third concurrent read of one cluster,
     // the exact case this map exists to prevent. Only the entry this read
     // installed is its to remove.
-    if (reading.get(ctx.stableId) === run) reading.delete(ctx.stableId);
+    if (reading.get(ctx.stableId)?.promise === run) reading.delete(ctx.stableId);
   });
-  reading.set(ctx.stableId, run);
+  reading.set(ctx.stableId, { promise: run, participants });
   return run;
 }
 
@@ -157,6 +203,7 @@ async function read(
   ctx: ClusterContext,
   connect: typeof connectCluster,
   now: () => number,
+  participants: ReadonlyMap<string, number>,
 ): Promise<void> {
   setLink(ctx.stableId, "connecting");
   const started = now();
@@ -167,6 +214,9 @@ async function read(
     info = { context: ctx.name, reachable: false, error: String(e) };
   }
   const elapsedMs = now() - started;
+  // Disconnect may have been picked while the probe was in flight. Its result
+  // is an observation from before that choice, so never revive a paused row.
+  if (![...participants].some(([workspaceId, generation]) => participantIsValid(ctx.stableId, workspaceId, generation))) return;
   infos = { ...infos, [ctx.stableId]: info };
   probes = { ...probes, [ctx.stableId]: deriveProbe(info, elapsedMs) };
   emit();

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -131,6 +131,16 @@ function participantIsValid(clusterId: string, workspaceId: string, generation: 
 export function invalidateProbe(workspaceId: string, clusterId: string): void {
   const key = pauseKey(workspaceId, clusterId);
   pauseGenerations.set(key, (pauseGenerations.get(key) ?? 0) + 1);
+  const running = reading.get(clusterId);
+  if (running && ![...running.participants].some(([id, generation]) => participantIsValid(clusterId, id, generation))) {
+    restoreObservedLink(clusterId);
+  }
+}
+
+/** An abandoned request is no longer connecting; retain only accepted facts. */
+function restoreObservedLink(clusterId: string): void {
+  const info = infos[clusterId];
+  setLink(clusterId, !info ? undefined : info.reachable ? "connected" : info.error ? "error" : "disconnected", info?.error ?? undefined);
 }
 
 interface ProbeOptions {
@@ -216,7 +226,11 @@ async function read(
   const elapsedMs = now() - started;
   // Disconnect may have been picked while the probe was in flight. Its result
   // is an observation from before that choice, so never revive a paused row.
-  if (![...participants].some(([workspaceId, generation]) => participantIsValid(ctx.stableId, workspaceId, generation))) return;
+  if (![...participants].some(([workspaceId, generation]) => participantIsValid(ctx.stableId, workspaceId, generation))) {
+    // A newer read owns the link once this one has been replaced.
+    if (reading.get(ctx.stableId)?.participants === participants) restoreObservedLink(ctx.stableId);
+    return;
+  }
   infos = { ...infos, [ctx.stableId]: info };
   probes = { ...probes, [ctx.stableId]: deriveProbe(info, elapsedMs) };
   emit();

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -47,7 +47,7 @@ suite("isBuiltInKind", () => {
 suite("describe", () => {
   it("names the home route and pins it", () => {
     const info = describe("/", "prod-eu");
-    expect(info).toMatchObject({ route: "/", title: "Control room", kind: "control", pinned: true });
+    expect(info).toMatchObject({ route: "/", title: "Home", kind: "control", pinned: true });
   });
 
   it("uses the real cluster name as the sub for cluster-scoped routes", () => {
@@ -57,7 +57,7 @@ suite("describe", () => {
   });
 
   it("gives app-scoped routes no sub at all", () => {
-    for (const route of ["/applog", "/notes", "/settings", "/connections", "/connect", "/toolbox"]) {
+    for (const route of ["/", "/applog", "/notes", "/settings", "/connections", "/connect", "/toolbox"]) {
       expect(describe(route, "staging-1").sub, route).toBeUndefined();
     }
   });
@@ -354,7 +354,7 @@ suite("screenFor", () => {
   });
 
   it("gives a route with no screen a placeholder", () => {
-    for (const route of ["/", "/incidents"]) {
+    for (const route of ["/incidents"]) {
       expect(screenFor(route), route).toBeNull();
     }
   });
@@ -458,3 +458,5 @@ suite("ScreenComponent", () => {
     expect(plain).toBeTypeOf("function");
   });
 });
+
+it("registers the app landing page", () => { expect(screenFor("/")?.name).toBe("Home"); });

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -6,6 +6,8 @@ import { describe as suite, it, expect } from "vitest";
 import {
   describe,
   isBuiltInKind,
+  isClusterScopedRoute,
+  keepsManagementWhenPaused,
   screenFor,
   type RoutedScreenProps,
   type ScreenComponent,
@@ -224,6 +226,21 @@ suite("describe", () => {
     // /k/ branch's RESOURCE_LABELS lookup must still resolve it — this pins
     // that against a regression, not against screenFor's routing.
     expect(describe("/k/events", "c")).toMatchObject({ title: "Events", kind: "workloads" });
+  });
+});
+
+suite("isClusterScopedRoute", () => {
+  it("keeps run and stream management available while pausing cluster readers", () => {
+    for (const route of ["/agent", "/forwards", "/terminals"]) expect(keepsManagementWhenPaused(route)).toBe(true);
+    for (const route of ["/overview", "/helm", "/k/pods"]) expect(keepsManagementWhenPaused(route)).toBe(false);
+  });
+  it("distinguishes cluster-following routes from app screens", () => {
+    for (const route of ["/overview", "/helm", "/forwards", "/terminals", "/k/pods", "/k/Pod/default/web", "/edit/Pod/default/web"]) {
+      expect(isClusterScopedRoute(route), route).toBe(true);
+    }
+    for (const route of ["/", "/settings", "/connections", "/notes"]) {
+      expect(isClusterScopedRoute(route), route).toBe(false);
+    }
   });
 });
 

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -189,6 +189,19 @@ export function describe(route: string, clusterName?: string): RouteInfo {
   return { route, title: route.replace(/^\//, "") || "Untitled", sub, kind: "control" };
 }
 
+/** Whether a route follows a cluster rather than being an app-level screen. */
+export function isClusterScopedRoute(route: string): boolean {
+  // `describe` is already the one exhaustive parser for route shapes. Passing
+  // a sentinel lets its `sub` answer this without duplicating dynamic routes.
+  const sentinel = "__cluster_scope__";
+  return describe(route, sentinel).sub === sentinel;
+}
+
+/** These screens own controls for work that survives their component lifetime. */
+export function keepsManagementWhenPaused(route: string): boolean {
+  return route === "/agent" || route === "/forwards" || route === "/terminals";
+}
+
 /**
  * What every routed screen is handed.
  *

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -9,6 +9,7 @@ import { Events } from "../screens/Events";
 import { Forwards } from "../screens/Forwards";
 import { Helm } from "../screens/Helm";
 import { Logs, parseLogsRoute } from "../screens/Logs";
+import { Home } from "../screens/Home";
 import { Overview } from "../screens/Overview";
 import { ReleaseNotes } from "../screens/ReleaseNotes";
 import { ResourceDetailScreen, Resources } from "../screens/Resources";
@@ -57,6 +58,7 @@ export function isBuiltInKind(slug: string): slug is ResourceKind {
  */
 const APP_SCOPED: Record<string, Omit<RouteInfo, "route" | "sub">> =
   Object.assign(Object.create(null), {
+    "/": { title: "Home", kind: "control", pinned: true },
     "/applog": { title: "Application log", kind: "applog" },
     "/notes": { title: "Release notes", kind: "notes" },
     "/settings": { title: "Settings", kind: "settings" },
@@ -68,7 +70,6 @@ const APP_SCOPED: Record<string, Omit<RouteInfo, "route" | "sub">> =
 /** Routes whose tab names the cluster it is looking at. */
 const CLUSTER_SCOPED: Record<string, Omit<RouteInfo, "route" | "sub">> =
   Object.assign(Object.create(null), {
-    "/": { title: "Control room", kind: "control", pinned: true },
     "/incidents": { title: "Incidents", kind: "incidents" },
     "/agent": { title: "Agent", kind: "agent" },
     "/resources": { title: "Workloads", kind: "workloads" },
@@ -262,6 +263,7 @@ export type ScreenComponent = ComponentType<RoutedScreenProps>;
  * here and nothing else; a route with no entry renders the Placeholder.
  */
 const SCREENS: Record<string, ScreenComponent> = Object.assign(Object.create(null), {
+  "/": Home,
   "/applog": AppLog,
   "/notes": ReleaseNotes,
   // The full view of the one agent run this window holds — the console dock

--- a/packages/ui-next/src/lib/tabs.test.ts
+++ b/packages/ui-next/src/lib/tabs.test.ts
@@ -143,6 +143,12 @@ describe("reconcile", () => {
     expect(reconcile(s, []).workspaces[0].activeCluster).toBeUndefined();
   });
 
+  it("drops pauses for contexts removed from the kubeconfig", () => {
+    const s = defaultState([ctx("a"), ctx("b")]);
+    s.workspaces[0].pausedClusters = ["a", "b"];
+    expect(reconcile(s, [ctx("b")]).workspaces[0].pausedClusters).toEqual(["b"]);
+  });
+
   it("relabels cluster-scoped tabs when reconciliation picks a surviving context", () => {
     const s = defaultState([ctx("a", "prod"), ctx("b", "staging")]);
     s.workspaces[0].tabs = [

--- a/packages/ui-next/src/lib/tabs.ts
+++ b/packages/ui-next/src/lib/tabs.ts
@@ -26,6 +26,8 @@ export interface Workspace {
   name: string;
   /** `ClusterContext.stableId`s. Never display names — see #265. */
   clusters: string[];
+  /** Clusters the reader has paused without removing from this workspace. */
+  pausedClusters?: string[];
   /** The cluster the sidebar and status bar are about. A `stableId` in `clusters`. */
   activeCluster?: string;
   tabs: Tab[];
@@ -122,6 +124,7 @@ export function defaultState(contexts: ClusterContext[]): TabsState {
     id: newId(),
     name: "Default",
     clusters: ids,
+    pausedClusters: [],
     tabs: [home],
     activeId: home.id,
     closed: [],
@@ -145,6 +148,8 @@ export function reconcile(state: TabsState, contexts: ClusterContext[]): TabsSta
     let next = w;
     const clusters = w.clusters.filter((id) => known.has(id));
     if (clusters.length !== w.clusters.length) next = { ...next, clusters };
+    const pausedClusters = (w.pausedClusters ?? []).filter((id) => clusters.includes(id));
+    if (pausedClusters.length !== (w.pausedClusters ?? []).length) next = { ...next, pausedClusters };
 
     // The active cluster follows its list: it survives if it is still there,
     // and otherwise the first that remains takes over — including for a

--- a/packages/ui-next/src/lib/tabsPersist.test.ts
+++ b/packages/ui-next/src/lib/tabsPersist.test.ts
@@ -128,6 +128,13 @@ describe("parseStoredState", () => {
     expect(parseStoredState(raw)?.workspaces[0].activeCluster).toBeUndefined();
   });
 
+  it("restores pauses only for clusters that remain in the workspace", () => {
+    const s = defaultState([ctx("a"), ctx("b")]);
+    s.workspaces[0].pausedClusters = ["a"];
+    const raw = JSON.stringify({ version: STORAGE_VERSION, ...s }).replace('["a"]', '["a","gone",7]');
+    expect(parseStoredState(raw)?.workspaces[0].pausedClusters).toEqual(["a"]);
+  });
+
   it("keeps a tab's sort through a save and a load", () => {
     const s = valid();
     s.workspaces[0].tabs[1].view = {

--- a/packages/ui-next/src/lib/tabsPersist.test.ts
+++ b/packages/ui-next/src/lib/tabsPersist.test.ts
@@ -60,6 +60,17 @@ describe("storage that refuses", () => {
 });
 
 describe("parseStoredState", () => {
+  it("restores legacy Control room tabs as app-wide Home without changing identity or saved work", () => {
+    const state = valid();
+    const home = state.workspaces[0].tabs[0];
+    home.title = "Control room";
+    home.sub = "old-prod";
+    const parsed = parseStoredState(JSON.stringify({ version: STORAGE_VERSION, ...state }))!;
+    expect(parsed.workspaces[0].tabs[0]).toEqual({ id: home.id, route: "/", title: "Home", kind: "control", pinned: true });
+    expect(parsed.workspaces[0].tabs[1]).toEqual(state.workspaces[0].tabs[1]);
+    expect(parsed.workspaces[0].activeId).toBe(state.workspaces[0].activeId);
+  });
+
   it("round-trips a state written by saveTabsState", () => {
     const storage = memory();
     const state = valid();

--- a/packages/ui-next/src/lib/tabsPersist.ts
+++ b/packages/ui-next/src/lib/tabsPersist.ts
@@ -1,3 +1,4 @@
+import { describe } from "./routes";
 import { loadRestoreSession, settingsStorage } from "@srelens/core";
 import type { TableSort } from "@srelens/ui-kit";
 import type { Tab, TabsState, Workspace } from "./tabs";
@@ -50,6 +51,14 @@ function parseTab(v: unknown): Tab | null {
   if (!isRecord(v) || !isString(v.id) || !isString(v.route) || !isString(v.title) || !isString(v.kind)) return null;
   const tab: Tab = { id: v.id, route: v.route, title: v.title, kind: v.kind as Tab["kind"] };
   if (isString(v.sub)) tab.sub = v.sub;
+  // The former Control room route is now app-wide; retain the tab's identity
+  // and pin preference while dropping its obsolete cluster label.
+  if (tab.route === "/") {
+    const home = describe("/");
+    tab.title = home.title;
+    tab.kind = home.kind;
+    delete tab.sub;
+  }
   if (v.preview === true) tab.preview = true;
   if (v.pinned === true) tab.pinned = true;
   const view = parseView(v.view);

--- a/packages/ui-next/src/lib/tabsPersist.ts
+++ b/packages/ui-next/src/lib/tabsPersist.ts
@@ -80,6 +80,7 @@ function parseWorkspace(v: unknown): Workspace | null {
     activeId: v.activeId,
     closed,
   };
+  if (Array.isArray(v.pausedClusters)) ws.pausedClusters = v.pausedClusters.filter(isString).filter((id) => clusters.includes(id));
   // Only a cluster the workspace actually has: the field is an index into
   // `clusters`, and `reconcile` would drop a dangling one anyway.
   if (isString(v.activeCluster) && clusters.includes(v.activeCluster)) ws.activeCluster = v.activeCluster;

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -313,6 +313,15 @@ describe("workspaces", () => {
     store.setWorkspaceClusters(id, ["x", "y"]);
     expect(store.currentWorkspace().clusters).toEqual(["x", "y"]);
   });
+
+  it("keeps a pause in its workspace and clears it when that cluster is removed", () => {
+    const id = store.getState().currentId;
+    store.setWorkspaceClusters(id, ["x", "y"]);
+    store.setClusterPaused(id, "x", true);
+    expect(store.isClusterPaused("x")).toBe(true);
+    store.setWorkspaceClusters(id, ["y"]);
+    expect(store.currentWorkspace().pausedClusters).toEqual([]);
+  });
 });
 
 describe("setState", () => {

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -403,7 +403,7 @@ describe("activeCluster", () => {
     expect(tabs.filter((t) => t.sub === "prod-eu")).toEqual([]);
     expect(subFor("/overview")).toBe("staging-eu");
     expect(subFor("/k/pods")).toBe("staging-eu");
-    expect(subFor("/")).toBe("staging-eu");
+    expect(subFor("/")).toBeUndefined();
     // A stableId on the strip would satisfy "no longer prod-eu" and be the
     // same bug wearing the other name.
     expect(tabs.filter((t) => t.sub === "id-stage")).toEqual([]);

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -351,11 +351,27 @@ export function setWorkspaceClusters(id: string, clusters: string[]): void {
     // from the machine, not ones dropped from a workspace.
     const active = w.activeCluster && clusters.includes(w.activeCluster) ? w.activeCluster : clusters[0];
     if (same && active === w.activeCluster) return w;
-    const next: Workspace = { ...w, clusters: [...clusters] };
+    const next: Workspace = { ...w, clusters: [...clusters], pausedClusters: (w.pausedClusters ?? []).filter((cluster) => clusters.includes(cluster)) };
     if (active) next.activeCluster = active;
     else delete next.activeCluster;
     return next;
   });
+}
+
+/** A pause belongs to one workspace: another workspace may still use this cluster. */
+export function setClusterPaused(workspaceId: string, clusterId: string, paused: boolean): void {
+  patchWorkspace(workspaceId, (w) => {
+    if (!w.clusters.includes(clusterId)) return w;
+    const current = w.pausedClusters ?? [];
+    const next = paused ? (current.includes(clusterId) ? current : [...current, clusterId]) : current.filter((id) => id !== clusterId);
+    if (next.length === current.length && next.every((id, index) => id === current[index])) return w;
+    return { ...w, pausedClusters: next };
+  });
+}
+
+export function isClusterPaused(clusterId: string, workspaceId = currentWorkspace().id): boolean {
+  const workspace = getState().workspaces.find((w) => w.id === workspaceId);
+  return (workspace?.pausedClusters ?? []).includes(clusterId);
 }
 
 const EMPTY_VIEW: NonNullable<Tab["view"]> = {};

--- a/packages/ui-next/src/lib/tree.test.ts
+++ b/packages/ui-next/src/lib/tree.test.ts
@@ -138,7 +138,7 @@ describe("routeForNode", () => {
 describe("INVESTIGATE", () => {
   it("is the control room, incidents, topology and the agent", () => {
     expect(INVESTIGATE.map((i) => [i.label, i.route])).toEqual([
-      ["Control room", "/"],
+      ["Home", "/"],
       ["Incidents", "/incidents"],
       ["Topology", "/topology"],
       ["Agent", "/agent"],

--- a/packages/ui-next/src/lib/tree.ts
+++ b/packages/ui-next/src/lib/tree.ts
@@ -78,7 +78,7 @@ const CLUSTER_ROUTES: ReadonlyArray<{ kind: ResourceKind; route: string; before?
 
 /** Where the app can be sent that is not a list of resources. */
 export const INVESTIGATE: ReadonlyArray<{ id: string; label: string; route: string }> = [
-  { id: "control", label: "Control room", route: "/" },
+  { id: "control", label: "Home", route: "/" },
   { id: "incidents", label: "Incidents", route: "/incidents" },
   { id: "topology", label: "Topology", route: "/topology" },
   { id: "agent", label: "Agent", route: "/agent" },

--- a/packages/ui-next/src/lib/workspace.ts
+++ b/packages/ui-next/src/lib/workspace.ts
@@ -93,8 +93,15 @@ export function useWorkspaceView(): WorkspaceView {
   return useSyncExternalStore(subscribe, getView, getView);
 }
 
-export function setLink(id: string, state: LinkState, error?: string): void {
+export function setLink(id: string, state: LinkState | undefined, error?: string): void {
   const current = view.links[id];
+  if (state === undefined) {
+    if (!current) return;
+    const links = { ...view.links };
+    delete links[id];
+    emit({ ...view, links });
+    return;
+  }
   if (current && current.state === state && current.error === error) return;
   const entry = error === undefined ? { state } : { state, error };
   emit({ ...view, links: { ...view.links, [id]: entry } });

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 /**
@@ -199,6 +199,16 @@ function row(stableId: string) {
 
 describe("Connect", () => {
   describe("what §24 puts on the page", () => {
+    it("renders a disconnected cluster as paused rather than its retained reading", async () => {
+      open();
+      await waitFor(() => expect(row(PROD.stableId).status.textContent).toContain("reachable"));
+
+      act(() => store.setClusterPaused(store.currentWorkspace().id, PROD.stableId, true));
+
+      await waitFor(() => expect(row(PROD.stableId).status.textContent).toContain("paused"));
+      expect(row(PROD.stableId).latency).toBeNull();
+    });
+
     it("draws the eyebrow, both headline lines and the lede", async () => {
       core.isTauri.mockReturnValue(true);
       open();

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -36,6 +36,7 @@ import { useMark } from "../lib/marks";
 import { openCluster } from "../lib/openCluster";
 import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
+import { useTabs } from "../lib/tabsStore";
 import { STATUS, bySource, latencyLabel, viaOf } from "./connections/clusterText";
 
 /**
@@ -154,6 +155,7 @@ const WEB_ONLY =
  * each of those rows re-render on every notification about any other one.
  */
 const UNREAD: Probe = { state: "unread" };
+const PAUSED: Probe = { state: "paused" };
 
 /**
  * How many files the rows came out of.
@@ -468,6 +470,7 @@ export function Connect({ route }: { route: string }) {
   const status = useContextsStatus();
   const listError = useContextsError();
   const probes = useProbes();
+  const { workspace } = useTabs();
 
   /** A listing asked for by the reader, still out. */
   const [busy, setBusy] = useState(false);
@@ -685,7 +688,7 @@ export function Connect({ route }: { route: string }) {
                 context={context}
                 // `no reading` until the store has an answer for this cluster,
                 // which is what lets every row paint before any probe lands.
-                probe={probes[context.stableId] ?? UNREAD}
+                probe={workspace.pausedClusters?.includes(context.stableId) ? PAUSED : (probes[context.stableId] ?? UNREAD)}
                 onOpen={openCluster}
               />
             ))}

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -263,13 +263,21 @@ describe("Connections", () => {
     expect(screen.getAllByText("no reading").length).toBe(2);
   });
 
+  it("does not contact every configured cluster when the screen opens", async () => {
+    open();
+    await screen.findByText("prod-eu");
+    expect(core.connectCluster).not.toHaveBeenCalled();
+  });
+
   it("one cluster that does not answer does not hold up the others", async () => {
     core.connectCluster.mockImplementation(async (name: string) => {
       if (name === "prod-eu") return never<ClusterInfo>();
       clock += LATENCY[name] ?? 0;
       return REACHABLE[name];
     });
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     // The reachable one's own round trip, while the other is still out.
     expect(await screen.findByText("12 ms")).toBeTruthy();
     expect(within(rowFor("staging-eu")).getByText("reachable")).toBeTruthy();
@@ -282,7 +290,9 @@ describe("Connections", () => {
    * different round trips that answer them.
    */
   it("fills in the control-plane facts once a cluster has answered", async () => {
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     expect(await screen.findByText("gke · v1.30.6 · europe-west4")).toBeTruthy();
     expect(core.clusterFacts).toHaveBeenCalledWith("staging-eu");
   });
@@ -293,7 +303,9 @@ describe("Connections", () => {
       reachable: false,
       error: "no route to host",
     }));
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(screen.getAllByText("unreachable").length).toBe(2));
     expect(core.clusterFacts).not.toHaveBeenCalled();
   });
@@ -403,6 +415,7 @@ describe("Connections", () => {
   it("re-lists and re-reads every cluster on Refresh all", async () => {
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(screen.getByText("12 ms")).toBeTruthy());
     expect(core.connectCluster).toHaveBeenCalledTimes(2);
 
@@ -432,6 +445,19 @@ describe("Connections", () => {
     expect(core.clusterFacts.mock.calls.filter((c) => c[0] === "staging-eu").length).toBe(2);
   });
 
+  it("shows a paused cluster as paused instead of its retained reading", async () => {
+    const user = userEvent.setup();
+    open();
+    await user.click(refreshAll());
+    await waitFor(() => expect(within(rowFor("prod-eu")).getByText("reachable")).toBeTruthy());
+
+    act(() => store.setClusterPaused(store.currentWorkspace().id, PROD.stableId, true));
+
+    await waitFor(() => expect(within(rowFor("prod-eu")).getByText("paused")).toBeTruthy());
+    expect(within(rowFor("prod-eu")).queryByText("41 ms")).toBeNull();
+    expect(detailFor(PROD)).toBeNull();
+  });
+
   /**
    * **The sequence guard.** A reader who hits `Refresh all` twice must be left
    * looking at the second answer, whatever order the two listings come back in.
@@ -443,9 +469,9 @@ describe("Connections", () => {
       .mockResolvedValueOnce({ contexts: [PROD] });
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(drawn().length).toBe(2));
 
-    await user.click(refreshAll());
     await user.click(refreshAll());
     await waitFor(() => expect(drawn()).toEqual(["prod-eu"]));
 
@@ -481,6 +507,7 @@ describe("Connections", () => {
     });
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(drawn().length).toBe(2));
 
     // The new listing lands while staging is still connecting. Waited on prod's
@@ -526,7 +553,9 @@ describe("Connections", () => {
     core.clusterFacts.mockImplementation(async (context: string) =>
       context === "staging-eu" && ++asked === 1 ? slow.promise : facts({ context }),
     );
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(core.clusterFacts).toHaveBeenCalledWith("staging-eu"));
 
     // Somebody else lists the contexts. No `reload()`, no re-read flag — just a
@@ -553,7 +582,9 @@ describe("Connections", () => {
    */
   it("files a cluster's facts under its stableId, not its name", async () => {
     expect(STAGING.stableId).not.toBe(STAGING.name);
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(detailFor(STAGING)).toBe("gke · v1.30.6 · europe-west4"));
     // The capability takes a context name, and that is what it was handed.
     expect(core.clusterFacts).toHaveBeenCalledWith(STAGING.name);
@@ -576,6 +607,7 @@ describe("Connections", () => {
     });
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(screen.getByText("12 ms")).toBeTruthy());
 
     await user.click(refreshAll());

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -23,7 +23,7 @@ import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { openCluster } from "../lib/openCluster";
 import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { isClusterPaused, openTab, useTabs } from "../lib/tabsStore";
 import { ClusterTable, type ClusterRow } from "./connections/ClusterTable";
 import { SourcesRail } from "./connections/SourcesRail";
 
@@ -46,6 +46,7 @@ const CONNECT = "/connect";
  * the `useMemo` below on every notification.
  */
 const UNREAD: Probe = { state: "unread" };
+const PAUSED: Probe = { state: "paused" };
 
 /**
  * `/connections` — §6's screen: every cluster srelens can see, what the last
@@ -92,6 +93,7 @@ export function Connections({ route }: { route: string }) {
   const status = useContextsStatus();
   const listError = useContextsError();
   const probes = useProbes();
+  const { workspace } = useTabs();
   /**
    * The kubeconfig paths this window was started with, read at render the way
    * `Helm` reads them.
@@ -227,7 +229,7 @@ export function Connections({ route }: { route: string }) {
   }
 
   /**
-   * Read every cluster on the current list, each on its own.
+   * Read every cluster only after the reader explicitly refreshes the list.
    *
    * **Nothing here is awaited in series and nothing gates the render.** The
    * table is drawn from `contexts` the moment they exist, with every row
@@ -243,9 +245,12 @@ export function Connections({ route }: { route: string }) {
   useEffect(() => {
     const force = forceNext.current;
     forceNext.current = false;
+    if (!force) return;
 
     async function read(context: ClusterContext) {
       const id = context.stableId;
+      // A saved reading is not permission to contact a paused cluster again.
+      if (isClusterPaused(id)) return;
       /**
        * **Awaited, never skipped.**
        *
@@ -258,6 +263,9 @@ export function Connections({ route }: { route: string }) {
        * left the facts unfetched whenever a read spanned two listings.
        */
       if (force || getProbe(id).state === "unread") await probeCluster(context);
+      // Disconnect can happen while the reachability read is out. Do not turn
+      // the reading it invalidated into a follow-up facts request.
+      if (isClusterPaused(id)) return;
       // Not reachable: `provider` and `region` come from the API server, so
       // asking buys a second timeout for a row that already says why it is
       // empty. A later reading that DOES answer comes back through here.
@@ -302,11 +310,14 @@ export function Connections({ route }: { route: string }) {
   const rows = useMemo<ClusterRow[]>(
     () =>
       contexts.map((context) => {
-        const probe = probes[context.stableId] ?? UNREAD;
-        const known = facts[context.stableId];
+        const paused = workspace.pausedClusters?.includes(context.stableId) === true;
+        // A cached answer resumes after Reconnect, but must not be presented
+        // as current while this workspace has disconnected the cluster.
+        const probe = paused ? PAUSED : (probes[context.stableId] ?? UNREAD);
+        const known = paused ? undefined : facts[context.stableId];
         return known ? { context, probe, facts: known } : { context, probe };
       }),
-    [contexts, probes, facts],
+    [contexts, probes, facts, workspace.pausedClusters],
   );
 
   /**

--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -2,6 +2,7 @@ import { createElement } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Body } from "../shell/Body";
 
 /**
  * The manifest, the apply, the diff and the delete are all supplied at core's
@@ -154,6 +155,18 @@ data:
 `;
 
 describe("EditResource", () => {
+  it.each([ROUTE, "/new/prod-eu"])("keeps unsaved YAML across a router pause: %s", async route => {
+    const props = { route, ported: [], onOpenInClassic: () => {}, onLocked: () => {} };
+    const { rerender } = render(<Body {...props} />);
+    await waitFor(() => expect(latestEditor()?.value).toBeTruthy());
+    act(() => latestEditor().onChange(EDITED));
+    rerender(<Body {...props} pausedContext={{ name: "prod-eu", stableId: "prod-eu", cluster: "prod", server: "", isCurrent: false, sourceFile: "", authKind: "token" }} />);
+    expect(screen.getByText("prod-eu is paused")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Apply" })).toBeNull();
+    rerender(<Body {...props} />);
+    await waitFor(() => expect(latestEditor()?.value).toBe(EDITED));
+  });
+
   it("opens on the live manifest, read from the cluster the tab is on", async () => {
     render(<EditResource route={ROUTE} />);
     await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));

--- a/packages/ui-next/src/screens/Events.tsx
+++ b/packages/ui-next/src/screens/Events.tsx
@@ -38,13 +38,14 @@ import {
 } from "../lib/kinds/events";
 import { useResourceList } from "../lib/resourceList";
 import { describe } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { openTab, useTabs } from "../lib/tabsStore";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
 import { ReasonRail } from "./events/ReasonRail";
 import {
   NamespaceErrorAlert,
   NamespacePicker,
   NoClusterScreen,
+  PausedClusterScreen,
   StaleSelectionAlert,
   columnOptionsFor,
   emptyTableCopy,
@@ -121,10 +122,14 @@ const GROUP_BY_CAUSE = "What do these warning events have in common?";
  */
 export function Events({ route }: { route: string }) {
   const context = useActiveContext();
+  const { workspace } = useTabs();
   const title = describe(route, context?.name).title;
 
   if (!context) {
     return <NoClusterScreen title={title} noun="events" />;
+  }
+  if (workspace.pausedClusters?.includes(context.stableId)) {
+    return <PausedClusterScreen title={title} noun="events" context={context} />;
   }
 
   return <EventList route={route} title={title} context={context} />;

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -53,7 +53,7 @@ vi.mock("@srelens/core", async (orig) => ({
 import { type ActiveForward, type ClusterContext, kindToForwardTarget, toKubectl } from "@srelens/core";
 import { Forwards } from "./Forwards";
 import { resetContexts, setContexts } from "../lib/clusters";
-import { setActiveCluster, setState } from "../lib/tabsStore";
+import { currentWorkspace, setClusterPaused, setActiveCluster, setState } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 
 const ROUTE = "/forwards";
@@ -603,6 +603,12 @@ describe("Forwards — the row's actions", () => {
 });
 
 describe("Forwards — the screen around the table", () => {
+  it("closes creation when its captured cluster is paused after a rail switch", async () => {
+    await fillNewForwardThenMove();
+    act(() => setClusterPaused(currentWorkspace().id, PROD.stableId, true));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(core.startPortForward).not.toHaveBeenCalled();
+  });
   it("adopts the forwards the backend is still running, once, on mount", async () => {
     open();
     // The web-mode leak this screen exists to close: the store is module-level

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -29,6 +29,8 @@ import {
   type StatusKind,
 } from "@srelens/ui-kit";
 import { useActiveContext } from "../lib/clusters";
+import { useTabs } from "../lib/tabsStore";
+import { useDismissOnPause } from "../lib/pausedContext";
 import { FailureAlert, FailureWord } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { formatBytes } from "../lib/numbers";
@@ -266,6 +268,9 @@ export function Forwards(_props: { route: string }) {
    * for exactly that reason (see `Forwarding` there); this is the other door.
    */
   const [newForward, setNewForward] = useState<{ context: string; namespace?: string } | null>(null);
+  const targetPaused = useDismissOnPause(newForward?.context, () => setNewForward(null));
+  const { workspace } = useTabs();
+  const paused = cluster !== undefined && workspace.pausedClusters?.includes(cluster.stableId) === true;
 
   /**
    * What the dialog says, and asks again, when the rail moves out from under
@@ -295,7 +300,7 @@ export function Forwards(_props: { route: string }) {
   };
 
   const newForwardButton = (
-    <Button variant="primary" size="sm" onClick={openNewForward}>
+    <Button variant="primary" size="sm" onClick={openNewForward} disabled={paused}>
       New forward
     </Button>
   );
@@ -420,7 +425,7 @@ export function Forwards(_props: { route: string }) {
     <Screen title="Port forwards" eyebrow="all clusters" actions={newForwardButton} fill>
       {/* Beside the body rather than inside either branch of it, so the dialog
           opens the same from a populated screen and an empty one. */}
-      {newForward && (
+      {newForward && !targetPaused && (
         <NewForwardDialog
           // The cluster that was in focus when the dialog was asked for, not
           // the one in focus now. A forward is made in one cluster even though

--- a/packages/ui-next/src/screens/Home.test.tsx
+++ b/packages/ui-next/src/screens/Home.test.tsx
@@ -29,7 +29,7 @@ describe("Home", () => {
     setContexts([]);
     render(<Home />);
     expect(screen.getByRole("heading", { name: "Home", level: 1 })).toBeTruthy();
-    expect(screen.getByText("Your Kubernetes workspace")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Clusters", level: 2 })).toBeTruthy();
     expect(screen.getByText("No clusters configured")).toBeTruthy();
     expect(screen.queryByText(/not in the new design/)).toBeNull();
     await userEvent.click(screen.getByRole("button", { name: "Connect a cluster" }));

--- a/packages/ui-next/src/screens/Home.test.tsx
+++ b/packages/ui-next/src/screens/Home.test.tsx
@@ -43,10 +43,10 @@ describe("Home", () => {
     setLink(PROD.stableId, "connected");
     render(<Home />);
     expect(screen.getAllByRole("button", { name: /^Open cluster / }).map(row => row.getAttribute("aria-label")))
-      .toEqual(["Open cluster staging", "Open cluster Production Europe"]);
+      .toEqual(["Open cluster staging — Not checked", "Open cluster Production Europe — Connected"]);
     expect(screen.getByText("PE")).toBeTruthy();
     expect(screen.getByText("Connected")).toBeTruthy();
-    await userEvent.click(screen.getByRole("button", { name: "Open cluster Production Europe" }));
+    await userEvent.click(screen.getByRole("button", { name: "Open cluster Production Europe — Connected" }));
     expect(activeCluster()).toBe(PROD.stableId);
     expect(currentWorkspace().clusters).toContain(PROD.stableId);
     expect(activeRoute()).toBe("/overview");
@@ -58,15 +58,15 @@ describe("Home", () => {
     render(<Home />);
     const filter = screen.getByRole("searchbox", { name: "Find a cluster" });
     await userEvent.type(filter, "prod");
-    expect(screen.getByRole("button", { name: "Open cluster Europe" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Open cluster staging" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open cluster Europe — Not checked" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Open cluster staging — Not checked" })).toBeNull();
     await userEvent.clear(filter);
     await userEvent.type(filter, "missing");
     expect(screen.getByText("No matching clusters")).toBeTruthy();
     await userEvent.click(screen.getByRole("button", { name: "Clear search" }));
     expect(screen.getAllByRole("button", { name: /^Open cluster / })).toHaveLength(2);
     act(() => setMark(PROD.stableId, { ...defaultMark(PROD.name), name: "Production renamed" }));
-    expect(screen.getByRole("button", { name: "Open cluster Production renamed" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open cluster Production renamed — Not checked" })).toBeTruthy();
   });
 
   it("distinguishes loading and failed discovery from an empty configuration", () => {
@@ -84,7 +84,7 @@ describe("Home", () => {
     setLink(PROD.stableId, "error", "connection refused");
     render(<Home />);
     expect(screen.getByText("Could not load all clusters")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open cluster prod" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open cluster prod — Unreachable" })).toBeTruthy();
     expect(screen.getByText("Unreachable")).toBeTruthy();
   });
 
@@ -104,10 +104,10 @@ it("retries a failed discovery and retains readable clusters if retry fails", as
   listContexts.mockRejectedValueOnce(Error("still unavailable")).mockResolvedValueOnce({ contexts: [PROD, STAGE] });
   render(<Home />);
   await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-  expect(screen.getByRole("button", { name: "Open cluster prod" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Open cluster prod — Not checked" })).toBeTruthy();
   expect(screen.getByText("Could not load all clusters")).toBeTruthy();
   await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-  expect(screen.getByRole("button", { name: "Open cluster staging" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Open cluster staging — Not checked" })).toBeTruthy();
   expect(screen.queryByText("Could not load all clusters")).toBeNull();
 });
 
@@ -119,6 +119,6 @@ it("does not let a delayed retry replace a newer context inventory", async () =>
   await userEvent.click(screen.getByRole("button", { name: "Retry" }));
   act(() => setContexts([STAGE]));
   await act(async () => resolve({ contexts: [PROD] }));
-  expect(screen.getByRole("button", { name: "Open cluster staging" })).toBeTruthy();
-  expect(screen.queryByRole("button", { name: "Open cluster prod" })).toBeNull();
+  expect(screen.getByRole("button", { name: "Open cluster staging — Not checked" })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Open cluster prod — Not checked" })).toBeNull();
 });

--- a/packages/ui-next/src/screens/Home.test.tsx
+++ b/packages/ui-next/src/screens/Home.test.tsx
@@ -1,0 +1,124 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { saveContextOrder, type ClusterContext } from "@srelens/core";
+import { screenFor } from "../lib/routes";
+import { Home } from "./Home";
+import { resetContexts, setContexts } from "../lib/clusters";
+import { defaultMark, loadMarks, setMark } from "../lib/marks";
+import { activeCluster, activeRoute, currentWorkspace, setState } from "../lib/tabsStore";
+import { defaultState } from "../lib/tabs";
+import { resetView, setLink } from "../lib/workspace";
+
+const ctx = (stableId: string, name: string): ClusterContext => ({
+  stableId, name, cluster: name, server: `https://${stableId}.example`, isCurrent: false,
+  sourceFile: "/mock/config", authKind: "client certificate",
+});
+const { listContexts } = vi.hoisted(() => ({ listContexts: vi.fn() }));
+vi.mock("@srelens/core", async original => ({ ...(await original<typeof import("@srelens/core")>()), listContexts }));
+const PROD = ctx("prod-id", "prod");
+const STAGE = ctx("stage-id", "staging");
+beforeEach(() => {
+  listContexts.mockReset();
+  localStorage.clear(); loadMarks(); resetContexts(); resetView();
+  setState(defaultState([]));
+});
+
+describe("Home", () => {
+  it("offers a working first step when no clusters are configured", async () => {
+    setContexts([]);
+    render(<Home />);
+    expect(screen.getByRole("heading", { name: "Home", level: 1 })).toBeTruthy();
+    expect(screen.getByText("Your Kubernetes workspace")).toBeTruthy();
+    expect(screen.getByText("No clusters configured")).toBeTruthy();
+    expect(screen.queryByText(/not in the new design/)).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Connect a cluster" }));
+    expect(activeRoute()).toBe("/connect");
+  });
+
+  it("preserves cluster order and custom identities, and opens the chosen overview", async () => {
+    setContexts([PROD, STAGE]);
+    saveContextOrder([STAGE.stableId, PROD.stableId]);
+    setMark(PROD.stableId, { ...defaultMark(PROD.name), name: "Production Europe", short: "PE" });
+    setLink(PROD.stableId, "connected");
+    render(<Home />);
+    expect(screen.getAllByRole("button", { name: /^Open cluster / }).map(row => row.getAttribute("aria-label")))
+      .toEqual(["Open cluster staging", "Open cluster Production Europe"]);
+    expect(screen.getByText("PE")).toBeTruthy();
+    expect(screen.getByText("Connected")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Open cluster Production Europe" }));
+    expect(activeCluster()).toBe(PROD.stableId);
+    expect(currentWorkspace().clusters).toContain(PROD.stableId);
+    expect(activeRoute()).toBe("/overview");
+  });
+
+  it("filters by custom names and original context names without discarding the list", async () => {
+    setContexts([PROD, STAGE]);
+    setMark(PROD.stableId, { ...defaultMark(PROD.name), name: "Europe" });
+    render(<Home />);
+    const filter = screen.getByRole("searchbox", { name: "Find a cluster" });
+    await userEvent.type(filter, "prod");
+    expect(screen.getByRole("button", { name: "Open cluster Europe" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Open cluster staging" })).toBeNull();
+    await userEvent.clear(filter);
+    await userEvent.type(filter, "missing");
+    expect(screen.getByText("No matching clusters")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    expect(screen.getAllByRole("button", { name: /^Open cluster / })).toHaveLength(2);
+    act(() => setMark(PROD.stableId, { ...defaultMark(PROD.name), name: "Production renamed" }));
+    expect(screen.getByRole("button", { name: "Open cluster Production renamed" })).toBeTruthy();
+  });
+
+  it("distinguishes loading and failed discovery from an empty configuration", () => {
+    const view = render(<Home />);
+    expect(screen.getByText("Loading clusters…")).toBeTruthy();
+    expect(screen.queryByText("No clusters configured")).toBeNull();
+    act(() => setContexts([], "kubeconfig unreadable"));
+    view.rerender(<Home />);
+    expect(screen.getByText("Could not load all clusters")).toBeTruthy();
+    expect(screen.queryByText("No clusters configured")).toBeNull();
+  });
+
+  it("keeps readable contexts available after a partial discovery failure", () => {
+    setContexts([PROD], "another kubeconfig is unreadable");
+    setLink(PROD.stableId, "error", "connection refused");
+    render(<Home />);
+    expect(screen.getByText("Could not load all clusters")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open cluster prod" })).toBeTruthy();
+    expect(screen.getByText("Unreachable")).toBeTruthy();
+  });
+
+  it.each([["Manage connections", "/connections"], ["Settings", "/settings"], ["Release notes", "/notes"]])(
+    "opens %s", async (name, route) => {
+      setContexts([]);
+      render(<Home />);
+      await userEvent.click(screen.getByRole("button", { name }));
+      expect(activeRoute()).toBe(route);
+      expect(screenFor(activeRoute())).not.toBeNull();
+    },
+  );
+});
+
+it("retries a failed discovery and retains readable clusters if retry fails", async () => {
+  setContexts([PROD], "source unavailable");
+  listContexts.mockRejectedValueOnce(Error("still unavailable")).mockResolvedValueOnce({ contexts: [PROD, STAGE] });
+  render(<Home />);
+  await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+  expect(screen.getByRole("button", { name: "Open cluster prod" })).toBeTruthy();
+  expect(screen.getByText("Could not load all clusters")).toBeTruthy();
+  await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+  expect(screen.getByRole("button", { name: "Open cluster staging" })).toBeTruthy();
+  expect(screen.queryByText("Could not load all clusters")).toBeNull();
+});
+
+it("does not let a delayed retry replace a newer context inventory", async () => {
+  setContexts([PROD], "source unavailable");
+  let resolve!: (value: unknown) => void;
+  listContexts.mockReturnValue(new Promise(done => { resolve = done; }));
+  render(<Home />);
+  await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+  act(() => setContexts([STAGE]));
+  await act(async () => resolve({ contexts: [PROD] }));
+  expect(screen.getByRole("button", { name: "Open cluster staging" })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Open cluster prod" })).toBeNull();
+});

--- a/packages/ui-next/src/screens/Home.test.tsx
+++ b/packages/ui-next/src/screens/Home.test.tsx
@@ -6,7 +6,7 @@ import { screenFor } from "../lib/routes";
 import { Home } from "./Home";
 import { resetContexts, setContexts } from "../lib/clusters";
 import { defaultMark, loadMarks, setMark } from "../lib/marks";
-import { activeCluster, activeRoute, currentWorkspace, setState } from "../lib/tabsStore";
+import { activeCluster, activeRoute, currentWorkspace, setState, setClusterPaused } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 import { resetView, setLink } from "../lib/workspace";
 
@@ -25,6 +25,15 @@ beforeEach(() => {
 });
 
 describe("Home", () => {
+  it("uses a neutral status for a paused cluster with a retained successful probe", () => {
+    setContexts([PROD]);
+    setState(defaultState([PROD]));
+    setLink(PROD.stableId, "connected");
+    setClusterPaused(currentWorkspace().id, PROD.stableId, true);
+    render(<Home />);
+    const row = screen.getByRole("button", { name: "Open cluster prod — Paused" });
+    expect(row.querySelector(".status")?.getAttribute("data-kind")).toBe("neutral");
+  });
   it("offers a working first step when no clusters are configured", async () => {
     setContexts([]);
     render(<Home />);

--- a/packages/ui-next/src/screens/Home.tsx
+++ b/packages/ui-next/src/screens/Home.tsx
@@ -44,7 +44,7 @@ export function Home() {
 
   return (
     <Screen title="Home" eyebrow="srelens" fill>
-      <div className="home-page scroll min-h-0 flex-1">
+      <div className="home-page min-h-0 flex-1">
         <div className="home-intro">
           <div>
             <span className="home-eyebrow">Explore · Observe · Troubleshoot</span>
@@ -68,7 +68,7 @@ export function Home() {
             {status === "loading" ? <LoadingState label="Loading clusters…" /> : contexts.length === 0 ? (
               status === "loaded" && <EmptyState title="No clusters configured" hint="Add a kubeconfig or connect to a cluster to start exploring. Your saved connections will appear here." />
             ) : filtered.length === 0 ? <EmptyState title="No matching clusters" hint="Search by display name, context, or API server." action={<Button variant="secondary" size="sm" onClick={() => setQuery("")}>Clear search</Button>} /> : (
-              <ul aria-label="Saved clusters">
+              <ul className="home-cluster-list scroll" aria-label="Saved clusters">
                 {filtered.map(ctx => <ClusterRow key={ctx.stableId} context={ctx} link={links[ctx.stableId]} />)}
               </ul>
             )}
@@ -88,20 +88,21 @@ export function Home() {
 
 function ClusterRow({ context, link }: { context: ClusterContext; link?: ReturnType<typeof useWorkspaceView>["links"][string] }) {
   const mark = getMark(context.stableId, context.name);
+  const status = link ? LINK_WORD[link.state] : "Not checked";
   let secondary = context.name;
   if (mark.name === context.name) {
     try { secondary = new URL(context.server).host; }
     catch { secondary = context.cluster !== context.name ? context.cluster : context.sourceFile; }
   }
   return <li className="border-b border-rule">
-    <button type="button" className="home-cluster-row" aria-label={`Open cluster ${mark.name}`} onClick={() => openCluster(context)}>
+    <button type="button" className="home-cluster-row" aria-label={`Open cluster ${mark.name} — ${status}`} onClick={() => openCluster(context)}>
       <Mark decorative name={mark.name} short={mark.short} color={mark.color} size="sm" withBadge={mark.withText}
         icon={mark.mark === "icon" ? symbolFor(mark.icon) : undefined} imageSrc={mark.mark === "image" ? mark.imageSrc : undefined} />
       <span className="min-w-0 flex-1 text-left">
         <span className="block truncate font-medium">{mark.name}</span>
         <span className="block truncate text-xs text-muted" title={secondary}>{secondary}</span>
       </span>
-      <StatusPill status={link ? LINK_WORD[link.state] : "Not checked"} kind={link?.state === "connected" ? "success" : link?.state === "connecting" ? "info" : link?.state === "error" ? "danger" : "neutral"} />
+      <StatusPill status={status} kind={link?.state === "connected" ? "success" : link?.state === "connecting" ? "info" : link?.state === "error" ? "danger" : "neutral"} />
       <span aria-hidden className="text-muted">→</span>
     </button>
   </li>;

--- a/packages/ui-next/src/screens/Home.tsx
+++ b/packages/ui-next/src/screens/Home.tsx
@@ -47,9 +47,9 @@ export function Home() {
       <div className="home-page min-h-0 flex-1">
         <div className="home-intro">
           <div>
-            <span className="home-eyebrow">Explore · Observe · Troubleshoot</span>
-            <h2>Your Kubernetes workspace</h2>
-            <p>Open a cluster to see its health, explore resources, and investigate what needs attention.</p>
+            <span className="home-eyebrow">Workspace</span>
+            <h2>Clusters</h2>
+            <p>Choose a cluster to open its overview.</p>
           </div>
           <Button variant="primary" onClick={() => openTab("/connect")}>
             <NavIcon icon={Icons.add} /> Connect a cluster
@@ -74,11 +74,10 @@ export function Home() {
             )}
           </section>
           <aside className="home-start" aria-label="Workspace tools">
-            <h2 className="home-section-heading">Make yourself at home</h2>
-            <HomeAction title="Manage connections" description="Review contexts, connection status, and kubeconfig sources." icon={Icons.cluster} route="/connections" />
-            <HomeAction title="Settings" description="Personalise your workspace, context names, and appearance." icon={Icons.settings} route="/settings" />
-            <HomeAction title="Release notes" description="See what’s new in srelens." icon={Icons.events} route="/notes" />
-            <p className="px-5 py-5 text-xs leading-relaxed text-muted">Each cluster opens on its overview. Home is always here when you need a place to start.</p>
+            <h2 className="home-section-heading">Quick links</h2>
+            <HomeAction title="Manage connections" icon={Icons.cluster} route="/connections" />
+            <HomeAction title="Settings" icon={Icons.settings} route="/settings" />
+            <HomeAction title="Release notes" icon={Icons.events} route="/notes" />
           </aside>
         </div>
       </div>
@@ -108,10 +107,10 @@ function ClusterRow({ context, link }: { context: ClusterContext; link?: ReturnT
   </li>;
 }
 
-function HomeAction({ title, description, icon, route }: { title: string; description: string; icon: typeof Icons.settings; route: string }) {
+function HomeAction({ title, icon, route }: { title: string; icon: typeof Icons.settings; route: string }) {
   return <button type="button" className="home-action" aria-label={title} onClick={() => openTab(route)}>
     <NavIcon icon={icon} />
-    <span className="min-w-0 text-left"><span className="block font-medium">{title}</span><span className="mt-1 block text-xs leading-relaxed text-muted">{description}</span></span>
+    <span className="min-w-0 truncate text-left font-medium">{title}</span>
     <span aria-hidden className="text-muted">→</span>
   </button>;
 }

--- a/packages/ui-next/src/screens/Home.tsx
+++ b/packages/ui-next/src/screens/Home.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+import { describeError, listContexts, type ClusterContext } from "@srelens/core";
+import { Button, EmptyState, LoadingState, Mark, NavIcon, Screen, StatusPill, TextInput } from "@srelens/ui-kit";
+import { getContexts, getKubeconfigFiles, setContexts, useContexts, useContextsError, useContextsStatus } from "../lib/clusters";
+import { useOrderedContexts } from "../lib/contextOrder";
+import { FailureAlert } from "../lib/errorCopy";
+import { Icons } from "../lib/icons";
+import { getMark, useEditableMark } from "../lib/marks";
+import { symbolFor } from "../lib/markSymbols";
+import { openCluster } from "../lib/openCluster";
+import { openTab } from "../lib/tabsStore";
+import { LINK_WORD, useWorkspaceView } from "../lib/workspace";
+
+/** App-wide entry point. Contexts and connection status come from the shell's shared stores. */
+export function Home() {
+  const contexts = useContexts();
+  const status = useContextsStatus();
+  const error = useContextsError();
+  const ordered = useOrderedContexts(contexts);
+  // Like the rail, subscribe once so filtering follows saved display-name edits.
+  useEditableMark("", "");
+  const { links } = useWorkspaceView();
+  const [query, setQuery] = useState("");
+  const [retrying, setRetrying] = useState(false);
+  const mounted = useRef(false);
+  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
+  const term = query.trim().toLocaleLowerCase();
+  const filtered = ordered.filter(ctx =>
+    [getMark(ctx.stableId, ctx.name).name, ctx.name, ctx.cluster, ctx.server].some(value => value.toLocaleLowerCase().includes(term)),
+  );
+
+  async function retry() {
+    setRetrying(true);
+    const previous = getContexts();
+    try {
+      const result = await listContexts(getKubeconfigFiles());
+      if (mounted.current && getContexts() === previous) setContexts(result.contexts ?? previous, result.error ?? "");
+    } catch (cause) {
+      if (mounted.current && getContexts() === previous) setContexts(previous, describeError(cause).detail);
+    } finally {
+      if (mounted.current) setRetrying(false);
+    }
+  }
+
+  return (
+    <Screen title="Home" eyebrow="srelens" fill>
+      <div className="home-page scroll min-h-0 flex-1">
+        <div className="home-intro">
+          <div>
+            <span className="home-eyebrow">Explore · Observe · Troubleshoot</span>
+            <h2>Your Kubernetes workspace</h2>
+            <p>Open a cluster to see its health, explore resources, and investigate what needs attention.</p>
+          </div>
+          <Button variant="primary" onClick={() => openTab("/connect")}>
+            <NavIcon icon={Icons.add} /> Connect a cluster
+          </Button>
+        </div>
+        <div className="home-layout">
+          <section className="home-clusters" aria-labelledby="home-clusters-title">
+            <div className="home-section-heading">
+              <h2 id="home-clusters-title">Your clusters <span className="text-muted">{contexts.length}</span></h2>
+              {contexts.length > 0 && <TextInput type="search" aria-label="Find a cluster" placeholder="Find a cluster…" value={query} onValueChange={setQuery} />}
+            </div>
+            {status === "failed" && <div className="border-b border-rule p-4">
+              <FailureAlert title="Could not load all clusters" error={error} />
+              <Button variant="secondary" size="sm" className="mt-2" disabled={retrying} onClick={() => void retry()}>{retrying ? "Retrying…" : "Retry"}</Button>
+            </div>}
+            {status === "loading" ? <LoadingState label="Loading clusters…" /> : contexts.length === 0 ? (
+              status === "loaded" && <EmptyState title="No clusters configured" hint="Add a kubeconfig or connect to a cluster to start exploring. Your saved connections will appear here." />
+            ) : filtered.length === 0 ? <EmptyState title="No matching clusters" hint="Search by display name, context, or API server." action={<Button variant="secondary" size="sm" onClick={() => setQuery("")}>Clear search</Button>} /> : (
+              <ul aria-label="Saved clusters">
+                {filtered.map(ctx => <ClusterRow key={ctx.stableId} context={ctx} link={links[ctx.stableId]} />)}
+              </ul>
+            )}
+          </section>
+          <aside className="home-start" aria-label="Workspace tools">
+            <h2 className="home-section-heading">Make yourself at home</h2>
+            <HomeAction title="Manage connections" description="Review contexts, connection status, and kubeconfig sources." icon={Icons.cluster} route="/connections" />
+            <HomeAction title="Settings" description="Personalise your workspace, context names, and appearance." icon={Icons.settings} route="/settings" />
+            <HomeAction title="Release notes" description="See what’s new in srelens." icon={Icons.events} route="/notes" />
+            <p className="px-5 py-5 text-xs leading-relaxed text-muted">Each cluster opens on its overview. Home is always here when you need a place to start.</p>
+          </aside>
+        </div>
+      </div>
+    </Screen>
+  );
+}
+
+function ClusterRow({ context, link }: { context: ClusterContext; link?: ReturnType<typeof useWorkspaceView>["links"][string] }) {
+  const mark = getMark(context.stableId, context.name);
+  let secondary = context.name;
+  if (mark.name === context.name) {
+    try { secondary = new URL(context.server).host; }
+    catch { secondary = context.cluster !== context.name ? context.cluster : context.sourceFile; }
+  }
+  return <li className="border-b border-rule">
+    <button type="button" className="home-cluster-row" aria-label={`Open cluster ${mark.name}`} onClick={() => openCluster(context)}>
+      <Mark decorative name={mark.name} short={mark.short} color={mark.color} size="sm" withBadge={mark.withText}
+        icon={mark.mark === "icon" ? symbolFor(mark.icon) : undefined} imageSrc={mark.mark === "image" ? mark.imageSrc : undefined} />
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block truncate font-medium">{mark.name}</span>
+        <span className="block truncate text-xs text-muted" title={secondary}>{secondary}</span>
+      </span>
+      <StatusPill status={link ? LINK_WORD[link.state] : "Not checked"} kind={link?.state === "connected" ? "success" : link?.state === "connecting" ? "info" : link?.state === "error" ? "danger" : "neutral"} />
+      <span aria-hidden className="text-muted">→</span>
+    </button>
+  </li>;
+}
+
+function HomeAction({ title, description, icon, route }: { title: string; description: string; icon: typeof Icons.settings; route: string }) {
+  return <button type="button" className="home-action" aria-label={title} onClick={() => openTab(route)}>
+    <NavIcon icon={icon} />
+    <span className="min-w-0 text-left"><span className="block font-medium">{title}</span><span className="mt-1 block text-xs leading-relaxed text-muted">{description}</span></span>
+    <span aria-hidden className="text-muted">→</span>
+  </button>;
+}

--- a/packages/ui-next/src/screens/Home.tsx
+++ b/packages/ui-next/src/screens/Home.tsx
@@ -10,6 +10,7 @@ import { symbolFor } from "../lib/markSymbols";
 import { openCluster } from "../lib/openCluster";
 import { openTab } from "../lib/tabsStore";
 import { LINK_WORD, useWorkspaceView } from "../lib/workspace";
+import { useTabs } from "../lib/tabsStore";
 
 /** App-wide entry point. Contexts and connection status come from the shell's shared stores. */
 export function Home() {
@@ -20,6 +21,7 @@ export function Home() {
   // Like the rail, subscribe once so filtering follows saved display-name edits.
   useEditableMark("", "");
   const { links } = useWorkspaceView();
+  const { workspace } = useTabs();
   const [query, setQuery] = useState("");
   const [retrying, setRetrying] = useState(false);
   const mounted = useRef(false);
@@ -69,7 +71,7 @@ export function Home() {
               status === "loaded" && <EmptyState title="No clusters configured" hint="Add a kubeconfig or connect to a cluster to start exploring. Your saved connections will appear here." />
             ) : filtered.length === 0 ? <EmptyState title="No matching clusters" hint="Search by display name, context, or API server." action={<Button variant="secondary" size="sm" onClick={() => setQuery("")}>Clear search</Button>} /> : (
               <ul className="home-cluster-list scroll" aria-label="Saved clusters">
-                {filtered.map(ctx => <ClusterRow key={ctx.stableId} context={ctx} link={links[ctx.stableId]} />)}
+                {filtered.map(ctx => <ClusterRow key={ctx.stableId} context={ctx} link={links[ctx.stableId]} paused={workspace.pausedClusters?.includes(ctx.stableId) === true} />)}
               </ul>
             )}
           </section>
@@ -85,9 +87,9 @@ export function Home() {
   );
 }
 
-function ClusterRow({ context, link }: { context: ClusterContext; link?: ReturnType<typeof useWorkspaceView>["links"][string] }) {
+function ClusterRow({ context, link, paused }: { context: ClusterContext; link?: ReturnType<typeof useWorkspaceView>["links"][string]; paused: boolean }) {
   const mark = getMark(context.stableId, context.name);
-  const status = link ? LINK_WORD[link.state] : "Not checked";
+  const status = paused ? "Paused" : link ? LINK_WORD[link.state] : "Not checked";
   let secondary = context.name;
   if (mark.name === context.name) {
     try { secondary = new URL(context.server).host; }
@@ -101,7 +103,7 @@ function ClusterRow({ context, link }: { context: ClusterContext; link?: ReturnT
         <span className="block truncate font-medium">{mark.name}</span>
         <span className="block truncate text-xs text-muted" title={secondary}>{secondary}</span>
       </span>
-      <StatusPill status={status} kind={link?.state === "connected" ? "success" : link?.state === "connecting" ? "info" : link?.state === "error" ? "danger" : "neutral"} />
+      <StatusPill status={status} kind={paused ? "neutral" : link?.state === "connected" ? "success" : link?.state === "connecting" ? "info" : link?.state === "error" ? "danger" : "neutral"} />
       <span aria-hidden className="text-muted">→</span>
     </button>
   </li>;

--- a/packages/ui-next/src/screens/ResourceMenu.test.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { setContexts } from "../lib/clusters";
 import userEvent from "@testing-library/user-event";
 
 // Everything this hook reaches into core for. Mocked so a test can control
@@ -512,6 +513,15 @@ describe("useRowMenu — the cluster the row was picked on", () => {
   const box = () => within(screen.getByRole("dialog"));
   const tickFor = (verb: string) => screen.getByRole("checkbox", { name: `Yes, still ${verb} on ${PINNED}.` });
   const REFUSAL = `This runs on ${PINNED}, not ${MOVED}. Confirm the cluster above, or cancel.`;
+  it("dismisses a pending write when its captured cluster is paused", async () => {
+    const contexts = [PINNED, MOVED].map(name => ({ name, stableId: `id-${name}`, cluster: name, server: "", isCurrent: false, sourceFile: "", authKind: "token" }));
+    setContexts(contexts);
+    store.setState(defaultState(contexts));
+    await pickThenMove("Delete");
+    act(() => store.setClusterPaused(store.currentWorkspace().id, `id-${PINNED}`, true));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(deleteResource).not.toHaveBeenCalled();
+  });
 
   /** Pick an entry on `prod-eu`, then move the rail to `stage-eu` under it. */
   async function pickThenMove(label: string, args: (context: string) => UseRowMenuArgs = argsOn) {

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -26,6 +26,7 @@ import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
 import type { KindActions, ListRow } from "../lib/kinds/types";
 import { startPodSession } from "../lib/sessions";
 import { openTab } from "../lib/tabsStore";
+import { isContextPaused, useDismissOnPause } from "../lib/pausedContext";
 import { NewForwardDialog } from "./forwards/NewForwardDialog";
 import { logsRoute } from "./Logs";
 
@@ -164,6 +165,11 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
    * a question with its own fields, not a `Pending` variant.
    */
   const [shellPick, setShellPick] = useState<ShellPick | null>(null);
+  const targetPaused = useDismissOnPause(pending?.context ?? forwarding?.context ?? shellPick?.context, () => {
+    setPending(null);
+    setForwarding(null);
+    setShellPick(null);
+  });
   const [shellBusy, setShellBusy] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
@@ -247,7 +253,9 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
     // `getObject` is in flight, and a shell opened on one cluster's container
     // list must not attach to another cluster's pod of the same name.
     const target = context;
+    if (isContextPaused(target)) return;
     const result = await getObject(target, kind, namespace || null, row.name);
+    if (isContextPaused(target)) return;
     if (result.error || !result.object) {
       notify.error(`Couldn't open a shell in ${row.name}`, describeError(result.error ?? "Pod not found").detail);
       return;
@@ -275,6 +283,7 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
    *  `/terminals`, worth showing rather than hiding behind a tab that never
    *  opens. */
   async function launchShell(row: ListRow, namespace: string, container: string, target: string) {
+    if (isContextPaused(target)) return;
     await startPodSession({ context: target, namespace, pod: row.name, container });
     openTab("/terminals", { clusterName: target });
   }
@@ -288,7 +297,7 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
   }
 
   async function confirm() {
-    if (!pending) return;
+    if (!pending || isContextPaused(pending.context)) return;
     const { row, context: target } = pending;
     const ns = row.namespace ?? "";
 
@@ -435,7 +444,7 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
     return list;
   }
 
-  const dialog = pending ? (
+  const dialog = targetPaused ? null : pending ? (
     <PendingDialog
       pending={pending}
       kind={kind}

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -33,7 +33,7 @@ import { rowKey, type KindDescriptor, type ListRow } from "../lib/kinds/types";
 import { clampPeekWidth, savePeekWidth, setPeekWidth, usePeekBounds, usePeekWidth } from "../lib/peekWidth";
 import { useResourceList } from "../lib/resourceList";
 import { describe, isBuiltInKind } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { openTab, useTabs } from "../lib/tabsStore";
 import { useResource } from "../lib/useResource";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
@@ -46,6 +46,7 @@ import {
   NamespaceErrorAlert,
   NamespacePicker,
   NoClusterScreen,
+  PausedClusterScreen,
   StaleSelectionAlert,
   columnOptionsFor,
   defaultHiddenKeys,
@@ -79,6 +80,7 @@ const CRD_RAIL_WIDTH = 264;
  */
 export function Resources({ route }: { route: string }) {
   const context = useActiveContext();
+  const { workspace } = useTabs();
   const slug = route.slice("/k/".length);
   // The tab strip already knows what this route is called; asking `describe`
   // keeps the screen's title and the tab's title the same string.
@@ -86,6 +88,9 @@ export function Resources({ route }: { route: string }) {
 
   if (!context) {
     return <NoClusterScreen title={title} noun="resources" />;
+  }
+  if (workspace.pausedClusters?.includes(context.stableId)) {
+    return <PausedClusterScreen title={title} noun="resources" context={context} />;
   }
 
   return <KindList route={route} slug={slug} title={title} context={context} />;

--- a/packages/ui-next/src/screens/Terminals.test.tsx
+++ b/packages/ui-next/src/screens/Terminals.test.tsx
@@ -175,6 +175,11 @@ afterEach(() => {
 });
 
 describe("Terminals", () => {
+  it("closes creation when its captured cluster is paused after a rail switch", async () => {
+    await pickPodThenMove(userEvent.setup());
+    act(() => tabs.setClusterPaused(tabs.currentWorkspace().id, CTX.stableId, true));
+    expect(screen.queryByRole("button", { name: "Start session" })).toBeNull();
+  });
   it("lets the pane shrink, so the rail is not pushed off the window", async () => {
     // xterm sizes its content in explicit pixels, and a flex item's implicit
     // `min-width: auto` refuses to shrink below its content — so without

--- a/packages/ui-next/src/screens/Terminals.tsx
+++ b/packages/ui-next/src/screens/Terminals.tsx
@@ -13,6 +13,8 @@ import {
 import { useConsole } from "../console";
 import { useActiveContext } from "../lib/clusters";
 import { ClusterMovedAlert } from "../lib/clusterMoved";
+import { useTabs } from "../lib/tabsStore";
+import { useDismissOnPause } from "../lib/pausedContext";
 import {
   endSession,
   getSessions,
@@ -192,6 +194,8 @@ function askQuestion(session: TerminalSessionRow | undefined, context: string): 
 export function Terminals(_props: { route: string }) {
   const sessions = useSyncExternalStore(subscribeSessions, getSessions, getSessions);
   const cluster = useActiveContext();
+  const { workspace } = useTabs();
+  const paused = cluster !== undefined && workspace.pausedClusters?.includes(cluster.stableId) === true;
   const { ask } = useConsole();
   const [picked, setPicked] = useState<number | null>(null);
   /**
@@ -206,6 +210,7 @@ export function Terminals(_props: { route: string }) {
    * `ResourceMenu`'s `Open shell` pinned its own pick for the same reason.
    */
   const [newSession, setNewSession] = useState<{ context: string; namespace: string } | null>(null);
+  const targetPaused = useDismissOnPause(newSession?.context, () => setNewSession(null));
 
   /**
    * A session started anywhere — this screen's menu, or the resource row
@@ -265,6 +270,7 @@ export function Terminals(_props: { route: string }) {
           <Button
             variant="primary"
             size="sm"
+            disabled={paused}
             onClick={() =>
               setNewSession({ context: cluster?.name ?? "", namespace: cluster?.namespace ?? "" })
             }
@@ -274,7 +280,7 @@ export function Terminals(_props: { route: string }) {
         </>
       }
     >
-      {newSession && (
+      {newSession && !targetPaused && (
         <NewSessionMenu
           // The cluster that was in focus when `New session` was pressed, not
           // the active session's and not the one in focus now: a new session is
@@ -316,6 +322,7 @@ export function Terminals(_props: { route: string }) {
             onNewSession={() =>
               setNewSession({ context: cluster?.name ?? "", namespace: cluster?.namespace ?? "" })
             }
+            newSessionDisabled={paused}
           />
         }
         mainHead={

--- a/packages/ui-next/src/screens/Workloads.tsx
+++ b/packages/ui-next/src/screens/Workloads.tsx
@@ -48,13 +48,14 @@ import { withRowAffordances } from "../lib/kinds/rowAffordances";
 import type { ListRow } from "../lib/kinds/types";
 import { useResourceList, type ResourceList } from "../lib/resourceList";
 import { describe } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { openTab, useTabs } from "../lib/tabsStore";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
 import { useRowMenu } from "./ResourceMenu";
 import {
   NamespaceErrorAlert,
   NamespacePicker,
   NoClusterScreen,
+  PausedClusterScreen,
   StaleSelectionAlert,
   columnOptionsFor,
   emptyTableCopy,
@@ -241,10 +242,14 @@ const UNION_COLUMNS: Column<WorkloadRow>[] = [
  */
 export function Workloads({ route }: { route: string }) {
   const context = useActiveContext();
+  const { workspace } = useTabs();
   const title = describe(route, context?.name).title;
 
   if (!context) {
     return <NoClusterScreen title={title} noun="workloads" />;
+  }
+  if (workspace.pausedClusters?.includes(context.stableId)) {
+    return <PausedClusterScreen title={title} noun="workloads" context={context} />;
   }
 
   return <WorkloadList route={route} title={title} context={context} />;

--- a/packages/ui-next/src/screens/connections/clusterText.ts
+++ b/packages/ui-next/src/screens/connections/clusterText.ts
@@ -161,4 +161,5 @@ export const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
   reachable: { word: "reachable", tone: "ok" },
   unreachable: { word: "unreachable", tone: "sev" },
   unread: { word: "no reading", tone: "muted" },
+  paused: { word: "paused", tone: "muted" },
 };

--- a/packages/ui-next/src/screens/resourceShell.tsx
+++ b/packages/ui-next/src/screens/resourceShell.tsx
@@ -1,7 +1,9 @@
+import type { ClusterContext } from "@srelens/core";
 import { Alert, Button, Combobox, EmptyState, LoadingState, MultiSelect, Screen, Spinner, type Column, type TableSort } from "@srelens/ui-kit";
 import { useContextsError, useContextsStatus } from "../lib/clusters";
 import { toggleColumn } from "../lib/columnPrefs";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
+import { reconnectCluster } from "../lib/openCluster";
 import { setTabView, useTabs, useTabView } from "../lib/tabsStore";
 
 /**
@@ -72,6 +74,20 @@ export function NoClusterScreen({ title, noun }: { title: string; noun: string }
           className="flex-1"
         />
       )}
+    </Screen>
+  );
+}
+
+/** A paused cluster keeps its place while every resource reader is stopped. */
+export function PausedClusterScreen({ title, noun, context }: { title: string; noun: string; context: ClusterContext }) {
+  return (
+    <Screen title={title} eyebrow={context.name} fill>
+      <EmptyState
+        title={`${context.name} is paused`}
+        hint={`Reconnect this cluster to resume listing ${noun}.`}
+        action={<Button variant="primary" onClick={() => reconnectCluster(context)}>Reconnect</Button>}
+        className="flex-1"
+      />
     </Screen>
   );
 }

--- a/packages/ui-next/src/screens/terminals/SessionRail.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.tsx
@@ -148,6 +148,8 @@ export interface SessionRailProps {
   onSelect: (id: number) => void;
   /** "New session" was picked, from the empty state. */
   onNewSession: () => void;
+  /** The screen is still usable, but the active cluster cannot start a shell. */
+  newSessionDisabled?: boolean;
 }
 
 /**
@@ -171,7 +173,7 @@ export interface SessionRailProps {
  * store precisely so a ticking display here does not churn its snapshot —
  * this component owns the clock the store deliberately does not.
  */
-export function SessionRail({ sessions, activeId, onSelect, onNewSession }: SessionRailProps) {
+export function SessionRail({ sessions, activeId, onSelect, onNewSession, newSessionDisabled = false }: SessionRailProps) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const tick = setInterval(() => setNow(Date.now()), IDLE_TICK_MS);
@@ -185,7 +187,7 @@ export function SessionRail({ sessions, activeId, onSelect, onNewSession }: Sess
         title="No sessions"
         hint="Open a shell into a pod, a node, or this machine."
         action={
-          <Button size="xs" onClick={onNewSession}>
+          <Button size="xs" onClick={onNewSession} disabled={newSessionDisabled}>
             New session
           </Button>
         }

--- a/packages/ui-next/src/shell/Body.test.tsx
+++ b/packages/ui-next/src/shell/Body.test.tsx
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useEffect, useState } from "react";
+
+const { reading, stopped } = vi.hoisted(() => ({ reading: vi.fn(), stopped: vi.fn() }));
 import userEvent from "@testing-library/user-event";
 
 // Type-only, so it is erased and cannot be hoisted above the mock below.
@@ -29,12 +32,30 @@ vi.mock("../lib/routes", async (importOriginal) => {
       </button>
     </>
   );
-  return { ...real, screenFor: (route: string) => (route === "/applog" ? Fake : null) };
+  const Editor = () => {
+    const [draft, setDraft] = useState("initial manifest");
+    useEffect(() => { reading(); return () => { stopped(); }; }, []);
+    return <textarea aria-label="Manifest" value={draft} onChange={e => setDraft(e.target.value)} />;
+  };
+  return { ...real, screenFor: (route: string) => (route === "/applog" ? Fake : route.startsWith("/edit/") || route.startsWith("/new/") ? Editor : null) };
 });
 
 import { Body } from "./Body";
 
 describe("Body", () => {
+  it.each(["/edit/prod-eu/ConfigMap/default/example", "/new/prod-eu"])("preserves the draft and suspends effects while paused: %s", route => {
+    reading.mockClear(); stopped.mockClear();
+    const props = { route, ported: [], onOpenInClassic: () => {}, onLocked: () => {} };
+    const { rerender } = render(<Body {...props} />);
+    fireEvent.change(screen.getByRole("textbox", { name: "Manifest" }), { target: { value: "unsaved changes" } });
+    rerender(<Body {...props} pausedContext={{ name: "prod-eu", stableId: "prod", cluster: "prod", server: "", isCurrent: false, sourceFile: "", authKind: "token" }} />);
+    expect(screen.queryByRole("textbox", { name: "Manifest" })).toBeNull();
+    expect(stopped).toHaveBeenCalledTimes(1);
+    rerender(<Body {...props} />);
+    expect((screen.getByRole("textbox", { name: "Manifest" }) as HTMLTextAreaElement).value).toBe("unsaved changes");
+    expect(reading).toHaveBeenCalledTimes(2);
+  });
+
   it("renders the screen when one is registered for the route", () => {
     render(<Body route="/applog" ported={[]} onOpenInClassic={() => {}} onLocked={() => {}} />);
     expect(screen.getByText("screen for /applog")).toBeDefined();

--- a/packages/ui-next/src/shell/Body.test.tsx
+++ b/packages/ui-next/src/shell/Body.test.tsx
@@ -90,4 +90,18 @@ describe("Body", () => {
     await userEvent.click(screen.getByRole("button", { name: "seal from the screen" }));
     expect(onLocked).toHaveBeenCalledTimes(1);
   });
+
+  it("does not mount a pinned screen while its cluster is paused", () => {
+    render(
+      <Body
+        route="/applog"
+        ported={[]}
+        onOpenInClassic={() => {}}
+        onLocked={() => {}}
+        pausedContext={{ name: "prod-eu", stableId: "prod", cluster: "prod", server: "", isCurrent: false, sourceFile: "", authKind: "token" }}
+      />,
+    );
+    expect(screen.getByText("prod-eu is paused")).toBeDefined();
+    expect(screen.queryByText("screen for /applog")).toBeNull();
+  });
 });

--- a/packages/ui-next/src/shell/Body.tsx
+++ b/packages/ui-next/src/shell/Body.tsx
@@ -1,7 +1,16 @@
-import { screenFor } from "../lib/routes";
+import type { ClusterContext } from "@srelens/core";
+import { Button, EmptyState, Screen as AppScreen } from "@srelens/ui-kit";
+import { describe, screenFor } from "../lib/routes";
+import { reconnectCluster } from "../lib/openCluster";
 import { Placeholder, type PlaceholderProps } from "./Placeholder";
 
 export interface BodyProps extends PlaceholderProps {
+  /**
+   * The cluster pinned to this tab when it has been paused. Kept at the router
+   * boundary so even hidden, mounted tabs cannot keep capability readers
+   * alive after their cluster is disconnected.
+   */
+  pausedContext?: ClusterContext;
   /**
    * Raise the lock surface over the window. Forwarded to the screen untouched
    * — see `RoutedScreenProps.onLocked` for what the contract is and why it is
@@ -16,7 +25,20 @@ export interface BodyProps extends PlaceholderProps {
  * This is the whole of the router. Everything about which screens exist lives
  * in `screenFor`; this only asks.
  */
-export function Body({ onLocked, ...props }: BodyProps) {
+export function Body({ onLocked, pausedContext, ...props }: BodyProps) {
+  if (pausedContext) {
+    const title = describe(props.route, pausedContext.name).title;
+    return (
+      <AppScreen title={title} eyebrow={pausedContext.name} fill>
+        <EmptyState
+          title={`${pausedContext.name} is paused`}
+          hint="Reconnect this cluster to resume this view."
+          action={<Button variant="primary" onClick={() => reconnectCluster(pausedContext)}>Reconnect</Button>}
+          className="flex-1"
+        />
+      </AppScreen>
+    );
+  }
   const Screen = screenFor(props.route);
   return Screen ? (
     <Screen

--- a/packages/ui-next/src/shell/Body.tsx
+++ b/packages/ui-next/src/shell/Body.tsx
@@ -1,7 +1,9 @@
 import type { ClusterContext } from "@srelens/core";
+import { Activity } from "react";
 import { Button, EmptyState, Screen as AppScreen } from "@srelens/ui-kit";
 import { describe, screenFor } from "../lib/routes";
 import { reconnectCluster } from "../lib/openCluster";
+import { parseEditRoute, parseNewRoute } from "../lib/detailRoute";
 import { Placeholder, type PlaceholderProps } from "./Placeholder";
 
 export interface BodyProps extends PlaceholderProps {
@@ -26,9 +28,11 @@ export interface BodyProps extends PlaceholderProps {
  * in `screenFor`; this only asks.
  */
 export function Body({ onLocked, pausedContext, ...props }: BodyProps) {
+  const preserveDraft = !!parseEditRoute(props.route) || !!parseNewRoute(props.route) || props.route === "/new";
+  let pausedView = null;
   if (pausedContext) {
     const title = describe(props.route, pausedContext.name).title;
-    return (
+    pausedView = (
       <AppScreen title={title} eyebrow={pausedContext.name} fill>
         <EmptyState
           title={`${pausedContext.name} is paused`}
@@ -39,8 +43,9 @@ export function Body({ onLocked, pausedContext, ...props }: BodyProps) {
       </AppScreen>
     );
   }
+  if (pausedContext && !preserveDraft) return pausedView;
   const Screen = screenFor(props.route);
-  return Screen ? (
+  const content = Screen ? (
     <Screen
       route={props.route}
       // The same two the Placeholder beside it consumes, down the same path —
@@ -61,4 +66,10 @@ export function Body({ onLocked, pausedContext, ...props }: BodyProps) {
   ) : (
     <Placeholder {...props} />
   );
+  // Hidden Activity retains React state but cleans up effects and hides DOM.
+  // A paused editor therefore keeps its draft without keeping readers alive.
+  return preserveDraft ? <>
+    <Activity mode={pausedContext ? "hidden" : "visible"}>{content}</Activity>
+    {pausedView}
+  </> : content;
 }

--- a/packages/ui-next/src/shell/Console.test.tsx
+++ b/packages/ui-next/src/shell/Console.test.tsx
@@ -489,6 +489,36 @@ describe("Console", () => {
     expect(askAgent).not.toHaveBeenCalled();
   });
 
+  it("refuses both screen asks and typed questions for a paused cluster", async () => {
+    const user = userEvent.setup();
+    setup();
+    act(() => tabsStore.setClusterPaused(tabsStore.currentWorkspace().id, HARNESS_CTX.stableId, true));
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    const box = screen.getByRole("textbox", { name: "Console prompt" });
+    await user.type(box, "why is it failing");
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(askAgent).not.toHaveBeenCalled();
+    expect((box as HTMLTextAreaElement).value).toBe("why is it failing");
+    expect(screen.getByText(/Reconnect .* to send a question/)).toBeTruthy();
+  });
+
+  it("checks the selected conversation's cluster even when the rail is elsewhere", async () => {
+    const stage = ctx("stage-id", "staging");
+    setContexts([HARNESS_CTX, stage]);
+    tabsStore.setState(defaultState([HARNESS_CTX, stage]));
+    tabsStore.setActiveCluster(stage.stableId, stage.name);
+    tabsStore.setClusterPaused(tabsStore.currentWorkspace().id, HARNESS_CTX.stableId, true);
+    tabsStore.openTab("/agent");
+    useRunSubject.mockReturnValue({ about: { cluster: HARNESS_CTX.name }, route: "/overview" });
+    useActiveRunKey.mockReturnValue("prod-eu|overview");
+    render(<ConsoleProvider onToggleTheme={() => {}}><Console fullView /></ConsoleProvider>);
+    const box = screen.getByRole("textbox", { name: "Console prompt" });
+    await userEvent.type(box, "inspect prod");
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(askAgent).not.toHaveBeenCalled();
+    expect(screen.getByText("Reconnect prod-eu to send a question")).toBeTruthy();
+  });
+
   /**
    * Codex P1: this component renders `null` in a browser, but the guard sits
    * BELOW the effect that registers the submit handler — so a screen's own Ask
@@ -1188,13 +1218,14 @@ describe("Console — header details", () => {
     expect(screen.getByText("2 exchanges")).toBeDefined();
   });
 
-  it("wires the dock's Stop to the store, and only while a turn is in flight", async () => {
+  it.each([false, true])("keeps Stop wired to the store while a turn is in flight (paused: %s)", async (paused) => {
     const user = userEvent.setup();
     useRun.mockReturnValue(
       runState({ busy: true, turns: [{ id: 1, role: "user", text: "q", calls: [], at: 1 }] }),
     );
     setup();
     await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    if (paused) act(() => tabsStore.setClusterPaused(tabsStore.currentWorkspace().id, HARNESS_CTX.stableId, true));
     await user.click(screen.getByRole("button", { name: "Stop" }));
     expect(stopAgentRun).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui-next/src/shell/Console.tsx
+++ b/packages/ui-next/src/shell/Console.tsx
@@ -33,6 +33,7 @@ import { openTab, setActiveCluster, switchWorkspace, useTabs } from "../lib/tabs
 import { logsRoute } from "../screens/Logs";
 import { Transcript } from "../screens/agent/Transcript";
 import { useWorkspaceSealed } from "./LockGate";
+import { isContextPaused } from "../lib/pausedContext";
 
 /** §F's four palette groups, in the order the mock lists them. */
 const GROUPS: readonly CommandGroup[] = ["Action", "Go", "Cluster", "Workspace"];
@@ -268,6 +269,7 @@ export function Console({ fullView }: { fullView?: boolean }) {
   // `askAgent` will be given.
   const askAbout = shown?.about ?? about;
   const askCluster = askAbout.cluster || context;
+  const askPaused = contexts.some(c => c.name === askCluster && workspace.pausedClusters?.includes(c.stableId));
   const askScope = shown ? contextLabelFor(shown.route, shown.about.cluster) : scope;
 
   const deps = useMemo<CommandDeps>(
@@ -363,6 +365,12 @@ export function Console({ fullView }: { fullView?: boolean }) {
       return false;
     }
     setNoCluster(false);
+    // A selected conversation can target a different cluster from the rail.
+    // Check that actual target at submission time, before consuming the draft.
+    if (isContextPaused(askCluster)) {
+      setOpen(true);
+      return false;
+    }
     return true;
   }
 
@@ -688,6 +696,11 @@ export function Console({ fullView }: { fullView?: boolean }) {
           {noCluster && (
             <span className="chip" style={{ color: "var(--sev)" }}>
               <span>No cluster is active — connect one before asking</span>
+            </span>
+          )}
+          {askPaused && (
+            <span className="chip">
+              <span>Reconnect {askCluster} to send a question</span>
             </span>
           )}
           {reading > 0 && (

--- a/packages/ui-next/src/shell/Nav.tsx
+++ b/packages/ui-next/src/shell/Nav.tsx
@@ -76,20 +76,21 @@ export function Nav({ contexts }: NavProps) {
 
   // Subscribes the sidebar to the strip: which row is highlighted is a fact
   // about the active tab, and that changes from a dozen places that are not here.
-  const { tabs, activeId } = useTabs();
+  const { tabs, activeId, workspace } = useTabs();
   const route = tabs.find((t) => t.id === activeId)?.route ?? "/";
 
   const name = ctx?.name;
+  const paused = ctx !== null && (workspace.pausedClusters ?? []).includes(ctx.stableId);
   const discovery = useResource<CrdRef[]>(
     async () => {
-      if (!name) return [];
+      if (!name || paused) return [];
       const out = await listCrds(name);
       // `listCrds` reports failure in the result rather than by rejecting, and
       // an empty tree is not the same news as "we were not allowed to look".
       if (out.error) throw new Error(out.error);
       return out.crds ?? [];
     },
-    [name],
+    [name, paused],
   );
   const crds = useMemo(() => discovery.data ?? [], [discovery.data]);
 
@@ -118,7 +119,9 @@ export function Nav({ contexts }: NavProps) {
     [crds, crdChildren],
   );
 
-  const link = ctx ? (view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN) : UNKNOWN;
+  const link = ctx
+    ? (paused ? { word: "Paused", kind: "neutral" as const } : view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN)
+    : UNKNOWN;
 
   const navigationWidth = useNavigationWidth();
 

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -49,8 +49,8 @@ function setup(props: Partial<Parameters<typeof Rail>[0]> = {}) {
 }
 
 /** Right-click a mark and wait for the menu that names it. */
-async function openMenu(cluster: string) {
-  fireEvent.contextMenu(screen.getByRole("button", { name: cluster }));
+async function openMenu(cluster: string, buttonName = cluster) {
+  fireEvent.contextMenu(screen.getByRole("button", { name: buttonName }));
   return screen.findByRole("menu", { name: `${cluster} actions` });
 }
 
@@ -108,7 +108,7 @@ describe("Rail", () => {
     const items = within(menu)
       .getAllByRole("menuitem")
       .map((item) => item.getAttribute("aria-label"));
-    expect(items).toEqual(["Open prod-eu", "Customise…", "Connection details", "Remove from workspace"]);
+    expect(items).toEqual(["Open prod-eu", "Customise…", "Disconnect", "Connection details", "Remove from workspace"]);
     expect(screen.queryByRole("complementary", { name: "Details" })).toBeNull();
   });
 
@@ -169,6 +169,25 @@ describe("Rail", () => {
     setup();
     await pick("prod-eu", "Connection details");
     expect(currentWorkspace().tabs.map((t) => t.route)).toContain("/connections");
+  });
+
+  it("pauses a cluster in place and offers Reconnect from the same menu", async () => {
+    setup();
+    await pick("prod-eu", "Disconnect");
+    expect(currentWorkspace().clusters).toContain("prod-eu");
+    expect(currentWorkspace().pausedClusters).toEqual(["prod-eu"]);
+    expect(screen.getByRole("button", { name: "prod-eu, Paused" })).toBeDefined();
+    const menu = await openMenu("prod-eu", "prod-eu, Paused");
+    expect(within(menu).getByRole("menuitem", { name: "Reconnect" })).toBeDefined();
+  });
+
+  it("does not describe a paused cluster as connecting", async () => {
+    setLink("prod-eu", "connecting");
+    setup();
+    const menu = await openMenu("prod-eu", "prod-eu, Connecting");
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Disconnect" }));
+    expect(screen.getByRole("button", { name: "prod-eu, Paused" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Connecting/ })).toBeNull();
   });
 
   it("removes the cluster from the workspace", async () => {

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen, fireEvent, waitFor, within } from "@testing-librar
 import userEvent from "@testing-library/user-event";
 import type { ClusterContext } from "@srelens/core";
 import { Rail } from "./Rail";
-import { activeCluster, currentWorkspace, openTab, setState } from "../lib/tabsStore";
+import { activeCluster, activeRoute, currentWorkspace, openTab, setState } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 import { resetView, setLink } from "../lib/workspace";
 import { defaultMark, getMark, loadMarks, setMark } from "../lib/marks";
@@ -70,6 +70,7 @@ describe("Rail", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "staging" }));
     expect(activeCluster()).toBe("staging");
+    expect(activeRoute()).toBe("/overview");
   });
 
   it("says why a cluster is out of reach in its name, classified rather than quoted", () => {
@@ -115,6 +116,7 @@ describe("Rail", () => {
     setup();
     await pick("staging", "Open staging");
     expect(activeCluster()).toBe("staging");
+    expect(activeRoute()).toBe("/overview");
   });
 
   /**
@@ -144,7 +146,7 @@ describe("Rail", () => {
 
     expect(activeCluster()).toBe("id-stage");
     const subs = currentWorkspace().tabs.map((t) => t.sub);
-    expect(subs).toEqual(["staging-eu", "staging-eu", "staging-eu"]);
+    expect(subs).toEqual([undefined, "staging-eu", "staging-eu"]);
     expect(subs).not.toContain("id-stage");
   });
 
@@ -160,7 +162,7 @@ describe("Rail", () => {
     await pick("staging-eu", "Open staging-eu");
 
     expect(activeCluster()).toBe("id-stage");
-    expect(currentWorkspace().tabs.map((t) => t.sub)).toEqual(["staging-eu", "staging-eu"]);
+    expect(currentWorkspace().tabs.map((t) => t.sub)).toEqual([undefined, "staging-eu"]);
   });
 
   it("opens the Connections tab", async () => {

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -15,7 +15,7 @@ import {
 import { friendly } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { getMark, resetMark, setMark, useEditableMark } from "../lib/marks";
-import { openCluster } from "../lib/openCluster";
+import { openCluster, pauseCluster, reconnectCluster } from "../lib/openCluster";
 import { useInfos } from "../lib/probe";
 import { openTab, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { useWorkspaceView } from "../lib/workspace";
@@ -52,17 +52,10 @@ const MAX_IMAGE_BYTES = 64 * 1024;
  * only covers the window between a kubeconfig changing and the store catching
  * up, and a mark for a cluster that is not there is worse than one mark fewer.
  *
- * What the menu offers, and what it deliberately does not. The design draws a
- * `Disconnect` in the destructive slot, and there is nothing behind that verb:
- * core connects (`connectCluster`, which is a probe) and deletes a context out
- * of the kubeconfig on disk (`deleteContext`, which is a far larger act than
- * this menu implies), and the `disconnected` link state is derived from a
- * probe's answer and re-derived by the next one — writing it by hand would be
- * a claim the next probe erases. So the item keeps the name of what it really
- * does, which is to drop the cluster from this workspace; a red row wired to
- * the nearest available verb is worse than an honest one. `Connection details`
- * opens `/connections`, which is a route this shell already knows and titles,
- * though the screen behind it is still the Placeholder.
+ * Disconnect is a persisted pause, not a made-up connection state: it leaves
+ * the cluster in this workspace and stops future probes until Reconnect asks
+ * for one. Its `Paused` label is intentionally distinct from a probe that
+ * found an unreachable cluster. `Connection details` opens `/connections`.
  *
  * The marks and the probes are read once for the whole list rather than once
  * per cluster: the number of clusters changes between renders, so a hook per
@@ -105,6 +98,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
     const mark = getMark(id, ctx.name);
     const info = infos[id];
     const link = links[id];
+    const paused = workspace.pausedClusters?.includes(id) === true;
     items.push({
       id,
       name: mark.name,
@@ -138,14 +132,16 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
       // is not offered here because there is nowhere in a 46px strip to offer
       // it from; the overview's Fleet row for the same cluster has it.
       unavailable:
-        link?.state === "error"
+        paused
+          ? "Paused"
+          : link?.state === "error"
           ? link.error
             ? friendly(link.error).title
             : "Unreachable"
           : link?.state === "disconnected"
             ? "Disconnected"
             : undefined,
-      markers: link?.state === "connecting" ? [{ label: "Connecting", tone: "info" }] : [],
+      markers: !paused && link?.state === "connecting" ? [{ label: "Connecting", tone: "info" }] : [],
       color: mark.color,
     });
   }
@@ -164,6 +160,13 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
     setEditing(null);
   }
 
+  function toggleConnection(id: string) {
+    const context = byId.get(id);
+    if (!context) return;
+    if (workspace.pausedClusters?.includes(id)) reconnectCluster(context);
+    else pauseCluster(workspace.id, id);
+  }
+
   function menuFor(item: ClusterRailItem): ContextMenuItem[] {
     return [
       { label: `Open ${item.name}`, onPick: () => select(item.id) },
@@ -171,6 +174,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
       // anything happens — it opens the dialog below.
       { label: "Customise…", icon: Icons.edit, onPick: () => setEditing(item.id) },
       { kind: "sep" },
+      { label: workspace.pausedClusters?.includes(item.id) ? "Reconnect" : "Disconnect", onPick: () => toggleConnection(item.id) },
       { label: "Connection details", onPick: () => openTab("/connections") },
       // Named for what it does. See the note above on the design's Disconnect.
       { label: "Remove from workspace", icon: Icons.trash, danger: true, onPick: () => remove(item.id) },

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -15,8 +15,9 @@ import {
 import { friendly } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { getMark, resetMark, setMark, useEditableMark } from "../lib/marks";
+import { openCluster } from "../lib/openCluster";
 import { useInfos } from "../lib/probe";
-import { openTab, setActiveCluster, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
+import { openTab, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { useWorkspaceView } from "../lib/workspace";
 
 export interface RailProps {
@@ -149,21 +150,10 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
     });
   }
 
-  /**
-   * Switch the rail's cluster, and hand the store the name the strip needs.
-   *
-   * `setActiveCluster` takes a stableId — that is what a workspace holds (#265)
-   * — but a tab's label is the context's NAME, and the store cannot translate
-   * between the two (`lib/clusters` imports it, not the other way round). The
-   * rail already has both, in `byId`, so the name is passed from here. Without
-   * it every cluster-scoped tab kept the label of the cluster switched away
-   * from while the mounted screen rendered the new one.
-   *
-   * Both ways in go through this: the click on a mark and the menu's `Open`.
-   * They are one gesture, and fixing one is how the two start disagreeing.
-   */
+  /** Selecting a cluster has the same destination as opening it from Home or Connections. */
   function select(id: string) {
-    setActiveCluster(id, byId.get(id)?.name);
+    const context = byId.get(id);
+    if (context) openCluster(context);
   }
 
   function remove(id: string) {

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -89,6 +89,12 @@ async function connect(version: string | null) {
 }
 
 describe("Status", () => {
+  it("does not assert disconnection before a cluster has been checked", () => {
+    setState(defaultState([ctx]));
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByText("Not checked")).toBeTruthy();
+    expect(screen.queryByText("Disconnected")).toBeNull();
+  });
   it("says so when no cluster is active", () => {
     setState(defaultState([]));
     mount(<Status contexts={[]} />);

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -12,7 +12,7 @@ import { useConsole } from "../console";
 import { getHelmOps, subscribeHelmOps } from "../lib/helmOps";
 import { useInfo } from "../lib/probe";
 import { getSessions, subscribeSessions } from "../lib/sessions";
-import { openTab, useActiveCluster } from "../lib/tabsStore";
+import { openTab, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { useWorkspaceSealed } from "./LockGate";
 // The words and their tones live beside `LinkState` rather than here: the
 // overview rail reads the same link and must say the same thing about it.
@@ -83,6 +83,7 @@ import { LINK_TONE, LINK_WORD, useWorkspaceView } from "../lib/workspace";
  */
 export function Status({ contexts }: { contexts: ClusterContext[] }) {
   const activeId = useActiveCluster();
+  const { workspace } = useTabs();
   const sealed = useWorkspaceSealed();
   const info = useInfo(activeId);
   const { links } = useWorkspaceView();
@@ -94,9 +95,9 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // Found rather than assumed: the active id is persisted and the context list
   // is whatever the machine has now, so an id can outlive the context it named.
   const ctx = contexts.find((c) => c.stableId === activeId);
-  // Nothing has probed yet, or there is nothing to probe. Either way the link
-  // is not up, and "Disconnected" is the honest reading of that.
-  const state = (activeId ? links[activeId]?.state : undefined) ?? "disconnected";
+  // Absence of a probe is not evidence of a failed connection.
+  const state = activeId ? links[activeId]?.state : undefined;
+  const paused = activeId !== null && (workspace.pausedClusters ?? []).includes(activeId);
   // Split rather than counted blind. A tunnel that gave up is still in the
   // store — it stays on the forwards screen until its reader dismisses it —
   // and counting it here would report a dead tunnel as one of the ones
@@ -140,7 +141,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
       id: "ctx",
       label: ctx ? mark.name : "No cluster",
       dot: true,
-      tone: LINK_TONE[state],
+      tone: paused || state === undefined ? "muted" : LINK_TONE[state],
       // Pressable only when there is a cluster to open. A "No cluster" button
       // that opens an overview of nothing is a dead end dressed as a way out.
       onSelect: ctx ? () => openTab("/overview", { clusterName: ctx.name }) : undefined,
@@ -155,7 +156,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   }
   // Pulsing only while connecting: the dot is animated for a readout that is
   // still changing, not for one that merely happens to be current.
-  segments.push({ id: "link", label: LINK_WORD[state], pulse: state === "connecting" });
+  segments.push({ id: "link", label: paused ? "Paused" : state === undefined ? "Not checked" : LINK_WORD[state], pulse: !paused && state === "connecting" });
 
   const end: StatusSegment[] = [];
   // Only when there is one, and this is the exception to the rule the version

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -260,49 +260,25 @@ async function booted() {
 }
 
 describe("Window boot", () => {
-  it("opens the active cluster overview after the initial connection succeeds", async () => {
-    connectCluster.mockResolvedValue({ context: "prod", reachable: true });
+  it("keeps the agent console mounted when its explicitly scoped cluster is paused", async () => {
     await booted();
-    await waitFor(() => expect(store.activeRoute()).toBe("/overview"));
-    expect(store.currentWorkspace().tabs.filter(tab => tab.route === "/overview")).toHaveLength(1);
+    act(() => { store.openTab("/agent", { clusterName: "prod" }); });
+    expect(screen.getByRole("textbox", { name: "Console prompt" })).toBeDefined();
+    act(() => { store.setClusterPaused(store.currentWorkspace().id, "prod", true); });
+    expect(screen.getByRole("textbox", { name: "Console prompt" })).toBeDefined();
   });
 
-  it("keeps Home when the active cluster cannot connect, even if another can", async () => {
+  it("does not contact configured clusters until the reader opens one", async () => {
     listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("stage")] });
-    connectCluster.mockImplementation(async (name: string) => ({ context: name, reachable: name === "stage" }));
     await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalledTimes(2));
-    expect(store.activeRoute()).toBe("/");
-    expect(screen.getByRole("heading", { name: "Home", level: 1 })).toBeTruthy();
-  });
-
-  it("does not replace work opened while the initial cluster connection is pending", async () => {
-    let resolve!: (value: unknown) => void;
-    connectCluster.mockReturnValue(new Promise(done => { resolve = done; }));
-    await booted();
-    act(() => { store.openTab("/settings"); });
-    await act(async () => resolve({ context: "prod", reachable: true }));
-    expect(store.activeRoute()).toBe("/settings");
-    expect(store.currentWorkspace().tabs.some(tab => tab.route === "/overview")).toBe(false);
-  });
-
-  it("keeps a restored tab active after connecting", async () => {
-    connectCluster.mockResolvedValue({ context: "prod", reachable: true });
-    const saved = defaultState([ctx("prod")]);
-    const tab = makeTab("/settings");
-    saved.workspaces[0].tabs.push(tab);
-    saved.workspaces[0].activeId = tab.id;
-    loadTabsState.mockReturnValue(saved);
-    await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalled());
-    expect(store.activeRoute()).toBe("/settings");
+    expect(connectCluster).not.toHaveBeenCalled();
   });
 
   it("keeps a restored Home tab active after connecting", async () => {
     connectCluster.mockResolvedValue({ context: "prod", reachable: true });
     loadTabsState.mockReturnValue(defaultState([ctx("prod")]));
     await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalled());
+    expect(connectCluster).not.toHaveBeenCalled();
     expect(store.activeRoute()).toBe("/");
   });
 
@@ -665,7 +641,7 @@ describe("Window accelerators", () => {
     expect(store.currentWorkspace().tabs).toHaveLength(1);
   });
 
-  it("probes each cluster of the workspace once at boot", async () => {
+  it("does not probe workspace clusters at boot", async () => {
     listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
     render(
       <ConsoleProvider>
@@ -673,8 +649,7 @@ describe("Window accelerators", () => {
       </ConsoleProvider>,
     );
     await screen.findByRole("tablist");
-    await waitFor(() => expect(connectCluster).toHaveBeenCalledTimes(2));
-    expect(connectCluster.mock.calls.map((c) => c[0])).toEqual(["prod", "dev"]);
+    expect(connectCluster).not.toHaveBeenCalled();
   });
 
   it("probes a configured cluster when Home adds it to the workspace", async () => {
@@ -682,7 +657,7 @@ describe("Window accelerators", () => {
     loadTabsState.mockReturnValue(saved);
     listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
     await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("prod"));
+    expect(connectCluster).not.toHaveBeenCalled();
     act(() => openCluster(ctx("dev")));
     await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("dev"));
   });

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -260,6 +260,28 @@ async function booted() {
 }
 
 describe("Window boot", () => {
+  it.each([false, true])("probes only an unpaused restored active resource tab (paused: %s)", async paused => {
+    listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("stage")] });
+    const saved = defaultState([ctx("prod"), ctx("stage")]);
+    const tab = makeTab("/overview", { clusterName: "prod" });
+    saved.workspaces[0].tabs.push(tab);
+    saved.workspaces[0].activeId = tab.id;
+    saved.workspaces[0].pausedClusters = paused ? ["prod"] : [];
+    loadTabsState.mockReturnValue(saved);
+    await booted();
+    if (paused) expect(connectCluster).not.toHaveBeenCalled();
+    else {
+      await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("prod"));
+      expect(connectCluster).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("probes a cluster when its overview is opened directly", async () => {
+    await booted();
+    act(() => { store.openTab("/overview", { clusterName: "prod" }); });
+    await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("prod"));
+  });
+
   it("keeps the agent console mounted when its explicitly scoped cluster is paused", async () => {
     await booted();
     act(() => { store.openTab("/agent", { clusterName: "prod" }); });

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -189,6 +189,7 @@ import { defaultMark, getMark, setMark, MARKS_KEY } from "../lib/marks";
 import { contextFor, getContextsError, getContextsStatus, resetContexts } from "../lib/clusters";
 import { resetLock } from "./LockGate";
 import { mcpAutoStartPhase, resetMcpAutoStart } from "../lib/mcpAutoStart";
+import { openCluster } from "../lib/openCluster";
 
 /** An open vault: the state every test in this file but the lock ones needs. */
 const VAULT_OPEN = {
@@ -666,6 +667,16 @@ describe("Window accelerators", () => {
     await screen.findByRole("tablist");
     await waitFor(() => expect(connectCluster).toHaveBeenCalledTimes(2));
     expect(connectCluster.mock.calls.map((c) => c[0])).toEqual(["prod", "dev"]);
+  });
+
+  it("probes a configured cluster when Home adds it to the workspace", async () => {
+    const saved = defaultState([ctx("prod")]);
+    loadTabsState.mockReturnValue(saved);
+    listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
+    await booted();
+    await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("prod"));
+    act(() => openCluster(ctx("dev")));
+    await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("dev"));
   });
 
   it("offers Close others on a tab's context menu", async () => {

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -300,6 +300,7 @@ describe("Window boot", () => {
   it("loads the cluster's saved sidebar groups before navigation mounts", async () => {
     localStorage.setItem(EXPANDED_KEY, JSON.stringify({ prod: ["network"], offline: ["workloads"] }));
     await booted();
+    act(() => { store.openTab("/overview"); });
     expect(screen.getByRole("treeitem", { name: "Services" })).toBeDefined();
     expect(screen.queryByRole("treeitem", { name: "Pods" })).toBeNull();
     await userEvent.click(screen.getByRole("treeitem", { name: "Workloads" }));

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { fireEvent } from "@testing-library/react";
 
@@ -215,7 +215,7 @@ beforeEach(() => {
   listContexts.mockReset().mockResolvedValue({ contexts: [ctx("prod")] });
   loadTabsState.mockReset().mockReturnValue(null);
   scheduleSave.mockReset();
-  connectCluster.mockReset().mockImplementation(async (name: string) => ({ context: name, reachable: true, version: "1.30" }));
+  connectCluster.mockReset().mockImplementation(async (name: string) => ({ context: name, reachable: false }));
   listCrds.mockReset().mockResolvedValue({ crds: [] });
   getForwards.mockReset().mockReturnValue([]);
   subscribeForwards.mockReset().mockReturnValue(() => {});
@@ -255,10 +255,48 @@ async function booted() {
       <Window ported={[]} onOpenInClassic={() => {}} />
     </ConsoleProvider>,
   );
-  await waitFor(() => expect(screen.getByRole("tablist")).toBeDefined());
+  await waitFor(() => expect(screen.getByRole("tablist", { name: "Open tabs" })).toBeDefined());
 }
 
 describe("Window boot", () => {
+  it("opens the active cluster overview after the initial connection succeeds", async () => {
+    connectCluster.mockResolvedValue({ context: "prod", reachable: true });
+    await booted();
+    await waitFor(() => expect(store.activeRoute()).toBe("/overview"));
+    expect(store.currentWorkspace().tabs.filter(tab => tab.route === "/overview")).toHaveLength(1);
+  });
+
+  it("keeps Home when the active cluster cannot connect, even if another can", async () => {
+    listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("stage")] });
+    connectCluster.mockImplementation(async (name: string) => ({ context: name, reachable: name === "stage" }));
+    await booted();
+    await waitFor(() => expect(connectCluster).toHaveBeenCalledTimes(2));
+    expect(store.activeRoute()).toBe("/");
+    expect(screen.getByRole("heading", { name: "Home", level: 1 })).toBeTruthy();
+  });
+
+  it("does not replace work opened while the initial cluster connection is pending", async () => {
+    let resolve!: (value: unknown) => void;
+    connectCluster.mockReturnValue(new Promise(done => { resolve = done; }));
+    await booted();
+    act(() => { store.openTab("/settings"); });
+    await act(async () => resolve({ context: "prod", reachable: true }));
+    expect(store.activeRoute()).toBe("/settings");
+    expect(store.currentWorkspace().tabs.some(tab => tab.route === "/overview")).toBe(false);
+  });
+
+  it("keeps a restored tab active after connecting", async () => {
+    connectCluster.mockResolvedValue({ context: "prod", reachable: true });
+    const saved = defaultState([ctx("prod")]);
+    const tab = makeTab("/settings");
+    saved.workspaces[0].tabs.push(tab);
+    saved.workspaces[0].activeId = tab.id;
+    loadTabsState.mockReturnValue(saved);
+    await booted();
+    await waitFor(() => expect(connectCluster).toHaveBeenCalled());
+    expect(store.activeRoute()).toBe("/settings");
+  });
+
   it("builds a Default workspace from the contexts when nothing was saved", async () => {
     await booted();
     expect(store.getState().workspaces[0].name).toBe("Default");
@@ -343,7 +381,7 @@ describe("Window boot", () => {
     listContexts.mockResolvedValue({ error: "kubeconfig unreadable" });
     await booted();
     expect(store.getState().workspaces.length).toBeGreaterThan(0);
-    expect(screen.getByRole("tablist")).toBeDefined();
+    expect(screen.getByRole("tablist", { name: "Open tabs" })).toBeDefined();
   });
 
   it("boots to a live window when the saved currentId names a workspace that did not parse and the cluster list also errors", async () => {
@@ -384,7 +422,7 @@ describe("Window boot", () => {
     saved.workspaces[0].tabs.push(makeTab("/k/Pod/default/%zz"));
     loadTabsState.mockReturnValue(saved);
     await booted();
-    expect(screen.getByRole("tablist")).toBeDefined();
+    expect(screen.getByRole("tablist", { name: "Open tabs" })).toBeDefined();
     expect(store.currentWorkspace().tabs.some((t) => t.route === "/k/Pod/default/%zz")).toBe(true);
   });
 
@@ -404,7 +442,7 @@ describe("Window boot", () => {
         <Window ported={[]} onOpenInClassic={() => {}} />
       </ConsoleProvider>,
     );
-    await waitFor(() => expect(screen.getByRole("tablist")).toBeDefined());
+    await waitFor(() => expect(screen.getByRole("tablist", { name: "Open tabs" })).toBeDefined());
     act(() => store.openTab("/k/pods"));
     expect(flushSave).not.toHaveBeenCalled();
     view.unmount();
@@ -481,7 +519,7 @@ describe("Window strip", () => {
     expect(screen.getAllByRole("tab")).toHaveLength(2);
     // Both bodies are mounted; only the active is visible.
     const headings = screen.getAllByRole("heading", { level: 1, hidden: true });
-    expect(headings.map((h) => h.textContent)).toEqual(["Control room", "Pods"]);
+    expect(headings.map((h) => h.textContent)).toEqual(["Home", "Pods"]);
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
     expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Pods");
   });
@@ -489,8 +527,8 @@ describe("Window strip", () => {
   it("selecting a tab switches the body", async () => {
     await booted();
     act(() => store.openTab("/k/pods"));
-    await userEvent.click(screen.getByRole("tab", { name: /Control room/ }));
-    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Control room");
+    await userEvent.click(screen.getByRole("tab", { name: /Home/ }));
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Home");
   });
 
   it("closing a tab goes through the store", async () => {
@@ -506,16 +544,12 @@ describe("Window strip", () => {
     expect(store.currentWorkspace().tabs.map((t) => t.route)).toEqual(["/", "/"]);
   });
 
-  it("names the workspace's active cluster on a new tab", async () => {
-    // `contexts[0]` would have been whichever context the kubeconfig lists
-    // first — not the current one, and not necessarily even in this
-    // workspace. The active cluster is what a new tab is about, so its name
-    // is what the tab carries.
+  it("keeps new Home tabs app-scoped even when a cluster is active", async () => {
     listContexts.mockResolvedValue({ contexts: [ctx("prod", "prod-eu")] });
     await booted();
     await userEvent.click(screen.getByRole("button", { name: /new tab/i }));
     const opened = store.currentWorkspace().tabs.at(-1)!;
-    expect(opened.sub).toBe("prod-eu");
+    expect(opened.sub).toBeUndefined();
   });
 
   it("hands the Placeholder the way back to classic, with the cluster", async () => {
@@ -525,9 +559,10 @@ describe("Window strip", () => {
         <Window ported={[]} onOpenInClassic={onOpenInClassic} />
       </ConsoleProvider>,
     );
-    await waitFor(() => expect(screen.getByRole("tablist")).toBeDefined());
+    await waitFor(() => expect(screen.getByRole("tablist", { name: "Open tabs" })).toBeDefined());
+    act(() => store.openTab("/incidents"));
     await userEvent.click(screen.getByRole("button", { name: /open in classic/i }));
-    expect(onOpenInClassic).toHaveBeenCalledWith("/", "prod");
+    expect(onOpenInClassic).toHaveBeenCalledWith("/incidents", "prod");
   });
 });
 
@@ -547,7 +582,7 @@ describe("Window — the console dock's scope", () => {
         <Window ported={[]} onOpenInClassic={() => {}} />
       </ConsoleProvider>,
     );
-    await waitFor(() => expect(screen.getByRole("tablist")).toBeDefined());
+    await waitFor(() => expect(screen.getByRole("tablist", { name: "Open tabs" })).toBeDefined());
   }
 
   it("scopes the dock to the active cluster on boot, then to a resource once one is open", async () => {
@@ -572,12 +607,12 @@ describe("Window — the console dock's scope", () => {
 });
 
 describe("Window accelerators", () => {
-  it("binds ⌘T to a new tab carrying the active cluster's name", async () => {
+  it("binds ⌘T to an app-wide Home tab", async () => {
     await booted();
     fireEvent.keyDown(window, { key: "t", metaKey: true });
     const tabs = store.currentWorkspace().tabs;
     expect(tabs).toHaveLength(2);
-    expect(tabs.at(-1)!.sub).toBe("prod");
+    expect(tabs.at(-1)!.sub).toBeUndefined();
   });
 
   it("⌘W closes the active tab and ⌘⇧T reopens it", async () => {
@@ -603,7 +638,7 @@ describe("Window accelerators", () => {
         <Window ported={[]} onOpenInClassic={() => {}} active={false} />
       </ConsoleProvider>,
     );
-    await screen.findByText(/not in the new design yet/);
+    await screen.findByRole("heading", { level: 1, name: "Home" });
     expect(screen.queryByRole("tablist")).toBeNull();
     fireEvent.keyDown(window, { key: "t", metaKey: true });
     expect(store.currentWorkspace().tabs).toHaveLength(1);
@@ -763,7 +798,7 @@ describe("Window lock cover", () => {
     await booted();
     expect(screen.getByRole("tablist")).toBeTruthy();
     expect(screen.getByRole("navigation", { name: "Clusters" })).toBeTruthy();
-    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Control room");
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Home");
     expect(screen.queryByText("Workspace locked")).toBeNull();
   });
 
@@ -780,7 +815,7 @@ describe("Window lock cover", () => {
     expect(screen.queryByRole("navigation", { name: "Clusters" })).toBeNull();
     // The screen under the strip is gone too — including from the hidden tab
     // surfaces, which stay mounted for every other reason.
-    expect(screen.queryByRole("heading", { level: 1, hidden: true, name: "Control room" })).toBeNull();
+    expect(screen.queryByRole("heading", { level: 1, hidden: true, name: "Home" })).toBeNull();
   });
 
   it("seals and covers on the lock chord", async () => {
@@ -880,7 +915,7 @@ describe("Window — what the cover has to take with it", () => {
 
   it("offers no way into Settings from the titlebar while the cover is up", async () => {
     await sealed();
-    const gear = screen.getByRole("button", { name: "Settings" }) as HTMLButtonElement;
+    const gear = within(screen.getByRole("banner", { name: "Window" })).getByRole("button", { name: "Settings" }) as HTMLButtonElement;
     expect(gear.disabled).toBe(true);
     await userEvent.click(gear);
     expect(store.currentWorkspace().tabs.some((t) => t.route === "/settings")).toBe(false);
@@ -942,7 +977,7 @@ describe("Window — what the cover has to take with it", () => {
     await userEvent.click(screen.getByRole("button", { name: "Unlock workspace" }));
     await screen.findByRole("tablist");
     expect(
-      (screen.getByRole("button", { name: "Settings" }) as HTMLButtonElement).disabled,
+      (within(screen.getByRole("banner", { name: "Window" })).getByRole("button", { name: "Settings" }) as HTMLButtonElement).disabled,
     ).toBe(false);
     expect(screen.getByRole("button", { name: /Default/ })).toBeTruthy();
     expect(
@@ -996,7 +1031,7 @@ describe("Window — the launch check, before the vault has answered", () => {
 
   it("offers no way into Settings for the whole check", async () => {
     await stillChecking();
-    const gear = screen.getByRole("button", { name: "Settings" }) as HTMLButtonElement;
+    const gear = within(screen.getByRole("banner", { name: "Window" })).getByRole("button", { name: "Settings" }) as HTMLButtonElement;
     expect(gear.disabled).toBe(true);
     await userEvent.click(gear);
     expect(store.currentWorkspace().tabs.some((t) => t.route === "/settings")).toBe(false);
@@ -1029,7 +1064,7 @@ describe("Window — the launch check, before the vault has answered", () => {
   it("gives every one of those back once the launch read says the vault is open", async () => {
     await booted();
     expect(
-      (screen.getByRole("button", { name: "Settings" }) as HTMLButtonElement).disabled,
+      (within(screen.getByRole("banner", { name: "Window" })).getByRole("button", { name: "Settings" }) as HTMLButtonElement).disabled,
     ).toBe(false);
     expect(screen.getByRole("button", { name: /Default/ })).toBeTruthy();
     expect(

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -298,6 +298,14 @@ describe("Window boot", () => {
     expect(store.activeRoute()).toBe("/settings");
   });
 
+  it("keeps a restored Home tab active after connecting", async () => {
+    connectCluster.mockResolvedValue({ context: "prod", reachable: true });
+    loadTabsState.mockReturnValue(defaultState([ctx("prod")]));
+    await booted();
+    await waitFor(() => expect(connectCluster).toHaveBeenCalled());
+    expect(store.activeRoute()).toBe("/");
+  });
+
   it("loads the cluster's saved sidebar groups before navigation mounts", async () => {
     localStorage.setItem(EXPANDED_KEY, JSON.stringify({ prod: ["network"], offline: ["workloads"] }));
     await booted();

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -47,6 +47,7 @@ import {
   useTabs,
 } from "../lib/tabsStore";
 import { useConsole } from "../console";
+import { openCluster } from "../lib/openCluster";
 import { getInfo, probeCluster } from "../lib/probe";
 import { hint, matchWindowKey, type WindowAction } from "../lib/shortcuts";
 import { AgentConsent } from "./AgentConsent";
@@ -101,6 +102,10 @@ export function Window({
   active = true,
 }: WindowProps) {
   const [booted, setBooted] = useState(false);
+  const mounted = useRef(false);
+  const visible = useRef(active);
+  visible.current = active;
+  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
   /**
    * The vault is usable, as `LockGate` reports it — classic's `vaultReady`, by
    * the same name and for the same one consumer. Flipped once per window; see
@@ -261,11 +266,26 @@ export function Window({
   // state and the status bar shows a version without waiting to be asked. The
   // effect runs per workspace rather than per render — switching away and back
   // re-runs it, and the probe store's memory is what keeps it to once each.
+  const startupOverviewOffered = useRef(false);
   const workspaceId = workspace.id;
   useEffect(() => {
     if (!booted) return;
     if (!active) return;
     const byId = new Map(contexts.map((c) => [c.stableId, c]));
+    // Only the untouched initial Home is a default destination. A slow probe
+    // must never replace a restored tab or navigation performed while it waits.
+    if (!startupOverviewOffered.current) {
+      startupOverviewOffered.current = true;
+      const initialState = getState();
+      const initialWorkspace = currentWorkspace();
+      const ctx = byId.get(initialWorkspace.activeCluster ?? "");
+      if (ctx && initialWorkspace.tabs.length === 1 && initialWorkspace.tabs[0].route === "/") {
+        const ready = getInfo(ctx.stableId) ? Promise.resolve() : probeCluster(ctx);
+        void ready.then(() => {
+          if (mounted.current && visible.current && getState() === initialState && getInfo(ctx.stableId)?.reachable) openCluster(ctx);
+        });
+      }
+    }
     for (const id of currentWorkspace().clusters) {
       if (getInfo(id)) continue;
       const ctx = byId.get(id);
@@ -527,7 +547,7 @@ export function Window({
       {active && (
         <Rail contexts={contexts} error={contextsError || undefined} onConnect={() => openTab("/connect")} />
       )}
-      {active && <Nav contexts={contexts} />}
+      {active && activeTabRoute !== "/" && <Nav contexts={contexts} />}
       {/* `min-w-0` as well as `min-h-0`. This column holds the tab strip
           and the screen, and a flex item's implicit `min-width: auto`
           refuses to shrink below its content — so a wide screen widens the

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -268,6 +268,7 @@ export function Window({
   // re-runs it, and the probe store's memory is what keeps it to once each.
   const startupOverviewOffered = useRef(false);
   const workspaceId = workspace.id;
+  const workspaceClusterIds = workspace.clusters.join("\u0000");
   useEffect(() => {
     if (!booted) return;
     if (!active) return;
@@ -293,7 +294,7 @@ export function Window({
     }
     // `contexts` rides along because a kubeconfig change replaces them; the
     // workspace id is the trigger for the switch case.
-  }, [booted, contexts, workspaceId, active]);
+  }, [booted, contexts, workspaceId, workspaceClusterIds, active]);
 
   /**
    * Which accelerators survive a raised cover, and why one of them does.

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -23,6 +23,8 @@ import { loadPeekWidth } from "../lib/peekWidth";
 import { loadSectionFolds } from "../lib/sectionFolds";
 import { loadExpanded, loadNamespaces } from "../lib/workspace";
 import { defaultState, reconcile } from "../lib/tabs";
+import { parseEditRoute, parseNewRoute } from "../lib/detailRoute";
+import { isClusterScopedRoute, keepsManagementWhenPaused } from "../lib/routes";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
 import {
   activateTab,
@@ -47,8 +49,6 @@ import {
   useTabs,
 } from "../lib/tabsStore";
 import { useConsole } from "../console";
-import { openCluster } from "../lib/openCluster";
-import { getInfo, probeCluster } from "../lib/probe";
 import { hint, matchWindowKey, type WindowAction } from "../lib/shortcuts";
 import { AgentConsent } from "./AgentConsent";
 import { Body } from "./Body";
@@ -102,13 +102,6 @@ export function Window({
   active = true,
 }: WindowProps) {
   const [booted, setBooted] = useState(false);
-  // A Home tab restored from disk is an explicit reader choice. Keep this
-  // separate from the tab shape: a fresh state has the same single `/` tab.
-  const restoredWorkspace = useRef(false);
-  const mounted = useRef(false);
-  const visible = useRef(active);
-  visible.current = active;
-  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
   /**
    * The vault is usable, as `LockGate` reports it — classic's `vaultReady`, by
    * the same name and for the same one consumer. Flipped once per window; see
@@ -221,7 +214,6 @@ export function Window({
         failure = outcome.error ?? "";
         listed = true;
         const saved = loadTabsState();
-        restoredWorkspace.current = saved !== null;
         if (saved && failure !== "") {
           // The list failed, not the clusters: reconciling against nothing would
           // strip every workspace's cluster ids and the next change would persist
@@ -266,39 +258,6 @@ export function Window({
     };
   }, [booted]);
 
-  // Every cluster you are looking at gets probed once, so the rail shows link
-  // state and the status bar shows a version without waiting to be asked. The
-  // effect runs per workspace rather than per render — switching away and back
-  // re-runs it, and the probe store's memory is what keeps it to once each.
-  const startupOverviewOffered = useRef(false);
-  const workspaceId = workspace.id;
-  const workspaceClusterIds = workspace.clusters.join("\u0000");
-  useEffect(() => {
-    if (!booted) return;
-    if (!active) return;
-    const byId = new Map(contexts.map((c) => [c.stableId, c]));
-    // Only the untouched initial Home is a default destination. A slow probe
-    // must never replace a restored tab or navigation performed while it waits.
-    if (!startupOverviewOffered.current) {
-      startupOverviewOffered.current = true;
-      const initialState = getState();
-      const initialWorkspace = currentWorkspace();
-      const ctx = byId.get(initialWorkspace.activeCluster ?? "");
-      if (!restoredWorkspace.current && ctx && initialWorkspace.tabs.length === 1 && initialWorkspace.tabs[0].route === "/") {
-        const ready = getInfo(ctx.stableId) ? Promise.resolve() : probeCluster(ctx);
-        void ready.then(() => {
-          if (mounted.current && visible.current && getState() === initialState && getInfo(ctx.stableId)?.reachable) openCluster(ctx);
-        });
-      }
-    }
-    for (const id of currentWorkspace().clusters) {
-      if (getInfo(id)) continue;
-      const ctx = byId.get(id);
-      if (ctx) void probeCluster(ctx);
-    }
-    // `contexts` rides along because a kubeconfig change replaces them; the
-    // workspace id is the trigger for the switch case.
-  }, [booted, contexts, workspaceId, workspaceClusterIds, active]);
 
   /**
    * Which accelerators survive a raised cover, and why one of them does.
@@ -577,7 +536,23 @@ export function Window({
           />
         )}
         <div className="relative min-h-0 flex-1">
-          {tabs.map((tab) => (
+          {tabs.map((tab) => {
+            // An editor's target is pinned in its route. Its tab label follows
+            // the rail, so it cannot decide whether the editor's readers are
+            // paused.
+            const pinnedContext = parseEditRoute(tab.route)?.cluster ?? parseNewRoute(tab.route)?.cluster;
+            // Status-bar actions open cluster-following routes without a
+            // `clusterName`. They follow the active cluster and need its pause
+            // gate; app-level tabs never receive one just because it is active.
+            const context = pinnedContext
+              ? contexts.find((c) => c.name === pinnedContext)
+              : tab.sub === undefined
+              ? (isClusterScopedRoute(tab.route) ? activeCtx : undefined)
+              : contexts.find((c) => c.name === tab.sub);
+            // Keep Stop/Detach accessible even on explicitly labelled tabs.
+            // Their submission and creation controls check the actual target.
+            const pausedContext = !keepsManagementWhenPaused(tab.route) && context && workspace.pausedClusters?.includes(context.stableId) ? context : undefined;
+            return (
             <TabSurface key={tab.id} visible={tab.id === activeId}>
               {/* A placeholder tab without a cluster of its own still leaves
                   via the cluster this window is looking at — that is the
@@ -585,6 +560,7 @@ export function Window({
               <Body
                 route={tab.route}
                 clusterName={tab.sub ?? activeCtx?.name}
+                pausedContext={pausedContext}
                 ported={ported}
                 onOpenInClassic={onOpenInClassic}
                 onOpenGallery={onOpenGallery}
@@ -597,7 +573,8 @@ export function Window({
                 onLocked={lockWorkspace}
               />
             </TabSurface>
-          ))}
+            );
+          })}
         </div>
         {/* Not on `/agent`: that screen mounts the dock at the foot of its own
             main column, so its rail is a full-height sibling and uses the

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -102,6 +102,9 @@ export function Window({
   active = true,
 }: WindowProps) {
   const [booted, setBooted] = useState(false);
+  // A Home tab restored from disk is an explicit reader choice. Keep this
+  // separate from the tab shape: a fresh state has the same single `/` tab.
+  const restoredWorkspace = useRef(false);
   const mounted = useRef(false);
   const visible = useRef(active);
   visible.current = active;
@@ -218,6 +221,7 @@ export function Window({
         failure = outcome.error ?? "";
         listed = true;
         const saved = loadTabsState();
+        restoredWorkspace.current = saved !== null;
         if (saved && failure !== "") {
           // The list failed, not the clusters: reconciling against nothing would
           // strip every workspace's cluster ids and the next change would persist
@@ -280,7 +284,7 @@ export function Window({
       const initialState = getState();
       const initialWorkspace = currentWorkspace();
       const ctx = byId.get(initialWorkspace.activeCluster ?? "");
-      if (ctx && initialWorkspace.tabs.length === 1 && initialWorkspace.tabs[0].route === "/") {
+      if (!restoredWorkspace.current && ctx && initialWorkspace.tabs.length === 1 && initialWorkspace.tabs[0].route === "/") {
         const ready = getInfo(ctx.stableId) ? Promise.resolve() : probeCluster(ctx);
         void ready.then(() => {
           if (mounted.current && visible.current && getState() === initialState && getInfo(ctx.stableId)?.reachable) openCluster(ctx);

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -22,6 +22,7 @@ import { mcpAutoStartSettled, mcpAutoStartStarting } from "../lib/mcpAutoStart";
 import { loadPeekWidth } from "../lib/peekWidth";
 import { loadSectionFolds } from "../lib/sectionFolds";
 import { loadExpanded, loadNamespaces } from "../lib/workspace";
+import { getInfo, probeCluster } from "../lib/probe";
 import { defaultState, reconcile } from "../lib/tabs";
 import { parseEditRoute, parseNewRoute } from "../lib/detailRoute";
 import { isClusterScopedRoute, keepsManagementWhenPaused } from "../lib/routes";
@@ -142,6 +143,16 @@ export function Window({
   // place that already knows both the active tab's route and the active
   // cluster's name; `Console` itself only reads `scope` back off the provider.
   const activeTabRoute = tabs.find((t) => t.id === activeId)?.route ?? "/";
+  const activeTab = tabs.find((t) => t.id === activeId);
+  const routeCluster = parseEditRoute(activeTabRoute)?.cluster ?? parseNewRoute(activeTabRoute)?.cluster ?? activeTab?.sub;
+  const probeContext = isClusterScopedRoute(activeTabRoute)
+    ? (routeCluster ? contexts.find(c => c.name === routeCluster) : activeCtx)
+    : undefined;
+  const probePaused = !!probeContext && !!workspace.pausedClusters?.includes(probeContext.stableId);
+  useEffect(() => {
+    if (!booted || !active || !probeContext || probePaused || getInfo(probeContext.stableId)) return;
+    void probeCluster(probeContext, undefined, undefined, { workspaceId: workspace.id });
+  }, [booted, active, probeContext, probePaused, workspace.id]);
   useEffect(() => {
     setScope(contextLabelFor(activeTabRoute, activeCtx?.name ?? ""));
   }, [activeTabRoute, activeCtx?.name, setScope]);

--- a/packages/ui-next/src/styles/next.css
+++ b/packages/ui-next/src/styles/next.css
@@ -35,22 +35,22 @@
 
 /* Home is an app-wide region: flush panes, compact rows, and room for prose. */
 .home-page { display: flex; flex-direction: column; container-type: inline-size; overflow: hidden; }
-.home-intro { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 36px 28px; border-bottom: 1px solid var(--rule); }
+.home-intro { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 20px 28px; border-bottom: 1px solid var(--rule); }
 .home-eyebrow { color: var(--accent); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
-.home-intro h2 { margin-top: 10px; font-size: 26px; line-height: 1.3; font-weight: 600; letter-spacing: -.025em; }
-.home-intro p { margin-top: 10px; max-width: 56ch; font-size: 13px; line-height: 1.7; color: var(--ink-muted); }
+.home-intro h2 { margin-top: 4px; font-size: 21px; line-height: 1.3; font-weight: 600; letter-spacing: -.025em; }
+.home-intro p { margin-top: 3px; max-width: 56ch; font-size: 13px; line-height: 1.5; color: var(--ink-muted); }
 .home-intro > button { flex-shrink: 0; }
-.home-layout { display: grid; grid-template-columns: minmax(0, 1fr) 300px; flex: 1; min-height: 0; }
+.home-layout { display: grid; grid-template-columns: minmax(0, 1fr) 260px; flex: 1; min-height: 0; }
 .home-clusters { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
 .home-cluster-list { flex: 1; min-height: 0; }
-.home-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--rule); font-size: 12px; font-weight: 600; }
+.home-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 20px; border-bottom: 1px solid var(--rule); font-size: 12px; font-weight: 600; }
 .home-section-heading input { max-width: 230px; }
 .home-section-heading h2 { flex-shrink: 0; }
 .home-section-heading h2 > span { margin-left: 6px; font-weight: 400; }
-.home-cluster-row { display: flex; align-items: center; gap: 12px; width: 100%; min-height: 64px; padding: 12px 20px; font-size: 13px; }
+.home-cluster-row { display: flex; align-items: center; gap: 12px; width: 100%; min-height: 56px; padding: 8px 20px; font-size: 13px; }
 .home-cluster-row:hover, .home-action:hover { background: var(--surface-sunk); }
 .home-start { overflow: auto; border-left: 1px solid var(--rule); }
-.home-action { display: grid; grid-template-columns: 18px minmax(0, 1fr) 12px; align-items: start; gap: 12px; width: 100%; padding: 18px 20px; border-bottom: 1px solid var(--rule); font-size: 13px; }
+.home-action { display: grid; grid-template-columns: 18px minmax(0, 1fr) 12px; align-items: center; gap: 12px; width: 100%; min-height: 52px; padding: 10px 20px; border-bottom: 1px solid var(--rule); font-size: 13px; }
 @container (max-width: 720px) {
   .home-intro { align-items: flex-start; flex-direction: column; padding: 24px 20px; gap: 18px; }
   .home-page { overflow: auto; }

--- a/packages/ui-next/src/styles/next.css
+++ b/packages/ui-next/src/styles/next.css
@@ -32,3 +32,26 @@
   border-width: 0 0 1px;
   box-shadow: none;
 }
+
+/* Home is an app-wide region: flush panes, compact rows, and room for prose. */
+.home-page { container-type: inline-size; }
+.home-intro { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 36px 28px; border-bottom: 1px solid var(--rule); }
+.home-eyebrow { color: var(--accent); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+.home-intro h2 { margin-top: 10px; font-size: 26px; line-height: 1.3; font-weight: 600; letter-spacing: -.025em; }
+.home-intro p { margin-top: 10px; max-width: 56ch; font-size: 13px; line-height: 1.7; color: var(--ink-muted); }
+.home-intro > button { flex-shrink: 0; }
+.home-layout { display: grid; grid-template-columns: minmax(0, 1fr) 300px; min-height: calc(100% - 180px); }
+.home-clusters { min-width: 0; }
+.home-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--rule); font-size: 12px; font-weight: 600; }
+.home-section-heading input { max-width: 230px; }
+.home-section-heading h2 { flex-shrink: 0; }
+.home-section-heading h2 > span { margin-left: 6px; font-weight: 400; }
+.home-cluster-row { display: flex; align-items: center; gap: 12px; width: 100%; min-height: 64px; padding: 12px 20px; font-size: 13px; }
+.home-cluster-row:hover, .home-action:hover { background: var(--surface-sunk); }
+.home-start { border-left: 1px solid var(--rule); }
+.home-action { display: grid; grid-template-columns: 18px minmax(0, 1fr) 12px; align-items: start; gap: 12px; width: 100%; padding: 18px 20px; border-bottom: 1px solid var(--rule); font-size: 13px; }
+@container (max-width: 720px) {
+  .home-intro { align-items: flex-start; flex-direction: column; padding: 24px 20px; gap: 18px; }
+  .home-layout { grid-template-columns: minmax(0, 1fr); min-height: 0; }
+  .home-start { border-left: 0; border-top: 1px solid var(--rule); }
+}

--- a/packages/ui-next/src/styles/next.css
+++ b/packages/ui-next/src/styles/next.css
@@ -34,24 +34,27 @@
 }
 
 /* Home is an app-wide region: flush panes, compact rows, and room for prose. */
-.home-page { container-type: inline-size; }
+.home-page { display: flex; flex-direction: column; container-type: inline-size; overflow: hidden; }
 .home-intro { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 36px 28px; border-bottom: 1px solid var(--rule); }
 .home-eyebrow { color: var(--accent); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
 .home-intro h2 { margin-top: 10px; font-size: 26px; line-height: 1.3; font-weight: 600; letter-spacing: -.025em; }
 .home-intro p { margin-top: 10px; max-width: 56ch; font-size: 13px; line-height: 1.7; color: var(--ink-muted); }
 .home-intro > button { flex-shrink: 0; }
-.home-layout { display: grid; grid-template-columns: minmax(0, 1fr) 300px; min-height: calc(100% - 180px); }
-.home-clusters { min-width: 0; }
+.home-layout { display: grid; grid-template-columns: minmax(0, 1fr) 300px; flex: 1; min-height: 0; }
+.home-clusters { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.home-cluster-list { flex: 1; min-height: 0; }
 .home-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--rule); font-size: 12px; font-weight: 600; }
 .home-section-heading input { max-width: 230px; }
 .home-section-heading h2 { flex-shrink: 0; }
 .home-section-heading h2 > span { margin-left: 6px; font-weight: 400; }
 .home-cluster-row { display: flex; align-items: center; gap: 12px; width: 100%; min-height: 64px; padding: 12px 20px; font-size: 13px; }
 .home-cluster-row:hover, .home-action:hover { background: var(--surface-sunk); }
-.home-start { border-left: 1px solid var(--rule); }
+.home-start { overflow: auto; border-left: 1px solid var(--rule); }
 .home-action { display: grid; grid-template-columns: 18px minmax(0, 1fr) 12px; align-items: start; gap: 12px; width: 100%; padding: 18px 20px; border-bottom: 1px solid var(--rule); font-size: 13px; }
 @container (max-width: 720px) {
   .home-intro { align-items: flex-start; flex-direction: column; padding: 24px 20px; gap: 18px; }
-  .home-layout { grid-template-columns: minmax(0, 1fr); min-height: 0; }
-  .home-start { border-left: 0; border-top: 1px solid var(--rule); }
+  .home-page { overflow: auto; }
+  .home-layout { display: block; flex: none; min-height: 0; }
+  .home-cluster-list { overflow: visible; }
+  .home-start { overflow: visible; border-left: 0; border-top: 1px solid var(--rule); }
 }

--- a/packages/ui-next/src/styles/next.css
+++ b/packages/ui-next/src/styles/next.css
@@ -53,8 +53,7 @@
 .home-action { display: grid; grid-template-columns: 18px minmax(0, 1fr) 12px; align-items: center; gap: 12px; width: 100%; min-height: 52px; padding: 10px 20px; border-bottom: 1px solid var(--rule); font-size: 13px; }
 @container (max-width: 720px) {
   .home-intro { align-items: flex-start; flex-direction: column; padding: 24px 20px; gap: 18px; }
-  .home-page { overflow: auto; }
-  .home-layout { display: block; flex: none; min-height: 0; }
+  .home-layout { display: block; overflow: auto; }
   .home-cluster-list { overflow: visible; }
   .home-start { overflow: visible; border-left: 0; border-top: 1px solid var(--rule); }
 }


### PR DESCRIPTION
## What changed and why

A window with no open work now shows an app-wide Home page instead of the unfinished Control room placeholder. Home offers a searchable list of configured clusters with their saved names, marks, ordering, and connection status, plus working entry points for connecting a cluster, managing connections, settings, and release notes. Loading and failed discovery remain distinct from an empty configuration; partial results stay available and failures can be retried.

Opening a cluster from Home or the cluster rail selects its Cluster Overview. Startup also opens the active cluster's overview after a successful connection when the initial Home is the only tab. Restored work and navigation performed while the connection is pending keep focus. Home stays accessible, and stored Control room tabs retain their identities while becoming app-scoped Home tabs.

The Home layout uses the new design's flush regions, hides the cluster navigation pane while Home is active, and stacks its content at narrow widths. Existing preference storage remains shared with the backend settings adapter.

## Validation

- Regression tests cover Home actions and route registration, saved cluster identities and order, search, discovery failures and retry races, startup defaults, restored tabs, and delayed connections.
- `pnpm test --maxWorkers=4`: 6,187 tests passed; 90.73% line coverage with unchanged gates. `pnpm typecheck` and `pnpm build` passed.
- `cargo test --workspace`: 2,096 passed, 13 ignored.
- Full-window browser harness verified empty and populated Home, desktop and narrow layouts, cluster selection, successful startup navigation, return to Home, and the release-notes action.
