### PR TITLE
feat(ui): connect clusters on demand

### DIFF
--- a/packages/ui-next/src/lib/openCluster.ts
+++ b/packages/ui-next/src/lib/openCluster.ts
@@ -1,12 +1,18 @@
 import type { ClusterContext } from "@srelens/core";
 import { currentWorkspace, openTab, setActiveCluster, setClusterPaused, setWorkspaceClusters } from "./tabsStore";
-import { probeCluster } from "./probe";
+import { invalidateProbe, probeCluster } from "./probe";
+
+/** Pause one workspace's reading and invalidate any observation already out. */
+export function pauseCluster(workspaceId: string, clusterId: string): void {
+  setClusterPaused(workspaceId, clusterId, true);
+  invalidateProbe(workspaceId, clusterId);
+}
 
 /** Resume a paused cluster and begin its explicit reachability read. */
 export function reconnectCluster(context: ClusterContext): void {
   const workspace = currentWorkspace();
   setClusterPaused(workspace.id, context.stableId, false);
-  void probeCluster(context);
+  void probeCluster(context, undefined, undefined, { workspaceId: workspace.id, fresh: true });
 }
 
 /**

--- a/packages/ui-next/src/lib/openCluster.ts
+++ b/packages/ui-next/src/lib/openCluster.ts
@@ -11,8 +11,11 @@ export function pauseCluster(workspaceId: string, clusterId: string): void {
 /** Resume a paused cluster and begin its explicit reachability read. */
 export function reconnectCluster(context: ClusterContext): void {
   const workspace = currentWorkspace();
+  const wasPaused = workspace.pausedClusters?.includes(context.stableId) === true;
   setClusterPaused(workspace.id, context.stableId, false);
-  void probeCluster(context, undefined, undefined, { workspaceId: workspace.id, fresh: true });
+  // Opening a cluster that is already connected joins its reading; only a
+  // reconnect must bypass the observation invalidated by Disconnect.
+  void probeCluster(context, undefined, undefined, { workspaceId: workspace.id, fresh: wasPaused });
 }
 
 /**

--- a/packages/ui-next/src/lib/openCluster.ts
+++ b/packages/ui-next/src/lib/openCluster.ts
@@ -1,5 +1,13 @@
 import type { ClusterContext } from "@srelens/core";
-import { currentWorkspace, openTab, setActiveCluster, setWorkspaceClusters } from "./tabsStore";
+import { currentWorkspace, openTab, setActiveCluster, setClusterPaused, setWorkspaceClusters } from "./tabsStore";
+import { probeCluster } from "./probe";
+
+/** Resume a paused cluster and begin its explicit reachability read. */
+export function reconnectCluster(context: ClusterContext): void {
+  const workspace = currentWorkspace();
+  setClusterPaused(workspace.id, context.stableId, false);
+  void probeCluster(context);
+}
 
 /**
  * Open a cluster: put it in this workspace, focus it, and open its overview.
@@ -28,6 +36,7 @@ export function openCluster(context: ClusterContext): void {
   if (!workspace.clusters.includes(id)) {
     setWorkspaceClusters(workspace.id, [...workspace.clusters, id]);
   }
+  reconnectCluster(context);
   // By NAME as well as by stableId, and the name is not spare: the workspace
   // stores the id (#265), while the strip's labels — and core's `list*` and
   // `watchResource` — are all in terms of the context name. `setActiveCluster`

--- a/packages/ui-next/src/lib/pausedContext.ts
+++ b/packages/ui-next/src/lib/pausedContext.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { getContexts, useContexts } from "./clusters";
+import { isClusterPaused, useTabs } from "./tabsStore";
+
+/** Capability calls use context names; pause preferences use stable ids. */
+export function isContextPaused(name: string): boolean {
+  return getContexts().some(context => context.name === name && isClusterPaused(context.stableId));
+}
+
+/** Hide immediately, then forget a dialog whose captured target was paused. */
+export function useDismissOnPause(name: string | undefined, dismiss: () => void): boolean {
+  const contexts = useContexts();
+  const { workspace } = useTabs();
+  const paused = contexts.some(context => context.name === name && workspace.pausedClusters?.includes(context.stableId));
+  useEffect(() => {
+    if (paused) dismiss();
+  }, [paused, dismiss]);
+  return paused;
+}

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -234,6 +234,24 @@ describe("one read per cluster", () => {
     expect(getProbe(ctx.stableId).state).toBe("reachable");
   });
 
