### PR TITLE
fix(ci): a broken third-party apt repo no longer reds every Linux job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       # Tauri v2 system libraries needed to compile the desktop crate.
       - name: Install Linux dependencies
         run: |
+          # The runner image ships apt repos this build does not use --
+          # Chrome and Microsoft -- and `apt-get update` exits 100 when ANY
+          # configured source fails, which under `bash -e` takes the step
+          # with it. Google served a Packages.gz that did not match its own
+          # Release file for hours on 2026-09-09 and red-ed every job here,
+          # none of which wants a single package from it. Removing a source
+          # list uninstalls nothing, so the preinstalled Chrome stays put.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.* \
+                     /etc/apt/sources.list.d/microsoft-prod.*
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
@@ -167,6 +176,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Linux dependencies
         run: |
+          # Third-party repos the runner image ships, dropped for the reason
+          # in the backend job above: an outage in one of them fails
+          # `apt-get update` for everyone, and this build uses none of them.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.* \
+                     /etc/apt/sources.list.d/microsoft-prod.*
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Linux dependencies
         run: |
+          # Third-party repos the runner image ships, dropped for the reason
+          # in ci.yml's backend job: an outage in one of them fails
+          # `apt-get update` for everyone, and this build uses none of them.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.* \
+                     /etc/apt/sources.list.d/microsoft-prod.*
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
@@ -439,6 +444,11 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          # Third-party repos the runner image ships, dropped for the reason
+          # in ci.yml's backend job: an outage in one of them fails
+          # `apt-get update` for everyone, and this build uses none of them.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.* \
+                     /etc/apt/sources.list.d/microsoft-prod.*
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
@@ -676,6 +686,11 @@ jobs:
       - name: Install musl tooling
         if: ${{ endsWith(matrix.target, '-musl') }}
         run: |
+          # Third-party repos the runner image ships, dropped for the reason
+          # in ci.yml's backend job: an outage in one of them fails
+          # `apt-get update` for everyone, and this build uses none of them.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.* \
+                     /etc/apt/sources.list.d/microsoft-prod.*
           sudo apt-get update
           sudo apt-get install -y musl-tools
 


### PR DESCRIPTION
Closes #488. Dev CI is red right now and this is why.

## What happened

The `backend` job dies twelve seconds in, at `Install Linux dependencies`, before any code runs:

```
Err:10 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
E: Failed to fetch .../binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Process completed with exit code 100.
```

Google republished that repo's Release file at 17:16:59 UTC while still serving the older `Packages.gz`, so apt saw an index whose checksum did not match the Release file. **A re-run ten minutes later failed identically**, so waiting it out was not an option.

That repo ships with the GitHub runner image, not with us, and this build takes no package from it. But `apt-get update` exits 100 when *any* configured source fails, and the step runs under `bash -e`, so an outage in a repo nothing here uses took the job down.

## The fix

Remove the Chrome and Microsoft source lists before `apt-get update`, at all five sites that share this shape:

| Workflow | Jobs |
| --- | --- |
| `ci.yml` | `backend`, `smoke` |
| `release.yml` | `smoke-full`, `build`, `tui` |

`build` and `tui` produce the release artifacts, so this was one bad afternoon away from failing a release as well as CI.

## Why it is safe

- Removing a source list **uninstalls nothing** — the preinstalled Chrome the smoke jobs may reach for stays exactly where it is. Only apt's indexing of that repo goes away.
- Every package these steps install comes from the Ubuntu archive, which updated fine throughout the outage.
- `rm -f` with a glob that matches nothing still exits 0 (verified under `bash -e`, the runner's shell), so a future runner image that drops or renames either file will not fail the step.

## Verified

- `rm -f` glob exits 0 both when it matches nothing and when it matches `.list` and `.sources` files.
- Both workflows parse with js-yaml, and every step containing `apt-get update` carries the guard — confirmed by walking the parsed job graph, not by grep.

Docker Desktop was down on this machine, so I could not reproduce the broken repo end to end in a container. CI on this PR exercises the change directly.