### PR TITLE
fix(ui): separate connection actions from cluster removal

### DIFF
--- a/packages/ui-next/src/shell/Rail.test.tsx
+++ b/packages/ui-next/src/shell/Rail.test.tsx
@@ -109,6 +109,9 @@ describe("Rail", () => {
       .getAllByRole("menuitem")
       .map((item) => item.getAttribute("aria-label"));
     expect(items).toEqual(["Open prod-eu", "Customise…", "Disconnect", "Connection details", "Remove from workspace"]);
+    const remove = within(menu).getByRole("menuitem", { name: "Remove from workspace" });
+    expect(remove.previousElementSibling?.getAttribute("role")).toBe("separator");
+    expect(remove.previousElementSibling?.previousElementSibling?.getAttribute("aria-label")).toBe("Connection details");
     expect(screen.queryByRole("complementary", { name: "Details" })).toBeNull();
   });
 

--- a/packages/ui-next/src/shell/Rail.tsx
+++ b/packages/ui-next/src/shell/Rail.tsx
@@ -176,6 +176,7 @@ export function Rail({ contexts, onConnect, error }: RailProps) {
       { kind: "sep" },
       { label: workspace.pausedClusters?.includes(item.id) ? "Reconnect" : "Disconnect", onPick: () => toggleConnection(item.id) },
       { label: "Connection details", onPick: () => openTab("/connections") },
+      { kind: "sep" },
       // Named for what it does. See the note above on the design's Disconnect.
       { label: "Remove from workspace", icon: Icons.trash, danger: true, onPick: () => remove(item.id) },
     ];


### PR DESCRIPTION
Separate Disconnect/Reconnect and Connection details from the destructive Remove from workspace row in the cluster hotbar menu, completing the menu grouping requested in #408.

Validation: all 25 Rail tests pass, including a regression asserting the separator's placement; inspected the actual Rail menu in a Chrome/Vite harness.

Follow-up to #408.