+  it("joins a valid cross-workspace read even when reconnect asks fresh", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const secondWorkspace = "second";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: secondWorkspace, name: "Second", pausedClusters: [] });
+    setState(state);
+    let settle!: (value: unknown) => void;
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settle = resolve as never; }));
+
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId: firstWorkspace });
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId: secondWorkspace, fresh: true });
+
+    expect(second).toBe(first);
+    expect(connect).toHaveBeenCalledTimes(1);
+    settle({ context: ctx.name, reachable: true });
+    await second;
+  });
+
   it("joins the read already out rather than starting a second", async () => {
     let settle!: (v: unknown) => void;
     const connect = vi.fn(() => new Promise<never>((r) => { settle = r as never; }));

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -210,6 +210,30 @@ describe("one read per cluster", () => {
     expect(getProbe(ctx.stableId).state).toBe("reachable");
   });
 
+  it("does not join a read invalidated by another workspace", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const secondWorkspace = "second";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: secondWorkspace, name: "Second", pausedClusters: [] });
+    setState(state);
+    const settles: ((value: unknown) => void)[] = [];
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settles.push(resolve as never); }));
+
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId: firstWorkspace });
+    setClusterPaused(firstWorkspace, ctx.stableId, true);
+    invalidateProbe(firstWorkspace, ctx.stableId);
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId: secondWorkspace });
+
+    expect(second).not.toBe(first);
+    expect(connect).toHaveBeenCalledTimes(2);
+    settles[0]({ context: ctx.name, reachable: true });
+    await first;
+    expect(getProbe(ctx.stableId).state).toBe("unread");
+    settles[1]({ context: ctx.name, reachable: true });
+    await second;
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
   it("joins the read already out rather than starting a second", async () => {
     let settle!: (v: unknown) => void;
     const connect = vi.fn(() => new Promise<never>((r) => { settle = r as never; }));

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -252,6 +252,26 @@ describe("one read per cluster", () => {
     await second;
   });
 
+  it("keeps a joined read when its initiating workspace disconnects", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const secondWorkspace = "second";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: secondWorkspace, name: "Second", pausedClusters: [] });
+    setState(state);
+    let settle!: (value: unknown) => void;
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settle = resolve as never; }));
+
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId: firstWorkspace });
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId: secondWorkspace });
+    setClusterPaused(firstWorkspace, ctx.stableId, true);
+    invalidateProbe(firstWorkspace, ctx.stableId);
+    settle({ context: ctx.name, reachable: true });
+    await second;
+
+    expect(second).toBe(first);
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
   it("joins the read already out rather than starting a second", async () => {
     let settle!: (v: unknown) => void;
     const connect = vi.fn(() => new Promise<never>((r) => { settle = r as never; }));

--- a/packages/ui-next/src/lib/probe.test.ts
+++ b/packages/ui-next/src/lib/probe.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { probeCluster, getInfo, useInfo, useInfos, getProbe, useProbe, useProbes, resetProbes } from "./probe";
+import { invalidateProbe, probeCluster, getInfo, useInfo, useInfos, getProbe, useProbe, useProbes, resetProbes } from "./probe";
 import { getView, resetView } from "./workspace";
+import { defaultState } from "./tabs";
+import { currentWorkspace, setClusterPaused, setState, switchWorkspace } from "./tabsStore";
 
 const ctx = {
   name: "prod-eu", stableId: "prod", cluster: "c", server: "", isCurrent: false,
   sourceFile: "/home/dana/.kube/config", authKind: "client certificate",
 };
 
-beforeEach(() => { resetView(); resetProbes(); });
+beforeEach(() => { resetView(); resetProbes(); setState(defaultState([ctx])); });
 
 describe("probeCluster", () => {
   it("marks connecting, then connected with the version", async () => {
@@ -176,6 +178,38 @@ describe("useProbes", () => {
  * whatever order they finish, and the loser is not recoverable from here.
  */
 describe("one read per cluster", () => {
+  it("discards a disconnected read and reconnects with a fresh one", async () => {
+    const settles: ((value: unknown) => void)[] = [];
+    const connect = vi.fn(() => new Promise<never>((resolve) => { settles.push(resolve as never); }));
+    const workspaceId = currentWorkspace().id;
+    const first = probeCluster(ctx, connect as never, () => 0, { workspaceId });
+    setClusterPaused(workspaceId, ctx.stableId, true);
+    invalidateProbe(workspaceId, ctx.stableId);
+    setClusterPaused(workspaceId, ctx.stableId, false);
+    const second = probeCluster(ctx, connect as never, () => 0, { workspaceId, fresh: true });
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    settles[0]({ context: ctx.name, reachable: true });
+    await first;
+    expect(getProbe(ctx.stableId).state).toBe("unread");
+
+    settles[1]({ context: ctx.name, reachable: true });
+    await second;
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
+  it("keeps a probe owned by its starting workspace when another workspace pauses", async () => {
+    const firstWorkspace = currentWorkspace().id;
+    const pausedWorkspace = "paused";
+    const state = defaultState([ctx]);
+    state.workspaces.push({ ...state.workspaces[0], id: pausedWorkspace, name: "Paused", pausedClusters: [ctx.stableId] });
+    setState(state);
+    const reading = probeCluster(ctx, vi.fn().mockResolvedValue({ context: ctx.name, reachable: true }) as never, () => 0, { workspaceId: firstWorkspace });
+    switchWorkspace(pausedWorkspace);
+    await reading;
+    expect(getProbe(ctx.stableId).state).toBe("reachable");
+  });
+
   it("joins the read already out rather than starting a second", async () => {
     let settle!: (v: unknown) => void;
     const connect = vi.fn(() => new Promise<never>((r) => { settle = r as never; }));

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from "react";
 import { connectCluster, describeError, type ClusterContext, type ClusterInfo } from "@srelens/core";
 import { setLink } from "./workspace";
+import { isClusterPaused } from "./tabsStore";
 
 let infos: Record<string, ClusterInfo> = {};
 
@@ -137,6 +138,7 @@ export function probeCluster(
   connect: typeof connectCluster = connectCluster,
   now: () => number = Date.now,
 ): Promise<void> {
+  if (isClusterPaused(ctx.stableId)) return Promise.resolve();
   const running = reading.get(ctx.stableId);
   if (running) return running;
   const run = read(ctx, connect, now).finally(() => {
@@ -167,6 +169,9 @@ async function read(
     info = { context: ctx.name, reachable: false, error: String(e) };
   }
   const elapsedMs = now() - started;
+  // Disconnect may have been picked while the probe was in flight. Its result
+  // is an observation from before that choice, so never revive a paused row.
+  if (isClusterPaused(ctx.stableId)) return;
   infos = { ...infos, [ctx.stableId]: info };
   probes = { ...probes, [ctx.stableId]: deriveProbe(info, elapsedMs) };
   emit();

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -1,7 +1,7 @@
 import { useSyncExternalStore } from "react";
 import { connectCluster, describeError, type ClusterContext, type ClusterInfo } from "@srelens/core";
 import { setLink } from "./workspace";
-import { isClusterPaused } from "./tabsStore";
+import { currentWorkspace, isClusterPaused } from "./tabsStore";
 
 let infos: Record<string, ClusterInfo> = {};
 
@@ -48,7 +48,7 @@ const emit = () => { for (const l of listeners) l(); };
 
 export function getInfo(stableId: string): ClusterInfo | undefined { return infos[stableId]; }
 export function getProbe(stableId: string): Probe { return probes[stableId] ?? UNREAD; }
-export function resetProbes(): void { infos = {}; probes = {}; reading.clear(); emit(); }
+export function resetProbes(): void { infos = {}; probes = {}; reading.clear(); pauseGenerations.clear(); emit(); }
 function subscribe(l: () => void) { listeners.add(l); return () => listeners.delete(l); }
 export function useProbe(stableId: string | null): Probe {
   return useSyncExternalStore(subscribe, () => (stableId ? (probes[stableId] ?? UNREAD) : UNREAD), () => UNREAD);
@@ -110,6 +110,22 @@ export function useInfos(): Record<string, ClusterInfo> {
  * a read hanging does not leave the next one joined to it.
  */
 const reading = new Map<string, Promise<void>>();
+const pauseGenerations = new Map<string, number>();
+
+function pauseKey(workspaceId: string, clusterId: string) {
+  return `${workspaceId}\u0000${clusterId}`;
+}
+
+/** Invalidate a workspace's in-flight reading when its reader disconnects. */
+export function invalidateProbe(workspaceId: string, clusterId: string): void {
+  const key = pauseKey(workspaceId, clusterId);
+  pauseGenerations.set(key, (pauseGenerations.get(key) ?? 0) + 1);
+}
+
+interface ProbeOptions {
+  workspaceId?: string;
+  fresh?: boolean;
+}
 
 /**
  * Read one cluster: connect to it, time the round trip, and record what came
@@ -137,11 +153,14 @@ export function probeCluster(
   ctx: ClusterContext,
   connect: typeof connectCluster = connectCluster,
   now: () => number = Date.now,
+  options: ProbeOptions = {},
 ): Promise<void> {
-  if (isClusterPaused(ctx.stableId)) return Promise.resolve();
+  const workspaceId = options.workspaceId ?? currentWorkspace().id;
+  if (isClusterPaused(ctx.stableId, workspaceId)) return Promise.resolve();
+  const generation = pauseGenerations.get(pauseKey(workspaceId, ctx.stableId)) ?? 0;
   const running = reading.get(ctx.stableId);
-  if (running) return running;
-  const run = read(ctx, connect, now).finally(() => {
+  if (running && !options.fresh) return running;
+  const run = read(ctx, connect, now, workspaceId, generation).finally(() => {
     // **By identity, not by key.** A read that {@link resetProbes} forgot
     // still lands, and deleting by key alone would clear whatever is under
     // that key by then — which is the CURRENT read. That silently reopens the
@@ -159,6 +178,8 @@ async function read(
   ctx: ClusterContext,
   connect: typeof connectCluster,
   now: () => number,
+  workspaceId: string,
+  generation: number,
 ): Promise<void> {
   setLink(ctx.stableId, "connecting");
   const started = now();
@@ -171,7 +192,10 @@ async function read(
   const elapsedMs = now() - started;
   // Disconnect may have been picked while the probe was in flight. Its result
   // is an observation from before that choice, so never revive a paused row.
-  if (isClusterPaused(ctx.stableId)) return;
+  if (
+    isClusterPaused(ctx.stableId, workspaceId) ||
+    generation !== (pauseGenerations.get(pauseKey(workspaceId, ctx.stableId)) ?? 0)
+  ) return;
   infos = { ...infos, [ctx.stableId]: info };
   probes = { ...probes, [ctx.stableId]: deriveProbe(info, elapsedMs) };
   emit();

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -111,9 +111,8 @@ export function useInfos(): Record<string, ClusterInfo> {
  */
 interface Reading {
   promise: Promise<void>;
-  /** The workspace whose pause decision the result must still satisfy. */
-  workspaceId: string;
-  generation: number;
+  /** Every workspace that is entitled to use this result. */
+  participants: Map<string, number>;
 }
 
 const reading = new Map<string, Reading>();
@@ -121,6 +120,11 @@ const pauseGenerations = new Map<string, number>();
 
 function pauseKey(workspaceId: string, clusterId: string) {
   return `${workspaceId}\u0000${clusterId}`;
+}
+
+function participantIsValid(clusterId: string, workspaceId: string, generation: number): boolean {
+  return !isClusterPaused(clusterId, workspaceId) &&
+    generation === (pauseGenerations.get(pauseKey(workspaceId, clusterId)) ?? 0);
 }
 
 /** Invalidate a workspace's in-flight reading when its reader disconnects. */
@@ -171,13 +175,17 @@ export function probeCluster(
   // read whose owner has since invalidated it: that read will deliberately
   // discard its result, leaving the joining workspace stuck on Connecting.
   const runningIsValid = running &&
-    !isClusterPaused(ctx.stableId, running.workspaceId) &&
-    running.generation === (pauseGenerations.get(pauseKey(running.workspaceId, ctx.stableId)) ?? 0);
+    [...running.participants].some(([id, participantGeneration]) =>
+      participantIsValid(ctx.stableId, id, participantGeneration));
   // A reconnect only needs a fresh read when the prior one was invalidated.
   // A valid read owned by another workspace is safe to share, and avoids two
   // accepted writes racing each other.
-  if (runningIsValid) return running.promise;
-  const run = read(ctx, connect, now, workspaceId, generation).finally(() => {
+  if (runningIsValid) {
+    running.participants.set(workspaceId, generation);
+    return running.promise;
+  }
+  const participants = new Map([[workspaceId, generation]]);
+  const run = read(ctx, connect, now, participants).finally(() => {
     // **By identity, not by key.** A read that {@link resetProbes} forgot
     // still lands, and deleting by key alone would clear whatever is under
     // that key by then — which is the CURRENT read. That silently reopens the
@@ -186,7 +194,7 @@ export function probeCluster(
     // installed is its to remove.
     if (reading.get(ctx.stableId)?.promise === run) reading.delete(ctx.stableId);
   });
-  reading.set(ctx.stableId, { promise: run, workspaceId, generation });
+  reading.set(ctx.stableId, { promise: run, participants });
   return run;
 }
 
@@ -195,8 +203,7 @@ async function read(
   ctx: ClusterContext,
   connect: typeof connectCluster,
   now: () => number,
-  workspaceId: string,
-  generation: number,
+  participants: ReadonlyMap<string, number>,
 ): Promise<void> {
   setLink(ctx.stableId, "connecting");
   const started = now();
@@ -209,10 +216,7 @@ async function read(
   const elapsedMs = now() - started;
   // Disconnect may have been picked while the probe was in flight. Its result
   // is an observation from before that choice, so never revive a paused row.
-  if (
-    isClusterPaused(ctx.stableId, workspaceId) ||
-    generation !== (pauseGenerations.get(pauseKey(workspaceId, ctx.stableId)) ?? 0)
-  ) return;
+  if (![...participants].some(([workspaceId, generation]) => participantIsValid(ctx.stableId, workspaceId, generation))) return;
   infos = { ...infos, [ctx.stableId]: info };
   probes = { ...probes, [ctx.stableId]: deriveProbe(info, elapsedMs) };
   emit();

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -109,7 +109,14 @@ export function useInfos(): Record<string, ClusterInfo> {
  * {@link resetProbes} clears this along with the answers, so a test that leaves
  * a read hanging does not leave the next one joined to it.
  */
-const reading = new Map<string, Promise<void>>();
+interface Reading {
+  promise: Promise<void>;
+  /** The workspace whose pause decision the result must still satisfy. */
+  workspaceId: string;
+  generation: number;
+}
+
+const reading = new Map<string, Reading>();
 const pauseGenerations = new Map<string, number>();
 
 function pauseKey(workspaceId: string, clusterId: string) {
@@ -159,7 +166,14 @@ export function probeCluster(
   if (isClusterPaused(ctx.stableId, workspaceId)) return Promise.resolve();
   const generation = pauseGenerations.get(pauseKey(workspaceId, ctx.stableId)) ?? 0;
   const running = reading.get(ctx.stableId);
-  if (running && !options.fresh) return running;
+  // A pause invalidates only its own workspace's observation. Another
+  // workspace may still use a simultaneous connection, but it must not join a
+  // read whose owner has since invalidated it: that read will deliberately
+  // discard its result, leaving the joining workspace stuck on Connecting.
+  const runningIsValid = running &&
+    !isClusterPaused(ctx.stableId, running.workspaceId) &&
+    running.generation === (pauseGenerations.get(pauseKey(running.workspaceId, ctx.stableId)) ?? 0);
+  if (runningIsValid && !options.fresh) return running.promise;
   const run = read(ctx, connect, now, workspaceId, generation).finally(() => {
     // **By identity, not by key.** A read that {@link resetProbes} forgot
     // still lands, and deleting by key alone would clear whatever is under
@@ -167,9 +181,9 @@ export function probeCluster(
     // guard and the next caller starts a third concurrent read of one cluster,
     // the exact case this map exists to prevent. Only the entry this read
     // installed is its to remove.
-    if (reading.get(ctx.stableId) === run) reading.delete(ctx.stableId);
+    if (reading.get(ctx.stableId)?.promise === run) reading.delete(ctx.stableId);
   });
-  reading.set(ctx.stableId, run);
+  reading.set(ctx.stableId, { promise: run, workspaceId, generation });
   return run;
 }
 

--- a/packages/ui-next/src/lib/probe.ts
+++ b/packages/ui-next/src/lib/probe.ts
@@ -12,7 +12,7 @@ let infos: Record<string, ClusterInfo> = {};
  * `infos`, so `getInfo`/`useInfo`/`useInfos` and their callers — the rail, the
  * status strip, Overview, Toolbox — stay untouched.
  */
-export type ProbeState = "unread" | "reachable" | "unreachable";
+export type ProbeState = "unread" | "reachable" | "unreachable" | "paused";
 
 export interface Probe {
   state: ProbeState;
@@ -173,7 +173,10 @@ export function probeCluster(
   const runningIsValid = running &&
     !isClusterPaused(ctx.stableId, running.workspaceId) &&
     running.generation === (pauseGenerations.get(pauseKey(running.workspaceId, ctx.stableId)) ?? 0);
-  if (runningIsValid && !options.fresh) return running.promise;
+  // A reconnect only needs a fresh read when the prior one was invalidated.
+  // A valid read owned by another workspace is safe to share, and avoids two
+  // accepted writes racing each other.
+  if (runningIsValid) return running.promise;
   const run = read(ctx, connect, now, workspaceId, generation).finally(() => {
     // **By identity, not by key.** A read that {@link resetProbes} forgot
     // still lands, and deleting by key alone would clear whatever is under

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -7,6 +7,7 @@ import {
   describe,
   isBuiltInKind,
   isClusterScopedRoute,
+  keepsManagementWhenPaused,
   screenFor,
   type RoutedScreenProps,
   type ScreenComponent,
@@ -229,6 +230,10 @@ suite("describe", () => {
 });
 
 suite("isClusterScopedRoute", () => {
+  it("keeps run and stream management available while pausing cluster readers", () => {
+    for (const route of ["/agent", "/forwards", "/terminals"]) expect(keepsManagementWhenPaused(route)).toBe(true);
+    for (const route of ["/overview", "/helm", "/k/pods"]) expect(keepsManagementWhenPaused(route)).toBe(false);
+  });
   it("distinguishes cluster-following routes from app screens", () => {
     for (const route of ["/overview", "/helm", "/forwards", "/terminals", "/k/pods", "/k/Pod/default/web", "/edit/Pod/default/web"]) {
       expect(isClusterScopedRoute(route), route).toBe(true);

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -230,7 +230,7 @@ suite("describe", () => {
 
 suite("isClusterScopedRoute", () => {
   it("distinguishes cluster-following routes from app screens", () => {
-    for (const route of ["/overview", "/helm", "/forwards", "/k/pods", "/k/Pod/default/web", "/edit/Pod/default/web"]) {
+    for (const route of ["/overview", "/helm", "/forwards", "/terminals", "/k/pods", "/k/Pod/default/web", "/edit/Pod/default/web"]) {
       expect(isClusterScopedRoute(route), route).toBe(true);
     }
     for (const route of ["/", "/settings", "/connections", "/notes"]) {

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -6,6 +6,7 @@ import { describe as suite, it, expect } from "vitest";
 import {
   describe,
   isBuiltInKind,
+  isClusterScopedRoute,
   screenFor,
   type RoutedScreenProps,
   type ScreenComponent,
@@ -224,6 +225,17 @@ suite("describe", () => {
     // /k/ branch's RESOURCE_LABELS lookup must still resolve it — this pins
     // that against a regression, not against screenFor's routing.
     expect(describe("/k/events", "c")).toMatchObject({ title: "Events", kind: "workloads" });
+  });
+});
+
+suite("isClusterScopedRoute", () => {
+  it("distinguishes cluster-following routes from app screens", () => {
+    for (const route of ["/overview", "/helm", "/forwards", "/k/pods", "/k/Pod/default/web", "/edit/Pod/default/web"]) {
+      expect(isClusterScopedRoute(route), route).toBe(true);
+    }
+    for (const route of ["/", "/settings", "/connections", "/notes"]) {
+      expect(isClusterScopedRoute(route), route).toBe(false);
+    }
   });
 });
 

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -197,6 +197,11 @@ export function isClusterScopedRoute(route: string): boolean {
   return describe(route, sentinel).sub === sentinel;
 }
 
+/** These screens own controls for work that survives their component lifetime. */
+export function keepsManagementWhenPaused(route: string): boolean {
+  return route === "/agent" || route === "/forwards" || route === "/terminals";
+}
+
 /**
  * What every routed screen is handed.
  *

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -189,6 +189,14 @@ export function describe(route: string, clusterName?: string): RouteInfo {
   return { route, title: route.replace(/^\//, "") || "Untitled", sub, kind: "control" };
 }
 
+/** Whether a route follows a cluster rather than being an app-level screen. */
+export function isClusterScopedRoute(route: string): boolean {
+  // `describe` is already the one exhaustive parser for route shapes. Passing
+  // a sentinel lets its `sub` answer this without duplicating dynamic routes.
+  const sentinel = "__cluster_scope__";
+  return describe(route, sentinel).sub === sentinel;
+}
+
 /**
  * What every routed screen is handed.
  *

--- a/packages/ui-next/src/lib/tabs.test.ts
+++ b/packages/ui-next/src/lib/tabs.test.ts
@@ -143,6 +143,12 @@ describe("reconcile", () => {
     expect(reconcile(s, []).workspaces[0].activeCluster).toBeUndefined();
   });
 
+  it("drops pauses for contexts removed from the kubeconfig", () => {
+    const s = defaultState([ctx("a"), ctx("b")]);
+    s.workspaces[0].pausedClusters = ["a", "b"];
+    expect(reconcile(s, [ctx("b")]).workspaces[0].pausedClusters).toEqual(["b"]);
+  });
+
   it("relabels cluster-scoped tabs when reconciliation picks a surviving context", () => {
     const s = defaultState([ctx("a", "prod"), ctx("b", "staging")]);
     s.workspaces[0].tabs = [

--- a/packages/ui-next/src/lib/tabs.ts
+++ b/packages/ui-next/src/lib/tabs.ts
@@ -26,6 +26,8 @@ export interface Workspace {
   name: string;
   /** `ClusterContext.stableId`s. Never display names — see #265. */
   clusters: string[];
+  /** Clusters the reader has paused without removing from this workspace. */
+  pausedClusters?: string[];
   /** The cluster the sidebar and status bar are about. A `stableId` in `clusters`. */
   activeCluster?: string;
   tabs: Tab[];
@@ -122,6 +124,7 @@ export function defaultState(contexts: ClusterContext[]): TabsState {
     id: newId(),
     name: "Default",
     clusters: ids,
+    pausedClusters: [],
     tabs: [home],
     activeId: home.id,
     closed: [],
@@ -145,6 +148,8 @@ export function reconcile(state: TabsState, contexts: ClusterContext[]): TabsSta
     let next = w;
     const clusters = w.clusters.filter((id) => known.has(id));
     if (clusters.length !== w.clusters.length) next = { ...next, clusters };
+    const pausedClusters = (w.pausedClusters ?? []).filter((id) => clusters.includes(id));
+    if (pausedClusters.length !== (w.pausedClusters ?? []).length) next = { ...next, pausedClusters };
 
     // The active cluster follows its list: it survives if it is still there,
     // and otherwise the first that remains takes over — including for a

--- a/packages/ui-next/src/lib/tabsPersist.test.ts
+++ b/packages/ui-next/src/lib/tabsPersist.test.ts
@@ -128,6 +128,13 @@ describe("parseStoredState", () => {
     expect(parseStoredState(raw)?.workspaces[0].activeCluster).toBeUndefined();
   });
 
+  it("restores pauses only for clusters that remain in the workspace", () => {
+    const s = defaultState([ctx("a"), ctx("b")]);
+    s.workspaces[0].pausedClusters = ["a"];
+    const raw = JSON.stringify({ version: STORAGE_VERSION, ...s }).replace('["a"]', '["a","gone",7]');
+    expect(parseStoredState(raw)?.workspaces[0].pausedClusters).toEqual(["a"]);
+  });
+
   it("keeps a tab's sort through a save and a load", () => {
     const s = valid();
     s.workspaces[0].tabs[1].view = {

--- a/packages/ui-next/src/lib/tabsPersist.ts
+++ b/packages/ui-next/src/lib/tabsPersist.ts
@@ -80,6 +80,7 @@ function parseWorkspace(v: unknown): Workspace | null {
     activeId: v.activeId,
     closed,
   };
+  if (Array.isArray(v.pausedClusters)) ws.pausedClusters = v.pausedClusters.filter(isString).filter((id) => clusters.includes(id));
   // Only a cluster the workspace actually has: the field is an index into
   // `clusters`, and `reconcile` would drop a dangling one anyway.
   if (isString(v.activeCluster) && clusters.includes(v.activeCluster)) ws.activeCluster = v.activeCluster;

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -313,6 +313,15 @@ describe("workspaces", () => {
     store.setWorkspaceClusters(id, ["x", "y"]);
     expect(store.currentWorkspace().clusters).toEqual(["x", "y"]);
   });
+
+  it("keeps a pause in its workspace and clears it when that cluster is removed", () => {
+    const id = store.getState().currentId;
+    store.setWorkspaceClusters(id, ["x", "y"]);
+    store.setClusterPaused(id, "x", true);
+    expect(store.isClusterPaused("x")).toBe(true);
+    store.setWorkspaceClusters(id, ["y"]);
+    expect(store.currentWorkspace().pausedClusters).toEqual([]);
+  });
 });
 
 describe("setState", () => {

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -351,11 +351,26 @@ export function setWorkspaceClusters(id: string, clusters: string[]): void {
     // from the machine, not ones dropped from a workspace.
     const active = w.activeCluster && clusters.includes(w.activeCluster) ? w.activeCluster : clusters[0];
     if (same && active === w.activeCluster) return w;
-    const next: Workspace = { ...w, clusters: [...clusters] };
+    const next: Workspace = { ...w, clusters: [...clusters], pausedClusters: (w.pausedClusters ?? []).filter((cluster) => clusters.includes(cluster)) };
     if (active) next.activeCluster = active;
     else delete next.activeCluster;
     return next;
   });
+}
+
+/** A pause belongs to one workspace: another workspace may still use this cluster. */
+export function setClusterPaused(workspaceId: string, clusterId: string, paused: boolean): void {
+  patchWorkspace(workspaceId, (w) => {
+    if (!w.clusters.includes(clusterId)) return w;
+    const current = w.pausedClusters ?? [];
+    const next = paused ? (current.includes(clusterId) ? current : [...current, clusterId]) : current.filter((id) => id !== clusterId);
+    if (next.length === current.length && next.every((id, index) => id === current[index])) return w;
+    return { ...w, pausedClusters: next };
+  });
+}
+
+export function isClusterPaused(clusterId: string): boolean {
+  return (currentWorkspace().pausedClusters ?? []).includes(clusterId);
 }
 
 const EMPTY_VIEW: NonNullable<Tab["view"]> = {};

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -369,8 +369,9 @@ export function setClusterPaused(workspaceId: string, clusterId: string, paused:
   });
 }
 
-export function isClusterPaused(clusterId: string): boolean {
-  return (currentWorkspace().pausedClusters ?? []).includes(clusterId);
+export function isClusterPaused(clusterId: string, workspaceId = currentWorkspace().id): boolean {
+  const workspace = getState().workspaces.find((w) => w.id === workspaceId);
+  return (workspace?.pausedClusters ?? []).includes(clusterId);
 }
 
 const EMPTY_VIEW: NonNullable<Tab["view"]> = {};

--- a/packages/ui-next/src/screens/Connect.test.tsx
+++ b/packages/ui-next/src/screens/Connect.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 /**
@@ -199,6 +199,16 @@ function row(stableId: string) {
 
 describe("Connect", () => {
   describe("what §24 puts on the page", () => {
+    it("renders a disconnected cluster as paused rather than its retained reading", async () => {
+      open();
+      await waitFor(() => expect(row(PROD.stableId).status.textContent).toContain("reachable"));
+
+      act(() => store.setClusterPaused(store.currentWorkspace().id, PROD.stableId, true));
+
+      await waitFor(() => expect(row(PROD.stableId).status.textContent).toContain("paused"));
+      expect(row(PROD.stableId).latency).toBeNull();
+    });
+
     it("draws the eyebrow, both headline lines and the lede", async () => {
       core.isTauri.mockReturnValue(true);
       open();

--- a/packages/ui-next/src/screens/Connect.tsx
+++ b/packages/ui-next/src/screens/Connect.tsx
@@ -36,6 +36,7 @@ import { useMark } from "../lib/marks";
 import { openCluster } from "../lib/openCluster";
 import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
+import { useTabs } from "../lib/tabsStore";
 import { STATUS, bySource, latencyLabel, viaOf } from "./connections/clusterText";
 
 /**
@@ -154,6 +155,7 @@ const WEB_ONLY =
  * each of those rows re-render on every notification about any other one.
  */
 const UNREAD: Probe = { state: "unread" };
+const PAUSED: Probe = { state: "paused" };
 
 /**
  * How many files the rows came out of.
@@ -468,6 +470,7 @@ export function Connect({ route }: { route: string }) {
   const status = useContextsStatus();
   const listError = useContextsError();
   const probes = useProbes();
+  const { workspace } = useTabs();
 
   /** A listing asked for by the reader, still out. */
   const [busy, setBusy] = useState(false);
@@ -685,7 +688,7 @@ export function Connect({ route }: { route: string }) {
                 context={context}
                 // `no reading` until the store has an answer for this cluster,
                 // which is what lets every row paint before any probe lands.
-                probe={probes[context.stableId] ?? UNREAD}
+                probe={workspace.pausedClusters?.includes(context.stableId) ? PAUSED : (probes[context.stableId] ?? UNREAD)}
                 onOpen={openCluster}
               />
             ))}

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -445,6 +445,19 @@ describe("Connections", () => {
     expect(core.clusterFacts.mock.calls.filter((c) => c[0] === "staging-eu").length).toBe(2);
   });
 
+  it("shows a paused cluster as paused instead of its retained reading", async () => {
+    const user = userEvent.setup();
+    open();
+    await user.click(refreshAll());
+    await waitFor(() => expect(within(rowFor("prod-eu")).getByText("reachable")).toBeTruthy());
+
+    act(() => store.setClusterPaused(store.currentWorkspace().id, PROD.stableId, true));
+
+    await waitFor(() => expect(within(rowFor("prod-eu")).getByText("paused")).toBeTruthy());
+    expect(within(rowFor("prod-eu")).queryByText("41 ms")).toBeNull();
+    expect(detailFor(PROD)).toBeNull();
+  });
+
   /**
    * **The sequence guard.** A reader who hits `Refresh all` twice must be left
    * looking at the second answer, whatever order the two listings come back in.

--- a/packages/ui-next/src/screens/Connections.test.tsx
+++ b/packages/ui-next/src/screens/Connections.test.tsx
@@ -263,13 +263,21 @@ describe("Connections", () => {
     expect(screen.getAllByText("no reading").length).toBe(2);
   });
 
+  it("does not contact every configured cluster when the screen opens", async () => {
+    open();
+    await screen.findByText("prod-eu");
+    expect(core.connectCluster).not.toHaveBeenCalled();
+  });
+
   it("one cluster that does not answer does not hold up the others", async () => {
     core.connectCluster.mockImplementation(async (name: string) => {
       if (name === "prod-eu") return never<ClusterInfo>();
       clock += LATENCY[name] ?? 0;
       return REACHABLE[name];
     });
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     // The reachable one's own round trip, while the other is still out.
     expect(await screen.findByText("12 ms")).toBeTruthy();
     expect(within(rowFor("staging-eu")).getByText("reachable")).toBeTruthy();
@@ -282,7 +290,9 @@ describe("Connections", () => {
    * different round trips that answer them.
    */
   it("fills in the control-plane facts once a cluster has answered", async () => {
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     expect(await screen.findByText("gke · v1.30.6 · europe-west4")).toBeTruthy();
     expect(core.clusterFacts).toHaveBeenCalledWith("staging-eu");
   });
@@ -293,7 +303,9 @@ describe("Connections", () => {
       reachable: false,
       error: "no route to host",
     }));
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(screen.getAllByText("unreachable").length).toBe(2));
     expect(core.clusterFacts).not.toHaveBeenCalled();
   });
@@ -403,6 +415,7 @@ describe("Connections", () => {
   it("re-lists and re-reads every cluster on Refresh all", async () => {
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(screen.getByText("12 ms")).toBeTruthy());
     expect(core.connectCluster).toHaveBeenCalledTimes(2);
 
@@ -443,9 +456,9 @@ describe("Connections", () => {
       .mockResolvedValueOnce({ contexts: [PROD] });
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(drawn().length).toBe(2));
 
-    await user.click(refreshAll());
     await user.click(refreshAll());
     await waitFor(() => expect(drawn()).toEqual(["prod-eu"]));
 
@@ -481,6 +494,7 @@ describe("Connections", () => {
     });
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(drawn().length).toBe(2));
 
     // The new listing lands while staging is still connecting. Waited on prod's
@@ -526,7 +540,9 @@ describe("Connections", () => {
     core.clusterFacts.mockImplementation(async (context: string) =>
       context === "staging-eu" && ++asked === 1 ? slow.promise : facts({ context }),
     );
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(core.clusterFacts).toHaveBeenCalledWith("staging-eu"));
 
     // Somebody else lists the contexts. No `reload()`, no re-read flag — just a
@@ -553,7 +569,9 @@ describe("Connections", () => {
    */
   it("files a cluster's facts under its stableId, not its name", async () => {
     expect(STAGING.stableId).not.toBe(STAGING.name);
+    const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(detailFor(STAGING)).toBe("gke · v1.30.6 · europe-west4"));
     // The capability takes a context name, and that is what it was handed.
     expect(core.clusterFacts).toHaveBeenCalledWith(STAGING.name);
@@ -576,6 +594,7 @@ describe("Connections", () => {
     });
     const user = userEvent.setup();
     open();
+    await user.click(refreshAll());
     await waitFor(() => expect(screen.getByText("12 ms")).toBeTruthy());
 
     await user.click(refreshAll());

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -261,6 +261,9 @@ export function Connections({ route }: { route: string }) {
        * left the facts unfetched whenever a read spanned two listings.
        */
       if (force || getProbe(id).state === "unread") await probeCluster(context);
+      // Disconnect can happen while the reachability read is out. Do not turn
+      // the reading it invalidated into a follow-up facts request.
+      if (isClusterPaused(id)) return;
       // Not reachable: `provider` and `region` come from the API server, so
       // asking buys a second timeout for a row that already says why it is
       // empty. A later reading that DOES answer comes back through here.

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -23,7 +23,7 @@ import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { openCluster } from "../lib/openCluster";
 import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { isClusterPaused, openTab } from "../lib/tabsStore";
 import { ClusterTable, type ClusterRow } from "./connections/ClusterTable";
 import { SourcesRail } from "./connections/SourcesRail";
 
@@ -247,6 +247,8 @@ export function Connections({ route }: { route: string }) {
 
     async function read(context: ClusterContext) {
       const id = context.stableId;
+      // A saved reading is not permission to contact a paused cluster again.
+      if (isClusterPaused(id)) return;
       /**
        * **Awaited, never skipped.**
        *

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -23,7 +23,7 @@ import { FailureAlert, FailureState } from "../lib/errorCopy";
 import { openCluster } from "../lib/openCluster";
 import { getProbe, probeCluster, useProbes, type Probe } from "../lib/probe";
 import { describe } from "../lib/routes";
-import { isClusterPaused, openTab } from "../lib/tabsStore";
+import { isClusterPaused, openTab, useTabs } from "../lib/tabsStore";
 import { ClusterTable, type ClusterRow } from "./connections/ClusterTable";
 import { SourcesRail } from "./connections/SourcesRail";
 
@@ -46,6 +46,7 @@ const CONNECT = "/connect";
  * the `useMemo` below on every notification.
  */
 const UNREAD: Probe = { state: "unread" };
+const PAUSED: Probe = { state: "paused" };
 
 /**
  * `/connections` — §6's screen: every cluster srelens can see, what the last
@@ -92,6 +93,7 @@ export function Connections({ route }: { route: string }) {
   const status = useContextsStatus();
   const listError = useContextsError();
   const probes = useProbes();
+  const { workspace } = useTabs();
   /**
    * The kubeconfig paths this window was started with, read at render the way
    * `Helm` reads them.
@@ -308,11 +310,14 @@ export function Connections({ route }: { route: string }) {
   const rows = useMemo<ClusterRow[]>(
     () =>
       contexts.map((context) => {
-        const probe = probes[context.stableId] ?? UNREAD;
-        const known = facts[context.stableId];
+        const paused = workspace.pausedClusters?.includes(context.stableId) === true;
+        // A cached answer resumes after Reconnect, but must not be presented
+        // as current while this workspace has disconnected the cluster.
+        const probe = paused ? PAUSED : (probes[context.stableId] ?? UNREAD);
+        const known = paused ? undefined : facts[context.stableId];
         return known ? { context, probe, facts: known } : { context, probe };
       }),
-    [contexts, probes, facts],
+    [contexts, probes, facts, workspace.pausedClusters],
   );
 
   /**

--- a/packages/ui-next/src/screens/Connections.tsx
+++ b/packages/ui-next/src/screens/Connections.tsx
@@ -227,7 +227,7 @@ export function Connections({ route }: { route: string }) {
   }
 
   /**
-   * Read every cluster on the current list, each on its own.
+   * Read every cluster only after the reader explicitly refreshes the list.
    *
    * **Nothing here is awaited in series and nothing gates the render.** The
    * table is drawn from `contexts` the moment they exist, with every row
@@ -243,6 +243,7 @@ export function Connections({ route }: { route: string }) {
   useEffect(() => {
     const force = forceNext.current;
     forceNext.current = false;
+    if (!force) return;
 
     async function read(context: ClusterContext) {
       const id = context.stableId;

--- a/packages/ui-next/src/screens/Events.tsx
+++ b/packages/ui-next/src/screens/Events.tsx
@@ -38,13 +38,14 @@ import {
 } from "../lib/kinds/events";
 import { useResourceList } from "../lib/resourceList";
 import { describe } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { openTab, useTabs } from "../lib/tabsStore";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
 import { ReasonRail } from "./events/ReasonRail";
 import {
   NamespaceErrorAlert,
   NamespacePicker,
   NoClusterScreen,
+  PausedClusterScreen,
   StaleSelectionAlert,
   columnOptionsFor,
   emptyTableCopy,
@@ -121,10 +122,14 @@ const GROUP_BY_CAUSE = "What do these warning events have in common?";
  */
 export function Events({ route }: { route: string }) {
   const context = useActiveContext();
+  const { workspace } = useTabs();
   const title = describe(route, context?.name).title;
 
   if (!context) {
     return <NoClusterScreen title={title} noun="events" />;
+  }
+  if (workspace.pausedClusters?.includes(context.stableId)) {
+    return <PausedClusterScreen title={title} noun="events" context={context} />;
   }
 
   return <EventList route={route} title={title} context={context} />;

--- a/packages/ui-next/src/screens/Forwards.test.tsx
+++ b/packages/ui-next/src/screens/Forwards.test.tsx
@@ -53,7 +53,7 @@ vi.mock("@srelens/core", async (orig) => ({
 import { type ActiveForward, type ClusterContext, kindToForwardTarget, toKubectl } from "@srelens/core";
 import { Forwards } from "./Forwards";
 import { resetContexts, setContexts } from "../lib/clusters";
-import { setActiveCluster, setState } from "../lib/tabsStore";
+import { currentWorkspace, setClusterPaused, setActiveCluster, setState } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 
 const ROUTE = "/forwards";
@@ -603,6 +603,12 @@ describe("Forwards — the row's actions", () => {
 });
 
 describe("Forwards — the screen around the table", () => {
+  it("closes creation when its captured cluster is paused after a rail switch", async () => {
+    await fillNewForwardThenMove();
+    act(() => setClusterPaused(currentWorkspace().id, PROD.stableId, true));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(core.startPortForward).not.toHaveBeenCalled();
+  });
   it("adopts the forwards the backend is still running, once, on mount", async () => {
     open();
     // The web-mode leak this screen exists to close: the store is module-level

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -29,6 +29,7 @@ import {
   type StatusKind,
 } from "@srelens/ui-kit";
 import { useActiveContext } from "../lib/clusters";
+import { useTabs } from "../lib/tabsStore";
 import { FailureAlert, FailureWord } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { formatBytes } from "../lib/numbers";
@@ -266,6 +267,8 @@ export function Forwards(_props: { route: string }) {
    * for exactly that reason (see `Forwarding` there); this is the other door.
    */
   const [newForward, setNewForward] = useState<{ context: string; namespace?: string } | null>(null);
+  const { workspace } = useTabs();
+  const paused = cluster !== undefined && workspace.pausedClusters?.includes(cluster.stableId) === true;
 
   /**
    * What the dialog says, and asks again, when the rail moves out from under
@@ -295,7 +298,7 @@ export function Forwards(_props: { route: string }) {
   };
 
   const newForwardButton = (
-    <Button variant="primary" size="sm" onClick={openNewForward}>
+    <Button variant="primary" size="sm" onClick={openNewForward} disabled={paused}>
       New forward
     </Button>
   );

--- a/packages/ui-next/src/screens/Forwards.tsx
+++ b/packages/ui-next/src/screens/Forwards.tsx
@@ -30,6 +30,7 @@ import {
 } from "@srelens/ui-kit";
 import { useActiveContext } from "../lib/clusters";
 import { useTabs } from "../lib/tabsStore";
+import { useDismissOnPause } from "../lib/pausedContext";
 import { FailureAlert, FailureWord } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { formatBytes } from "../lib/numbers";
@@ -267,6 +268,7 @@ export function Forwards(_props: { route: string }) {
    * for exactly that reason (see `Forwarding` there); this is the other door.
    */
   const [newForward, setNewForward] = useState<{ context: string; namespace?: string } | null>(null);
+  const targetPaused = useDismissOnPause(newForward?.context, () => setNewForward(null));
   const { workspace } = useTabs();
   const paused = cluster !== undefined && workspace.pausedClusters?.includes(cluster.stableId) === true;
 
@@ -423,7 +425,7 @@ export function Forwards(_props: { route: string }) {
     <Screen title="Port forwards" eyebrow="all clusters" actions={newForwardButton} fill>
       {/* Beside the body rather than inside either branch of it, so the dialog
           opens the same from a populated screen and an empty one. */}
-      {newForward && (
+      {newForward && !targetPaused && (
         <NewForwardDialog
           // The cluster that was in focus when the dialog was asked for, not
           // the one in focus now. A forward is made in one cluster even though

--- a/packages/ui-next/src/screens/Home.test.tsx
+++ b/packages/ui-next/src/screens/Home.test.tsx
@@ -6,7 +6,7 @@ import { screenFor } from "../lib/routes";
 import { Home } from "./Home";
 import { resetContexts, setContexts } from "../lib/clusters";
 import { defaultMark, loadMarks, setMark } from "../lib/marks";
-import { activeCluster, activeRoute, currentWorkspace, setState } from "../lib/tabsStore";
+import { activeCluster, activeRoute, currentWorkspace, setState, setClusterPaused } from "../lib/tabsStore";
 import { defaultState } from "../lib/tabs";
 import { resetView, setLink } from "../lib/workspace";
 
@@ -25,6 +25,15 @@ beforeEach(() => {
 });
 
 describe("Home", () => {
+  it("uses a neutral status for a paused cluster with a retained successful probe", () => {
+    setContexts([PROD]);
+    setState(defaultState([PROD]));
+    setLink(PROD.stableId, "connected");
+    setClusterPaused(currentWorkspace().id, PROD.stableId, true);
+    render(<Home />);
+    const row = screen.getByRole("button", { name: "Open cluster prod — Paused" });
+    expect(row.querySelector(".status")?.getAttribute("data-kind")).toBe("neutral");
+  });
   it("offers a working first step when no clusters are configured", async () => {
     setContexts([]);
     render(<Home />);

--- a/packages/ui-next/src/screens/Home.tsx
+++ b/packages/ui-next/src/screens/Home.tsx
@@ -103,7 +103,7 @@ function ClusterRow({ context, link, paused }: { context: ClusterContext; link?:
         <span className="block truncate font-medium">{mark.name}</span>
         <span className="block truncate text-xs text-muted" title={secondary}>{secondary}</span>
       </span>
-      <StatusPill status={status} kind={link?.state === "connected" ? "success" : link?.state === "connecting" ? "info" : link?.state === "error" ? "danger" : "neutral"} />
+      <StatusPill status={status} kind={paused ? "neutral" : link?.state === "connected" ? "success" : link?.state === "connecting" ? "info" : link?.state === "error" ? "danger" : "neutral"} />
       <span aria-hidden className="text-muted">→</span>
     </button>
   </li>;

--- a/packages/ui-next/src/screens/Home.tsx
+++ b/packages/ui-next/src/screens/Home.tsx
@@ -10,6 +10,7 @@ import { symbolFor } from "../lib/markSymbols";
 import { openCluster } from "../lib/openCluster";
 import { openTab } from "../lib/tabsStore";
 import { LINK_WORD, useWorkspaceView } from "../lib/workspace";
+import { useTabs } from "../lib/tabsStore";
 
 /** App-wide entry point. Contexts and connection status come from the shell's shared stores. */
 export function Home() {
@@ -20,6 +21,7 @@ export function Home() {
   // Like the rail, subscribe once so filtering follows saved display-name edits.
   useEditableMark("", "");
   const { links } = useWorkspaceView();
+  const { workspace } = useTabs();
   const [query, setQuery] = useState("");
   const [retrying, setRetrying] = useState(false);
   const mounted = useRef(false);
@@ -69,7 +71,7 @@ export function Home() {
               status === "loaded" && <EmptyState title="No clusters configured" hint="Add a kubeconfig or connect to a cluster to start exploring. Your saved connections will appear here." />
             ) : filtered.length === 0 ? <EmptyState title="No matching clusters" hint="Search by display name, context, or API server." action={<Button variant="secondary" size="sm" onClick={() => setQuery("")}>Clear search</Button>} /> : (
               <ul className="home-cluster-list scroll" aria-label="Saved clusters">
-                {filtered.map(ctx => <ClusterRow key={ctx.stableId} context={ctx} link={links[ctx.stableId]} />)}
+                {filtered.map(ctx => <ClusterRow key={ctx.stableId} context={ctx} link={links[ctx.stableId]} paused={workspace.pausedClusters?.includes(ctx.stableId) === true} />)}
               </ul>
             )}
           </section>
@@ -85,9 +87,9 @@ export function Home() {
   );
 }
 
-function ClusterRow({ context, link }: { context: ClusterContext; link?: ReturnType<typeof useWorkspaceView>["links"][string] }) {
+function ClusterRow({ context, link, paused }: { context: ClusterContext; link?: ReturnType<typeof useWorkspaceView>["links"][string]; paused: boolean }) {
   const mark = getMark(context.stableId, context.name);
-  const status = link ? LINK_WORD[link.state] : "Not checked";
+  const status = paused ? "Paused" : link ? LINK_WORD[link.state] : "Not checked";
   let secondary = context.name;
   if (mark.name === context.name) {
     try { secondary = new URL(context.server).host; }

--- a/packages/ui-next/src/screens/ResourceMenu.test.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { setContexts } from "../lib/clusters";
 import userEvent from "@testing-library/user-event";
 
 // Everything this hook reaches into core for. Mocked so a test can control
@@ -512,6 +513,15 @@ describe("useRowMenu — the cluster the row was picked on", () => {
   const box = () => within(screen.getByRole("dialog"));
   const tickFor = (verb: string) => screen.getByRole("checkbox", { name: `Yes, still ${verb} on ${PINNED}.` });
   const REFUSAL = `This runs on ${PINNED}, not ${MOVED}. Confirm the cluster above, or cancel.`;
+  it("dismisses a pending write when its captured cluster is paused", async () => {
+    const contexts = [PINNED, MOVED].map(name => ({ name, stableId: `id-${name}`, cluster: name, server: "", isCurrent: false, sourceFile: "", authKind: "token" }));
+    setContexts(contexts);
+    store.setState(defaultState(contexts));
+    await pickThenMove("Delete");
+    act(() => store.setClusterPaused(store.currentWorkspace().id, `id-${PINNED}`, true));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(deleteResource).not.toHaveBeenCalled();
+  });
 
   /** Pick an entry on `prod-eu`, then move the rail to `stage-eu` under it. */
   async function pickThenMove(label: string, args: (context: string) => UseRowMenuArgs = argsOn) {

--- a/packages/ui-next/src/screens/ResourceMenu.tsx
+++ b/packages/ui-next/src/screens/ResourceMenu.tsx
@@ -26,6 +26,7 @@ import { ROW_ACTION_LABEL } from "../lib/kinds/rowActions";
 import type { KindActions, ListRow } from "../lib/kinds/types";
 import { startPodSession } from "../lib/sessions";
 import { openTab } from "../lib/tabsStore";
+import { isContextPaused, useDismissOnPause } from "../lib/pausedContext";
 import { NewForwardDialog } from "./forwards/NewForwardDialog";
 import { logsRoute } from "./Logs";
 
@@ -164,6 +165,11 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
    * a question with its own fields, not a `Pending` variant.
    */
   const [shellPick, setShellPick] = useState<ShellPick | null>(null);
+  const targetPaused = useDismissOnPause(pending?.context ?? forwarding?.context ?? shellPick?.context, () => {
+    setPending(null);
+    setForwarding(null);
+    setShellPick(null);
+  });
   const [shellBusy, setShellBusy] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
@@ -247,7 +253,9 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
     // `getObject` is in flight, and a shell opened on one cluster's container
     // list must not attach to another cluster's pod of the same name.
     const target = context;
+    if (isContextPaused(target)) return;
     const result = await getObject(target, kind, namespace || null, row.name);
+    if (isContextPaused(target)) return;
     if (result.error || !result.object) {
       notify.error(`Couldn't open a shell in ${row.name}`, describeError(result.error ?? "Pod not found").detail);
       return;
@@ -275,6 +283,7 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
    *  `/terminals`, worth showing rather than hiding behind a tab that never
    *  opens. */
   async function launchShell(row: ListRow, namespace: string, container: string, target: string) {
+    if (isContextPaused(target)) return;
     await startPodSession({ context: target, namespace, pod: row.name, container });
     openTab("/terminals", { clusterName: target });
   }
@@ -288,7 +297,7 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
   }
 
   async function confirm() {
-    if (!pending) return;
+    if (!pending || isContextPaused(pending.context)) return;
     const { row, context: target } = pending;
     const ns = row.namespace ?? "";
 
@@ -435,7 +444,7 @@ export function useRowMenu({ context, kind, actions, group }: UseRowMenuArgs): {
     return list;
   }
 
-  const dialog = pending ? (
+  const dialog = targetPaused ? null : pending ? (
     <PendingDialog
       pending={pending}
       kind={kind}

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -33,7 +33,7 @@ import { rowKey, type KindDescriptor, type ListRow } from "../lib/kinds/types";
 import { clampPeekWidth, savePeekWidth, setPeekWidth, usePeekBounds, usePeekWidth } from "../lib/peekWidth";
 import { useResourceList } from "../lib/resourceList";
 import { describe, isBuiltInKind } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { openTab, useTabs } from "../lib/tabsStore";
 import { useResource } from "../lib/useResource";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
@@ -46,6 +46,7 @@ import {
   NamespaceErrorAlert,
   NamespacePicker,
   NoClusterScreen,
+  PausedClusterScreen,
   StaleSelectionAlert,
   columnOptionsFor,
   defaultHiddenKeys,
@@ -79,6 +80,7 @@ const CRD_RAIL_WIDTH = 264;
  */
 export function Resources({ route }: { route: string }) {
   const context = useActiveContext();
+  const { workspace } = useTabs();
   const slug = route.slice("/k/".length);
   // The tab strip already knows what this route is called; asking `describe`
   // keeps the screen's title and the tab's title the same string.
@@ -86,6 +88,9 @@ export function Resources({ route }: { route: string }) {
 
   if (!context) {
     return <NoClusterScreen title={title} noun="resources" />;
+  }
+  if (workspace.pausedClusters?.includes(context.stableId)) {
+    return <PausedClusterScreen title={title} noun="resources" context={context} />;
   }
 
   return <KindList route={route} slug={slug} title={title} context={context} />;

--- a/packages/ui-next/src/screens/Terminals.test.tsx
+++ b/packages/ui-next/src/screens/Terminals.test.tsx
@@ -175,6 +175,11 @@ afterEach(() => {
 });
 
 describe("Terminals", () => {
+  it("closes creation when its captured cluster is paused after a rail switch", async () => {
+    await pickPodThenMove(userEvent.setup());
+    act(() => tabs.setClusterPaused(tabs.currentWorkspace().id, CTX.stableId, true));
+    expect(screen.queryByRole("button", { name: "Start session" })).toBeNull();
+  });
   it("lets the pane shrink, so the rail is not pushed off the window", async () => {
     // xterm sizes its content in explicit pixels, and a flex item's implicit
     // `min-width: auto` refuses to shrink below its content — so without

--- a/packages/ui-next/src/screens/Terminals.tsx
+++ b/packages/ui-next/src/screens/Terminals.tsx
@@ -14,6 +14,7 @@ import { useConsole } from "../console";
 import { useActiveContext } from "../lib/clusters";
 import { ClusterMovedAlert } from "../lib/clusterMoved";
 import { useTabs } from "../lib/tabsStore";
+import { useDismissOnPause } from "../lib/pausedContext";
 import {
   endSession,
   getSessions,
@@ -209,6 +210,7 @@ export function Terminals(_props: { route: string }) {
    * `ResourceMenu`'s `Open shell` pinned its own pick for the same reason.
    */
   const [newSession, setNewSession] = useState<{ context: string; namespace: string } | null>(null);
+  const targetPaused = useDismissOnPause(newSession?.context, () => setNewSession(null));
 
   /**
    * A session started anywhere — this screen's menu, or the resource row
@@ -278,7 +280,7 @@ export function Terminals(_props: { route: string }) {
         </>
       }
     >
-      {newSession && (
+      {newSession && !targetPaused && (
         <NewSessionMenu
           // The cluster that was in focus when `New session` was pressed, not
           // the active session's and not the one in focus now: a new session is

--- a/packages/ui-next/src/screens/Terminals.tsx
+++ b/packages/ui-next/src/screens/Terminals.tsx
@@ -13,6 +13,7 @@ import {
 import { useConsole } from "../console";
 import { useActiveContext } from "../lib/clusters";
 import { ClusterMovedAlert } from "../lib/clusterMoved";
+import { useTabs } from "../lib/tabsStore";
 import {
   endSession,
   getSessions,
@@ -192,6 +193,8 @@ function askQuestion(session: TerminalSessionRow | undefined, context: string): 
 export function Terminals(_props: { route: string }) {
   const sessions = useSyncExternalStore(subscribeSessions, getSessions, getSessions);
   const cluster = useActiveContext();
+  const { workspace } = useTabs();
+  const paused = cluster !== undefined && workspace.pausedClusters?.includes(cluster.stableId) === true;
   const { ask } = useConsole();
   const [picked, setPicked] = useState<number | null>(null);
   /**
@@ -265,6 +268,7 @@ export function Terminals(_props: { route: string }) {
           <Button
             variant="primary"
             size="sm"
+            disabled={paused}
             onClick={() =>
               setNewSession({ context: cluster?.name ?? "", namespace: cluster?.namespace ?? "" })
             }
@@ -316,6 +320,7 @@ export function Terminals(_props: { route: string }) {
             onNewSession={() =>
               setNewSession({ context: cluster?.name ?? "", namespace: cluster?.namespace ?? "" })
             }
+            newSessionDisabled={paused}
           />
         }
         mainHead={

--- a/packages/ui-next/src/screens/Workloads.tsx
+++ b/packages/ui-next/src/screens/Workloads.tsx
@@ -48,13 +48,14 @@ import { withRowAffordances } from "../lib/kinds/rowAffordances";
 import type { ListRow } from "../lib/kinds/types";
 import { useResourceList, type ResourceList } from "../lib/resourceList";
 import { describe } from "../lib/routes";
-import { openTab } from "../lib/tabsStore";
+import { openTab, useTabs } from "../lib/tabsStore";
 import { setNamespaces, useNamespaces } from "../lib/workspace";
 import { useRowMenu } from "./ResourceMenu";
 import {
   NamespaceErrorAlert,
   NamespacePicker,
   NoClusterScreen,
+  PausedClusterScreen,
   StaleSelectionAlert,
   columnOptionsFor,
   emptyTableCopy,
@@ -241,10 +242,14 @@ const UNION_COLUMNS: Column<WorkloadRow>[] = [
  */
 export function Workloads({ route }: { route: string }) {
   const context = useActiveContext();
+  const { workspace } = useTabs();
   const title = describe(route, context?.name).title;
 
   if (!context) {
     return <NoClusterScreen title={title} noun="workloads" />;
+  }
+  if (workspace.pausedClusters?.includes(context.stableId)) {
+    return <PausedClusterScreen title={title} noun="workloads" context={context} />;
   }
 
   return <WorkloadList route={route} title={title} context={context} />;

--- a/packages/ui-next/src/screens/connections/clusterText.ts
+++ b/packages/ui-next/src/screens/connections/clusterText.ts
@@ -161,4 +161,5 @@ export const STATUS: Record<ProbeState, { word: string; tone: BadgeTone }> = {
   reachable: { word: "reachable", tone: "ok" },
   unreachable: { word: "unreachable", tone: "sev" },
   unread: { word: "no reading", tone: "muted" },
+  paused: { word: "paused", tone: "muted" },
 };

--- a/packages/ui-next/src/screens/resourceShell.tsx
+++ b/packages/ui-next/src/screens/resourceShell.tsx
@@ -1,7 +1,9 @@
+import type { ClusterContext } from "@srelens/core";
 import { Alert, Button, Combobox, EmptyState, LoadingState, MultiSelect, Screen, Spinner, type Column, type TableSort } from "@srelens/ui-kit";
 import { useContextsError, useContextsStatus } from "../lib/clusters";
 import { toggleColumn } from "../lib/columnPrefs";
 import { FailureAlert, FailureState } from "../lib/errorCopy";
+import { reconnectCluster } from "../lib/openCluster";
 import { setTabView, useTabs, useTabView } from "../lib/tabsStore";
 
 /**
@@ -72,6 +74,20 @@ export function NoClusterScreen({ title, noun }: { title: string; noun: string }
           className="flex-1"
         />
       )}
+    </Screen>
+  );
+}
+
+/** A paused cluster keeps its place while every resource reader is stopped. */
+export function PausedClusterScreen({ title, noun, context }: { title: string; noun: string; context: ClusterContext }) {
+  return (
+    <Screen title={title} eyebrow={context.name} fill>
+      <EmptyState
+        title={`${context.name} is paused`}
+        hint={`Reconnect this cluster to resume listing ${noun}.`}
+        action={<Button variant="primary" onClick={() => reconnectCluster(context)}>Reconnect</Button>}
+        className="flex-1"
+      />
     </Screen>
   );
 }

--- a/packages/ui-next/src/screens/terminals/SessionRail.tsx
+++ b/packages/ui-next/src/screens/terminals/SessionRail.tsx
@@ -148,6 +148,8 @@ export interface SessionRailProps {
   onSelect: (id: number) => void;
   /** "New session" was picked, from the empty state. */
   onNewSession: () => void;
+  /** The screen is still usable, but the active cluster cannot start a shell. */
+  newSessionDisabled?: boolean;
 }
 
 /**
@@ -171,7 +173,7 @@ export interface SessionRailProps {
  * store precisely so a ticking display here does not churn its snapshot —
  * this component owns the clock the store deliberately does not.
  */
-export function SessionRail({ sessions, activeId, onSelect, onNewSession }: SessionRailProps) {
+export function SessionRail({ sessions, activeId, onSelect, onNewSession, newSessionDisabled = false }: SessionRailProps) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const tick = setInterval(() => setNow(Date.now()), IDLE_TICK_MS);
@@ -185,7 +187,7 @@ export function SessionRail({ sessions, activeId, onSelect, onNewSession }: Sess
         title="No sessions"
         hint="Open a shell into a pod, a node, or this machine."
         action={
-          <Button size="xs" onClick={onNewSession}>
+          <Button size="xs" onClick={onNewSession} disabled={newSessionDisabled}>
             New session
           </Button>
         }

--- a/packages/ui-next/src/shell/Body.test.tsx
+++ b/packages/ui-next/src/shell/Body.test.tsx
@@ -90,4 +90,18 @@ describe("Body", () => {
     await userEvent.click(screen.getByRole("button", { name: "seal from the screen" }));
     expect(onLocked).toHaveBeenCalledTimes(1);
   });
+
+  it("does not mount a pinned screen while its cluster is paused", () => {
+    render(
+      <Body
+        route="/applog"
+        ported={[]}
+        onOpenInClassic={() => {}}
+        onLocked={() => {}}
+        pausedContext={{ name: "prod-eu", stableId: "prod", cluster: "prod", server: "", isCurrent: false, sourceFile: "", authKind: "token" }}
+      />,
+    );
+    expect(screen.getByText("prod-eu is paused")).toBeDefined();
+    expect(screen.queryByText("screen for /applog")).toBeNull();
+  });
 });

--- a/packages/ui-next/src/shell/Body.tsx
+++ b/packages/ui-next/src/shell/Body.tsx
@@ -1,7 +1,16 @@
-import { screenFor } from "../lib/routes";
+import type { ClusterContext } from "@srelens/core";
+import { Button, EmptyState, Screen as AppScreen } from "@srelens/ui-kit";
+import { describe, screenFor } from "../lib/routes";
+import { reconnectCluster } from "../lib/openCluster";
 import { Placeholder, type PlaceholderProps } from "./Placeholder";
 
 export interface BodyProps extends PlaceholderProps {
+  /**
+   * The cluster pinned to this tab when it has been paused. Kept at the router
+   * boundary so even hidden, mounted tabs cannot keep capability readers
+   * alive after their cluster is disconnected.
+   */
+  pausedContext?: ClusterContext;
   /**
    * Raise the lock surface over the window. Forwarded to the screen untouched
    * — see `RoutedScreenProps.onLocked` for what the contract is and why it is
@@ -16,7 +25,20 @@ export interface BodyProps extends PlaceholderProps {
  * This is the whole of the router. Everything about which screens exist lives
  * in `screenFor`; this only asks.
  */
-export function Body({ onLocked, ...props }: BodyProps) {
+export function Body({ onLocked, pausedContext, ...props }: BodyProps) {
+  if (pausedContext) {
+    const title = describe(props.route, pausedContext.name).title;
+    return (
+      <AppScreen title={title} eyebrow={pausedContext.name} fill>
+        <EmptyState
+          title={`${pausedContext.name} is paused`}
+          hint="Reconnect this cluster to resume this view."
+          action={<Button variant="primary" onClick={() => reconnectCluster(pausedContext)}>Reconnect</Button>}
+          className="flex-1"
+        />
+      </AppScreen>
+    );
+  }
   const Screen = screenFor(props.route);
   return Screen ? (
     <Screen

--- a/packages/ui-next/src/shell/Console.test.tsx
+++ b/packages/ui-next/src/shell/Console.test.tsx
@@ -1218,13 +1218,14 @@ describe("Console — header details", () => {
     expect(screen.getByText("2 exchanges")).toBeDefined();
   });
 
-  it("wires the dock's Stop to the store, and only while a turn is in flight", async () => {
+  it.each([false, true])("keeps Stop wired to the store while a turn is in flight (paused: %s)", async (paused) => {
     const user = userEvent.setup();
     useRun.mockReturnValue(
       runState({ busy: true, turns: [{ id: 1, role: "user", text: "q", calls: [], at: 1 }] }),
     );
     setup();
     await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    if (paused) act(() => tabsStore.setClusterPaused(tabsStore.currentWorkspace().id, HARNESS_CTX.stableId, true));
     await user.click(screen.getByRole("button", { name: "Stop" }));
     expect(stopAgentRun).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui-next/src/shell/Console.test.tsx
+++ b/packages/ui-next/src/shell/Console.test.tsx
@@ -489,6 +489,36 @@ describe("Console", () => {
     expect(askAgent).not.toHaveBeenCalled();
   });
 
+  it("refuses both screen asks and typed questions for a paused cluster", async () => {
+    const user = userEvent.setup();
+    setup();
+    act(() => tabsStore.setClusterPaused(tabsStore.currentWorkspace().id, HARNESS_CTX.stableId, true));
+    await user.click(screen.getByRole("button", { name: "Ask from elsewhere" }));
+    const box = screen.getByRole("textbox", { name: "Console prompt" });
+    await user.type(box, "why is it failing");
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(askAgent).not.toHaveBeenCalled();
+    expect((box as HTMLTextAreaElement).value).toBe("why is it failing");
+    expect(screen.getByText(/Reconnect .* to send a question/)).toBeTruthy();
+  });
+
+  it("checks the selected conversation's cluster even when the rail is elsewhere", async () => {
+    const stage = ctx("stage-id", "staging");
+    setContexts([HARNESS_CTX, stage]);
+    tabsStore.setState(defaultState([HARNESS_CTX, stage]));
+    tabsStore.setActiveCluster(stage.stableId, stage.name);
+    tabsStore.setClusterPaused(tabsStore.currentWorkspace().id, HARNESS_CTX.stableId, true);
+    tabsStore.openTab("/agent");
+    useRunSubject.mockReturnValue({ about: { cluster: HARNESS_CTX.name }, route: "/overview" });
+    useActiveRunKey.mockReturnValue("prod-eu|overview");
+    render(<ConsoleProvider onToggleTheme={() => {}}><Console fullView /></ConsoleProvider>);
+    const box = screen.getByRole("textbox", { name: "Console prompt" });
+    await userEvent.type(box, "inspect prod");
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(askAgent).not.toHaveBeenCalled();
+    expect(screen.getByText("Reconnect prod-eu to send a question")).toBeTruthy();
+  });
+
   /**
    * Codex P1: this component renders `null` in a browser, but the guard sits
    * BELOW the effect that registers the submit handler — so a screen's own Ask

--- a/packages/ui-next/src/shell/Console.tsx
+++ b/packages/ui-next/src/shell/Console.tsx
@@ -33,6 +33,7 @@ import { openTab, setActiveCluster, switchWorkspace, useTabs } from "../lib/tabs
 import { logsRoute } from "../screens/Logs";
 import { Transcript } from "../screens/agent/Transcript";
 import { useWorkspaceSealed } from "./LockGate";
+import { isContextPaused } from "../lib/pausedContext";
 
 /** §F's four palette groups, in the order the mock lists them. */
 const GROUPS: readonly CommandGroup[] = ["Action", "Go", "Cluster", "Workspace"];
@@ -268,6 +269,7 @@ export function Console({ fullView }: { fullView?: boolean }) {
   // `askAgent` will be given.
   const askAbout = shown?.about ?? about;
   const askCluster = askAbout.cluster || context;
+  const askPaused = contexts.some(c => c.name === askCluster && workspace.pausedClusters?.includes(c.stableId));
   const askScope = shown ? contextLabelFor(shown.route, shown.about.cluster) : scope;
 
   const deps = useMemo<CommandDeps>(
@@ -363,6 +365,12 @@ export function Console({ fullView }: { fullView?: boolean }) {
       return false;
     }
     setNoCluster(false);
+    // A selected conversation can target a different cluster from the rail.
+    // Check that actual target at submission time, before consuming the draft.
+    if (isContextPaused(askCluster)) {
+      setOpen(true);
+      return false;
+    }
     return true;
   }
 
@@ -688,6 +696,11 @@ export function Console({ fullView }: { fullView?: boolean }) {
           {noCluster && (
             <span className="chip" style={{ color: "var(--sev)" }}>
               <span>No cluster is active — connect one before asking</span>
+            </span>
+          )}
+          {askPaused && (
+            <span className="chip">
+              <span>Reconnect {askCluster} to send a question</span>
             </span>
           )}
           {reading > 0 && (

--- a/packages/ui-next/src/shell/Nav.tsx
+++ b/packages/ui-next/src/shell/Nav.tsx
@@ -76,7 +76,7 @@ export function Nav({ contexts }: NavProps) {
 
   // Subscribes the sidebar to the strip: which row is highlighted is a fact
   // about the active tab, and that changes from a dozen places that are not here.
-  const { tabs, activeId } = useTabs();
+  const { tabs, activeId, workspace } = useTabs();
   const route = tabs.find((t) => t.id === activeId)?.route ?? "/";
 
   const name = ctx?.name;
@@ -118,7 +118,9 @@ export function Nav({ contexts }: NavProps) {
     [crds, crdChildren],
   );
 
-  const link = ctx ? (view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN) : UNKNOWN;
+  const link = ctx
+    ? (workspace.pausedClusters?.includes(ctx.stableId) ? { word: "Paused", kind: "neutral" as const } : view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN)
+    : UNKNOWN;
 
   const navigationWidth = useNavigationWidth();
 

--- a/packages/ui-next/src/shell/Nav.tsx
+++ b/packages/ui-next/src/shell/Nav.tsx
@@ -80,16 +80,17 @@ export function Nav({ contexts }: NavProps) {
   const route = tabs.find((t) => t.id === activeId)?.route ?? "/";
 
   const name = ctx?.name;
+  const paused = ctx !== null && (workspace.pausedClusters ?? []).includes(ctx.stableId);
   const discovery = useResource<CrdRef[]>(
     async () => {
-      if (!name) return [];
+      if (!name || paused) return [];
       const out = await listCrds(name);
       // `listCrds` reports failure in the result rather than by rejecting, and
       // an empty tree is not the same news as "we were not allowed to look".
       if (out.error) throw new Error(out.error);
       return out.crds ?? [];
     },
-    [name],
+    [name, paused],
   );
   const crds = useMemo(() => discovery.data ?? [], [discovery.data]);
 
@@ -119,7 +120,7 @@ export function Nav({ contexts }: NavProps) {
   );
 
   const link = ctx
-    ? (workspace.pausedClusters?.includes(ctx.stableId) ? { word: "Paused", kind: "neutral" as const } : view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN)
+    ? (paused ? { word: "Paused", kind: "neutral" as const } : view.links[ctx.stableId] ? LINK[view.links[ctx.stableId].state] : UNKNOWN)
     : UNKNOWN;
 
   const navigationWidth = useNavigationWidth();

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -181,6 +181,15 @@ describe("Rail", () => {
     expect(within(menu).getByRole("menuitem", { name: "Reconnect" })).toBeDefined();
   });
 
+  it("does not describe a paused cluster as connecting", async () => {
+    setLink("prod-eu", "connecting");
+    setup();
+    const menu = await openMenu("prod-eu", "prod-eu, Connecting");
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Disconnect" }));
+    expect(screen.getByRole("button", { name: "prod-eu, Paused" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Connecting/ })).toBeNull();
+  });
+
   it("removes the cluster from the workspace", async () => {
     setup();
     await pick("prod-eu", "Remove from workspace");

--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -49,8 +49,8 @@ function setup(props: Partial<Parameters<typeof Rail>[0]> = {}) {
 }
 
 /** Right-click a mark and wait for the menu that names it. */
-async function openMenu(cluster: string) {
-  fireEvent.contextMenu(screen.getByRole("button", { name: cluster }));
+async function openMenu(cluster: string, buttonName = cluster) {
+  fireEvent.contextMenu(screen.getByRole("button", { name: buttonName }));
   return screen.findByRole("menu", { name: `${cluster} actions` });
 }
 
@@ -108,7 +108,7 @@ describe("Rail", () => {
     const items = within(menu)
       .getAllByRole("menuitem")
       .map((item) => item.getAttribute("aria-label"));
-    expect(items).toEqual(["Open prod-eu", "Customise…", "Connection details", "Remove from workspace"]);
+    expect(items).toEqual(["Open prod-eu", "Customise…", "Disconnect", "Connection details", "Remove from workspace"]);
     expect(screen.queryByRole("complementary", { name: "Details" })).toBeNull();
   });
 
@@ -169,6 +169,16 @@ describe("Rail", () => {
     setup();
     await pick("prod-eu", "Connection details");
     expect(currentWorkspace().tabs.map((t) => t.route)).toContain("/connections");
+  });
+
+  it("pauses a cluster in place and offers Reconnect from the same menu", async () => {
+    setup();
+    await pick("prod-eu", "Disconnect");
+    expect(currentWorkspace().clusters).toContain("prod-eu");
+    expect(currentWorkspace().pausedClusters).toEqual(["prod-eu"]);
+    expect(screen.getByRole("button", { name: "prod-eu, Paused" })).toBeDefined();
+    const menu = await openMenu("prod-eu", "prod-eu, Paused");
+    expect(within(menu).getByRole("menuitem", { name: "Reconnect" })).toBeDefined();
   });
 
   it("removes the cluster from the workspace", async () => {

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -98,6 +98,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
     const mark = getMark(id, ctx.name);
     const info = infos[id];
     const link = links[id];
+    const paused = workspace.pausedClusters?.includes(id) === true;
     items.push({
       id,
       name: mark.name,
@@ -131,7 +132,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
       // is not offered here because there is nowhere in a 46px strip to offer
       // it from; the overview's Fleet row for the same cluster has it.
       unavailable:
-        workspace.pausedClusters?.includes(id)
+        paused
           ? "Paused"
           : link?.state === "error"
           ? link.error
@@ -140,7 +141,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
           : link?.state === "disconnected"
             ? "Disconnected"
             : undefined,
-      markers: link?.state === "connecting" ? [{ label: "Connecting", tone: "info" }] : [],
+      markers: !paused && link?.state === "connecting" ? [{ label: "Connecting", tone: "info" }] : [],
       color: mark.color,
     });
   }

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -15,9 +15,9 @@ import {
 import { friendly } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { getMark, resetMark, setMark, useEditableMark } from "../lib/marks";
-import { openCluster } from "../lib/openCluster";
+import { openCluster, reconnectCluster } from "../lib/openCluster";
 import { useInfos } from "../lib/probe";
-import { openTab, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
+import { openTab, setClusterPaused, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { useWorkspaceView } from "../lib/workspace";
 
 export interface RailProps {
@@ -52,17 +52,10 @@ const MAX_IMAGE_BYTES = 64 * 1024;
  * only covers the window between a kubeconfig changing and the store catching
  * up, and a mark for a cluster that is not there is worse than one mark fewer.
  *
- * What the menu offers, and what it deliberately does not. The design draws a
- * `Disconnect` in the destructive slot, and there is nothing behind that verb:
- * core connects (`connectCluster`, which is a probe) and deletes a context out
- * of the kubeconfig on disk (`deleteContext`, which is a far larger act than
- * this menu implies), and the `disconnected` link state is derived from a
- * probe's answer and re-derived by the next one — writing it by hand would be
- * a claim the next probe erases. So the item keeps the name of what it really
- * does, which is to drop the cluster from this workspace; a red row wired to
- * the nearest available verb is worse than an honest one. `Connection details`
- * opens `/connections`, which is a route this shell already knows and titles,
- * though the screen behind it is still the Placeholder.
+ * Disconnect is a persisted pause, not a made-up connection state: it leaves
+ * the cluster in this workspace and stops future probes until Reconnect asks
+ * for one. Its `Paused` label is intentionally distinct from a probe that
+ * found an unreachable cluster. `Connection details` opens `/connections`.
  *
  * The marks and the probes are read once for the whole list rather than once
  * per cluster: the number of clusters changes between renders, so a hook per
@@ -138,7 +131,9 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
       // is not offered here because there is nowhere in a 46px strip to offer
       // it from; the overview's Fleet row for the same cluster has it.
       unavailable:
-        link?.state === "error"
+        workspace.pausedClusters?.includes(id)
+          ? "Paused"
+          : link?.state === "error"
           ? link.error
             ? friendly(link.error).title
             : "Unreachable"
@@ -164,6 +159,13 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
     setEditing(null);
   }
 
+  function toggleConnection(id: string) {
+    const context = byId.get(id);
+    if (!context) return;
+    if (workspace.pausedClusters?.includes(id)) reconnectCluster(context);
+    else setClusterPaused(workspace.id, id, true);
+  }
+
   function menuFor(item: ClusterRailItem): ContextMenuItem[] {
     return [
       { label: `Open ${item.name}`, onPick: () => select(item.id) },
@@ -171,6 +173,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
       // anything happens — it opens the dialog below.
       { label: "Customise…", icon: Icons.edit, onPick: () => setEditing(item.id) },
       { kind: "sep" },
+      { label: workspace.pausedClusters?.includes(item.id) ? "Reconnect" : "Disconnect", onPick: () => toggleConnection(item.id) },
       { label: "Connection details", onPick: () => openTab("/connections") },
       // Named for what it does. See the note above on the design's Disconnect.
       { label: "Remove from workspace", icon: Icons.trash, danger: true, onPick: () => remove(item.id) },

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -15,9 +15,9 @@ import {
 import { friendly } from "../lib/errorCopy";
 import { Icons } from "../lib/icons";
 import { getMark, resetMark, setMark, useEditableMark } from "../lib/marks";
-import { openCluster, reconnectCluster } from "../lib/openCluster";
+import { openCluster, pauseCluster, reconnectCluster } from "../lib/openCluster";
 import { useInfos } from "../lib/probe";
-import { openTab, setClusterPaused, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
+import { openTab, setWorkspaceClusters, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { useWorkspaceView } from "../lib/workspace";
 
 export interface RailProps {
@@ -163,7 +163,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
     const context = byId.get(id);
     if (!context) return;
     if (workspace.pausedClusters?.includes(id)) reconnectCluster(context);
-    else setClusterPaused(workspace.id, id, true);
+    else pauseCluster(workspace.id, id);
   }
 
   function menuFor(item: ClusterRailItem): ContextMenuItem[] {

--- a/packages/ui-next/src/shell/Status.test.tsx
+++ b/packages/ui-next/src/shell/Status.test.tsx
@@ -89,6 +89,12 @@ async function connect(version: string | null) {
 }
 
 describe("Status", () => {
+  it("does not assert disconnection before a cluster has been checked", () => {
+    setState(defaultState([ctx]));
+    mount(<Status contexts={[ctx]} />);
+    expect(screen.getByText("Not checked")).toBeTruthy();
+    expect(screen.queryByText("Disconnected")).toBeNull();
+  });
   it("says so when no cluster is active", () => {
     setState(defaultState([]));
     mount(<Status contexts={[]} />);

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -12,7 +12,7 @@ import { useConsole } from "../console";
 import { getHelmOps, subscribeHelmOps } from "../lib/helmOps";
 import { useInfo } from "../lib/probe";
 import { getSessions, subscribeSessions } from "../lib/sessions";
-import { openTab, useActiveCluster } from "../lib/tabsStore";
+import { openTab, useActiveCluster, useTabs } from "../lib/tabsStore";
 import { useWorkspaceSealed } from "./LockGate";
 // The words and their tones live beside `LinkState` rather than here: the
 // overview rail reads the same link and must say the same thing about it.
@@ -83,6 +83,7 @@ import { LINK_TONE, LINK_WORD, useWorkspaceView } from "../lib/workspace";
  */
 export function Status({ contexts }: { contexts: ClusterContext[] }) {
   const activeId = useActiveCluster();
+  const { workspace } = useTabs();
   const sealed = useWorkspaceSealed();
   const info = useInfo(activeId);
   const { links } = useWorkspaceView();
@@ -97,6 +98,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // Nothing has probed yet, or there is nothing to probe. Either way the link
   // is not up, and "Disconnected" is the honest reading of that.
   const state = (activeId ? links[activeId]?.state : undefined) ?? "disconnected";
+  const paused = activeId !== null && (workspace.pausedClusters ?? []).includes(activeId);
   // Split rather than counted blind. A tunnel that gave up is still in the
   // store — it stays on the forwards screen until its reader dismisses it —
   // and counting it here would report a dead tunnel as one of the ones
@@ -140,7 +142,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
       id: "ctx",
       label: ctx ? mark.name : "No cluster",
       dot: true,
-      tone: LINK_TONE[state],
+      tone: paused ? "muted" : LINK_TONE[state],
       // Pressable only when there is a cluster to open. A "No cluster" button
       // that opens an overview of nothing is a dead end dressed as a way out.
       onSelect: ctx ? () => openTab("/overview", { clusterName: ctx.name }) : undefined,
@@ -155,7 +157,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   }
   // Pulsing only while connecting: the dot is animated for a readout that is
   // still changing, not for one that merely happens to be current.
-  segments.push({ id: "link", label: LINK_WORD[state], pulse: state === "connecting" });
+  segments.push({ id: "link", label: paused ? "Paused" : LINK_WORD[state], pulse: !paused && state === "connecting" });
 
   const end: StatusSegment[] = [];
   // Only when there is one, and this is the exception to the rule the version

--- a/packages/ui-next/src/shell/Status.tsx
+++ b/packages/ui-next/src/shell/Status.tsx
@@ -95,9 +95,8 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   // Found rather than assumed: the active id is persisted and the context list
   // is whatever the machine has now, so an id can outlive the context it named.
   const ctx = contexts.find((c) => c.stableId === activeId);
-  // Nothing has probed yet, or there is nothing to probe. Either way the link
-  // is not up, and "Disconnected" is the honest reading of that.
-  const state = (activeId ? links[activeId]?.state : undefined) ?? "disconnected";
+  // Absence of a probe is not evidence of a failed connection.
+  const state = activeId ? links[activeId]?.state : undefined;
   const paused = activeId !== null && (workspace.pausedClusters ?? []).includes(activeId);
   // Split rather than counted blind. A tunnel that gave up is still in the
   // store — it stays on the forwards screen until its reader dismisses it —
@@ -142,7 +141,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
       id: "ctx",
       label: ctx ? mark.name : "No cluster",
       dot: true,
-      tone: paused ? "muted" : LINK_TONE[state],
+      tone: paused || state === undefined ? "muted" : LINK_TONE[state],
       // Pressable only when there is a cluster to open. A "No cluster" button
       // that opens an overview of nothing is a dead end dressed as a way out.
       onSelect: ctx ? () => openTab("/overview", { clusterName: ctx.name }) : undefined,
@@ -157,7 +156,7 @@ export function Status({ contexts }: { contexts: ClusterContext[] }) {
   }
   // Pulsing only while connecting: the dot is animated for a readout that is
   // still changing, not for one that merely happens to be current.
-  segments.push({ id: "link", label: paused ? "Paused" : LINK_WORD[state], pulse: !paused && state === "connecting" });
+  segments.push({ id: "link", label: paused ? "Paused" : state === undefined ? "Not checked" : LINK_WORD[state], pulse: !paused && state === "connecting" });
 
   const end: StatusSegment[] = [];
   // Only when there is one, and this is the exception to the rule the version

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -260,6 +260,14 @@ async function booted() {
 }
 
 describe("Window boot", () => {
+  it("keeps the agent console mounted when its explicitly scoped cluster is paused", async () => {
+    await booted();
+    act(() => { store.openTab("/agent", { clusterName: "prod" }); });
+    expect(screen.getByRole("textbox", { name: "Console prompt" })).toBeDefined();
+    act(() => { store.setClusterPaused(store.currentWorkspace().id, "prod", true); });
+    expect(screen.getByRole("textbox", { name: "Console prompt" })).toBeDefined();
+  });
+
   it("does not contact configured clusters until the reader opens one", async () => {
     listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("stage")] });
     await booted();

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -260,49 +260,17 @@ async function booted() {
 }
 
 describe("Window boot", () => {
-  it("opens the active cluster overview after the initial connection succeeds", async () => {
-    connectCluster.mockResolvedValue({ context: "prod", reachable: true });
-    await booted();
-    await waitFor(() => expect(store.activeRoute()).toBe("/overview"));
-    expect(store.currentWorkspace().tabs.filter(tab => tab.route === "/overview")).toHaveLength(1);
-  });
-
-  it("keeps Home when the active cluster cannot connect, even if another can", async () => {
+  it("does not contact configured clusters until the reader opens one", async () => {
     listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("stage")] });
-    connectCluster.mockImplementation(async (name: string) => ({ context: name, reachable: name === "stage" }));
     await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalledTimes(2));
-    expect(store.activeRoute()).toBe("/");
-    expect(screen.getByRole("heading", { name: "Home", level: 1 })).toBeTruthy();
-  });
-
-  it("does not replace work opened while the initial cluster connection is pending", async () => {
-    let resolve!: (value: unknown) => void;
-    connectCluster.mockReturnValue(new Promise(done => { resolve = done; }));
-    await booted();
-    act(() => { store.openTab("/settings"); });
-    await act(async () => resolve({ context: "prod", reachable: true }));
-    expect(store.activeRoute()).toBe("/settings");
-    expect(store.currentWorkspace().tabs.some(tab => tab.route === "/overview")).toBe(false);
-  });
-
-  it("keeps a restored tab active after connecting", async () => {
-    connectCluster.mockResolvedValue({ context: "prod", reachable: true });
-    const saved = defaultState([ctx("prod")]);
-    const tab = makeTab("/settings");
-    saved.workspaces[0].tabs.push(tab);
-    saved.workspaces[0].activeId = tab.id;
-    loadTabsState.mockReturnValue(saved);
-    await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalled());
-    expect(store.activeRoute()).toBe("/settings");
+    expect(connectCluster).not.toHaveBeenCalled();
   });
 
   it("keeps a restored Home tab active after connecting", async () => {
     connectCluster.mockResolvedValue({ context: "prod", reachable: true });
     loadTabsState.mockReturnValue(defaultState([ctx("prod")]));
     await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalled());
+    expect(connectCluster).not.toHaveBeenCalled();
     expect(store.activeRoute()).toBe("/");
   });
 
@@ -665,7 +633,7 @@ describe("Window accelerators", () => {
     expect(store.currentWorkspace().tabs).toHaveLength(1);
   });
 
-  it("probes each cluster of the workspace once at boot", async () => {
+  it("does not probe workspace clusters at boot", async () => {
     listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
     render(
       <ConsoleProvider>
@@ -673,8 +641,7 @@ describe("Window accelerators", () => {
       </ConsoleProvider>,
     );
     await screen.findByRole("tablist");
-    await waitFor(() => expect(connectCluster).toHaveBeenCalledTimes(2));
-    expect(connectCluster.mock.calls.map((c) => c[0])).toEqual(["prod", "dev"]);
+    expect(connectCluster).not.toHaveBeenCalled();
   });
 
   it("probes a configured cluster when Home adds it to the workspace", async () => {
@@ -682,7 +649,7 @@ describe("Window accelerators", () => {
     loadTabsState.mockReturnValue(saved);
     listContexts.mockResolvedValue({ contexts: [ctx("prod"), ctx("dev")] });
     await booted();
-    await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("prod"));
+    expect(connectCluster).not.toHaveBeenCalled();
     act(() => openCluster(ctx("dev")));
     await waitFor(() => expect(connectCluster).toHaveBeenCalledWith("dev"));
   });

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -24,7 +24,7 @@ import { loadSectionFolds } from "../lib/sectionFolds";
 import { loadExpanded, loadNamespaces } from "../lib/workspace";
 import { defaultState, reconcile } from "../lib/tabs";
 import { parseEditRoute, parseNewRoute } from "../lib/detailRoute";
-import { isClusterScopedRoute } from "../lib/routes";
+import { isClusterScopedRoute, keepsManagementWhenPaused } from "../lib/routes";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
 import {
   activateTab,
@@ -547,13 +547,11 @@ export function Window({
             const context = pinnedContext
               ? contexts.find((c) => c.name === pinnedContext)
               : tab.sub === undefined
-              // These screens manage forwards and shells that already exist.
-              // They must stay available to stop or detach them while their
-              // cluster is paused; their creation controls have their own
-              // capability gates.
-              ? (isClusterScopedRoute(tab.route) && tab.route !== "/forwards" && tab.route !== "/terminals" ? activeCtx : undefined)
+              ? (isClusterScopedRoute(tab.route) ? activeCtx : undefined)
               : contexts.find((c) => c.name === tab.sub);
-            const pausedContext = context && workspace.pausedClusters?.includes(context.stableId) ? context : undefined;
+            // Keep Stop/Detach accessible even on explicitly labelled tabs.
+            // Their submission and creation controls check the actual target.
+            const pausedContext = !keepsManagementWhenPaused(tab.route) && context && workspace.pausedClusters?.includes(context.stableId) ? context : undefined;
             return (
             <TabSurface key={tab.id} visible={tab.id === activeId}>
               {/* A placeholder tab without a cluster of its own still leaves

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -132,7 +132,7 @@ export function Window({
   // uiScale doc), so a zoom chord here has to fall through to it untouched.
   const desktop = useMemo(() => isTauri(), []);
   const { setOpen, setScope } = useConsole();
-  const { tabs, activeId } = useTabs();
+  const { tabs, activeId, workspace } = useTabs();
   useMark("", "");
   const activeIdCluster = useActiveCluster();
   const activeCtx = contexts.find((c) => c.stableId === activeIdCluster) ?? null;
@@ -534,7 +534,10 @@ export function Window({
           />
         )}
         <div className="relative min-h-0 flex-1">
-          {tabs.map((tab) => (
+          {tabs.map((tab) => {
+            const context = tab.sub === undefined ? undefined : contexts.find((c) => c.name === tab.sub);
+            const pausedContext = context && workspace.pausedClusters?.includes(context.stableId) ? context : undefined;
+            return (
             <TabSurface key={tab.id} visible={tab.id === activeId}>
               {/* A placeholder tab without a cluster of its own still leaves
                   via the cluster this window is looking at — that is the
@@ -542,6 +545,7 @@ export function Window({
               <Body
                 route={tab.route}
                 clusterName={tab.sub ?? activeCtx?.name}
+                pausedContext={pausedContext}
                 ported={ported}
                 onOpenInClassic={onOpenInClassic}
                 onOpenGallery={onOpenGallery}
@@ -554,7 +558,8 @@ export function Window({
                 onLocked={lockWorkspace}
               />
             </TabSurface>
-          ))}
+            );
+          })}
         </div>
         {/* Not on `/agent`: that screen mounts the dock at the foot of its own
             main column, so its rail is a full-height sibling and uses the

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -23,6 +23,7 @@ import { loadPeekWidth } from "../lib/peekWidth";
 import { loadSectionFolds } from "../lib/sectionFolds";
 import { loadExpanded, loadNamespaces } from "../lib/workspace";
 import { defaultState, reconcile } from "../lib/tabs";
+import { parseEditRoute, parseNewRoute } from "../lib/detailRoute";
 import { isClusterScopedRoute } from "../lib/routes";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
 import {
@@ -536,10 +537,16 @@ export function Window({
         )}
         <div className="relative min-h-0 flex-1">
           {tabs.map((tab) => {
+            // An editor's target is pinned in its route. Its tab label follows
+            // the rail, so it cannot decide whether the editor's readers are
+            // paused.
+            const pinnedContext = parseEditRoute(tab.route)?.cluster ?? parseNewRoute(tab.route)?.cluster;
             // Status-bar actions open cluster-following routes without a
             // `clusterName`. They follow the active cluster and need its pause
             // gate; app-level tabs never receive one just because it is active.
-            const context = tab.sub === undefined
+            const context = pinnedContext
+              ? contexts.find((c) => c.name === pinnedContext)
+              : tab.sub === undefined
               // These screens manage forwards and shells that already exist.
               // They must stay available to stop or detach them while their
               // cluster is paused; their creation controls have their own

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -540,7 +540,11 @@ export function Window({
             // `clusterName`. They follow the active cluster and need its pause
             // gate; app-level tabs never receive one just because it is active.
             const context = tab.sub === undefined
-              ? (isClusterScopedRoute(tab.route) ? activeCtx : undefined)
+              // These screens manage forwards and shells that already exist.
+              // They must stay available to stop or detach them while their
+              // cluster is paused; their creation controls have their own
+              // capability gates.
+              ? (isClusterScopedRoute(tab.route) && tab.route !== "/forwards" && tab.route !== "/terminals" ? activeCtx : undefined)
               : contexts.find((c) => c.name === tab.sub);
             const pausedContext = context && workspace.pausedClusters?.includes(context.stableId) ? context : undefined;
             return (

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -23,6 +23,7 @@ import { loadPeekWidth } from "../lib/peekWidth";
 import { loadSectionFolds } from "../lib/sectionFolds";
 import { loadExpanded, loadNamespaces } from "../lib/workspace";
 import { defaultState, reconcile } from "../lib/tabs";
+import { isClusterScopedRoute } from "../lib/routes";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
 import {
   activateTab,
@@ -535,7 +536,12 @@ export function Window({
         )}
         <div className="relative min-h-0 flex-1">
           {tabs.map((tab) => {
-            const context = tab.sub === undefined ? undefined : contexts.find((c) => c.name === tab.sub);
+            // Status-bar actions open cluster-following routes without a
+            // `clusterName`. They follow the active cluster and need its pause
+            // gate; app-level tabs never receive one just because it is active.
+            const context = tab.sub === undefined
+              ? (isClusterScopedRoute(tab.route) ? activeCtx : undefined)
+              : contexts.find((c) => c.name === tab.sub);
             const pausedContext = context && workspace.pausedClusters?.includes(context.stableId) ? context : undefined;
             return (
             <TabSurface key={tab.id} visible={tab.id === activeId}>

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -47,8 +47,6 @@ import {
   useTabs,
 } from "../lib/tabsStore";
 import { useConsole } from "../console";
-import { openCluster } from "../lib/openCluster";
-import { getInfo, probeCluster } from "../lib/probe";
 import { hint, matchWindowKey, type WindowAction } from "../lib/shortcuts";
 import { AgentConsent } from "./AgentConsent";
 import { Body } from "./Body";
@@ -102,13 +100,6 @@ export function Window({
   active = true,
 }: WindowProps) {
   const [booted, setBooted] = useState(false);
-  // A Home tab restored from disk is an explicit reader choice. Keep this
-  // separate from the tab shape: a fresh state has the same single `/` tab.
-  const restoredWorkspace = useRef(false);
-  const mounted = useRef(false);
-  const visible = useRef(active);
-  visible.current = active;
-  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
   /**
    * The vault is usable, as `LockGate` reports it — classic's `vaultReady`, by
    * the same name and for the same one consumer. Flipped once per window; see
@@ -141,7 +132,7 @@ export function Window({
   // uiScale doc), so a zoom chord here has to fall through to it untouched.
   const desktop = useMemo(() => isTauri(), []);
   const { setOpen, setScope } = useConsole();
-  const { tabs, activeId, workspace } = useTabs();
+  const { tabs, activeId } = useTabs();
   useMark("", "");
   const activeIdCluster = useActiveCluster();
   const activeCtx = contexts.find((c) => c.stableId === activeIdCluster) ?? null;
@@ -221,7 +212,6 @@ export function Window({
         failure = outcome.error ?? "";
         listed = true;
         const saved = loadTabsState();
-        restoredWorkspace.current = saved !== null;
         if (saved && failure !== "") {
           // The list failed, not the clusters: reconciling against nothing would
           // strip every workspace's cluster ids and the next change would persist
@@ -266,39 +256,6 @@ export function Window({
     };
   }, [booted]);
 
-  // Every cluster you are looking at gets probed once, so the rail shows link
-  // state and the status bar shows a version without waiting to be asked. The
-  // effect runs per workspace rather than per render — switching away and back
-  // re-runs it, and the probe store's memory is what keeps it to once each.
-  const startupOverviewOffered = useRef(false);
-  const workspaceId = workspace.id;
-  const workspaceClusterIds = workspace.clusters.join("\u0000");
-  useEffect(() => {
-    if (!booted) return;
-    if (!active) return;
-    const byId = new Map(contexts.map((c) => [c.stableId, c]));
-    // Only the untouched initial Home is a default destination. A slow probe
-    // must never replace a restored tab or navigation performed while it waits.
-    if (!startupOverviewOffered.current) {
-      startupOverviewOffered.current = true;
-      const initialState = getState();
-      const initialWorkspace = currentWorkspace();
-      const ctx = byId.get(initialWorkspace.activeCluster ?? "");
-      if (!restoredWorkspace.current && ctx && initialWorkspace.tabs.length === 1 && initialWorkspace.tabs[0].route === "/") {
-        const ready = getInfo(ctx.stableId) ? Promise.resolve() : probeCluster(ctx);
-        void ready.then(() => {
-          if (mounted.current && visible.current && getState() === initialState && getInfo(ctx.stableId)?.reachable) openCluster(ctx);
-        });
-      }
-    }
-    for (const id of currentWorkspace().clusters) {
-      if (getInfo(id)) continue;
-      const ctx = byId.get(id);
-      if (ctx) void probeCluster(ctx);
-    }
-    // `contexts` rides along because a kubeconfig change replaces them; the
-    // workspace id is the trigger for the switch case.
-  }, [booted, contexts, workspaceId, workspaceClusterIds, active]);
 
   /**
    * Which accelerators survive a raised cover, and why one of them does.


### PR DESCRIPTION
Implements the on-demand connection behavior in #408.

Clusters are no longer probed on startup or when Connections opens. Opening a cluster from Home or the rail resumes it and probes it. The rail context menu now provides Disconnect/Reconnect, persisting the paused state per workspace; paused resource screens stop their readers and offer Reconnect.

Validation: ui-next TypeScript check and 396 focused Vitest tests.