### PR TITLE
feat(ui): add tab hover details, reordering, and edge scrolling

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -20,7 +20,8 @@
         "minHeight": 640,
         "center": true,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/apps/desktop/src/tauri-drag-drop.test.ts
+++ b/apps/desktop/src/tauri-drag-drop.test.ts
@@ -1,0 +1,12 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+
+it("lets document-tab HTML drag/drop reach the desktop webview", () => {
+  const config = JSON.parse(readFileSync(join(__dirname, "../src-tauri/tauri.conf.json"), "utf8"));
+  // Tauri's native file-drop handler consumes drops before the DOM sees them.
+  // Browser-only tab tests cannot catch this desktop host configuration.
+  expect(config.app.windows.length).toBeGreaterThan(0);
+  for (const window of config.app.windows) expect(window.dragDropEnabled).toBe(false);
+});

--- a/packages/ui-kit/src/TabStrip.test.tsx
+++ b/packages/ui-kit/src/TabStrip.test.tsx
@@ -428,3 +428,64 @@ describe("TabStrip with nothing open", () => {
     expect(tab("Pods").getAttribute("tabindex")).toBe("0");
   });
 });
+
+describe("tab navigation enhancements", () => {
+  it("shows full identity on keyboard focus and dismisses it with Escape", async () => {
+    setup({ tabs: [{ id: "one", title: "ConfigMaps", sub: "short", context: "long-cluster-context", detail: "ConfigMap · monitoring" }] });
+    await userEvent.tab();
+    expect((await screen.findByRole("tooltip")).textContent).toContain("long-cluster-context");
+    expect(screen.getByRole("tooltip").textContent).toContain("ConfigMap · monitoring");
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+  it("requests a keyboard reorder without activating a tab", () => {
+    const onMove = vi.fn(); const {onSelect}=setup({onMove});
+    fireEvent.keyDown(tab("checkout-api"),{key:"ArrowLeft",ctrlKey:true,shiftKey:true});
+    expect(onMove).toHaveBeenCalledWith("logs",0);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+  it("keeps edge controls visible and out of the tab order when nothing overflows", () => {
+    setup();
+    for(const label of ["Scroll tabs left","Scroll tabs right"]){
+      const button=screen.getByRole("button",{name:label});
+      expect(button).toHaveProperty("disabled",true);
+      expect(button.tabIndex).toBe(-1);
+    }
+  });
+  it("does not select or reorder a tab dropped back in its own position", () => {
+    const onMove=vi.fn();const {onSelect}=setup({onMove});
+    const node=tab("checkout-api");
+    fireEvent.dragStart(node,{dataTransfer:{setData:vi.fn()}});
+    fireEvent.dragOver(node,{clientX:0});
+    fireEvent.drop(node,{clientX:0});
+    fireEvent.dragEnd(node);
+    fireEvent.click(node);
+    expect(onMove).not.toHaveBeenCalled();expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+it("announces a completed keyboard move and keeps focus and selection separate", async () => {
+  function Reorderable() {
+    const [tabs,setTabs]=useState(TABS);
+    return <TabStrip tabs={tabs} activeId="pods" onSelect={()=>{}} onMove={(id,to)=>setTabs(old=>{
+      const next=[...old]; const [moved]=next.splice(next.findIndex(t=>t.id===id),1);next.splice(to,0,moved);return next;
+    })}/>;
+  }
+  render(<Reorderable/>);
+  tab("checkout-api").focus();
+  fireEvent.keyDown(tab("checkout-api"),{key:"ArrowLeft",metaKey:true,shiftKey:true});
+  expect(screen.getAllByRole("tab")[0]).toBe(tab("checkout-api"));
+  expect(document.activeElement).toBe(tab("checkout-api"));
+  expect(tab("Pods").getAttribute("aria-selected")).toBe("true");
+  expect(screen.getByRole("status").textContent).toBe("checkout-api moved to position 1 of 3");
+});
+
+it("shows an insertion marker and requests a drop without selecting", () => {
+  const onMove=vi.fn();const {onSelect}=setup({onMove});
+  fireEvent.dragStart(tab("nginx-7d4b"),{dataTransfer:{setData:vi.fn()}});
+  fireEvent.dragOver(tab("Pods"),{clientX:0});
+  expect(tab("Pods").getAttribute("data-drop")).toBe("before");
+  fireEvent.drop(tab("Pods"),{clientX:0});
+  expect(onMove).toHaveBeenCalledWith("shell",0);
+  expect(onSelect).not.toHaveBeenCalled();
+});

--- a/packages/ui-kit/src/TabStrip.test.tsx
+++ b/packages/ui-kit/src/TabStrip.test.tsx
@@ -489,3 +489,28 @@ it("shows an insertion marker and requests a drop without selecting", () => {
   expect(onMove).toHaveBeenCalledWith("shell",0);
   expect(onSelect).not.toHaveBeenCalled();
 });
+
+
+it("rejects a tab drag that began on its close button and permits the next body drag", () => {
+  const onMove = vi.fn();
+  const onClose = vi.fn();
+  const { onSelect } = setup({ onMove, onClose });
+  const source = tab("nginx-7d4b");
+  const close = screen.getByRole("button", { name: "Close nginx-7d4b" });
+  const dataTransfer = { setData: vi.fn() };
+  fireEvent.pointerDown(close.querySelector("svg") ?? close);
+  // Native dragstart targets the draggable ancestor, not the pressed button.
+  expect(fireEvent.dragStart(source, { dataTransfer })).toBe(false);
+  fireEvent.dragOver(tab("Pods"), { clientX: 0 });
+  fireEvent.drop(tab("Pods"), { clientX: 0 });
+  expect(onMove).not.toHaveBeenCalled();
+  expect(dataTransfer.setData).not.toHaveBeenCalled();
+  expect(onSelect).not.toHaveBeenCalled();
+  fireEvent.click(close);
+  expect(onClose).toHaveBeenCalledWith("shell");
+
+  fireEvent.pointerDown(source);
+  expect(fireEvent.dragStart(source, { dataTransfer })).toBe(true);
+  fireEvent.drop(tab("Pods"), { clientX: 0 });
+  expect(onMove).toHaveBeenCalledWith("shell", 0);
+});

--- a/packages/ui-kit/src/TabStrip.test.tsx
+++ b/packages/ui-kit/src/TabStrip.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect, vi } from "vitest";
 import { useState, type FormEvent } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
@@ -513,4 +515,13 @@ it("rejects a tab drag that began on its close button and permits the next body 
   expect(fireEvent.dragStart(source, { dataTransfer })).toBe(true);
   fireEvent.drop(tab("Pods"), { clientX: 0 });
   expect(onMove).toHaveBeenCalledWith("shell", 0);
+});
+
+
+it("keeps long tooltip identifiers on one horizontally scrollable line", () => {
+  const css = readFileSync(join(__dirname, "styles/kit.css"), "utf8");
+  const rule = css.match(/\.tab-tooltip\s*\{([^}]+)\}/)?.[1] ?? "";
+  expect(rule).toMatch(/white-space:\s*nowrap/);
+  expect(rule).toMatch(/overflow-x:\s*auto/);
+  expect(rule).not.toMatch(/overflow-wrap:\s*anywhere/);
 });

--- a/packages/ui-kit/src/TabStrip.tsx
+++ b/packages/ui-kit/src/TabStrip.tsx
@@ -179,6 +179,7 @@ export function TabStrip({
   const edges = useTabStripScroll(listRef, tabs.map(t => t.id).join("|"));
   const dragId = useRef<string | null>(null);
   const suppressClick = useRef(false);
+  const pressedControl = useRef(false);
   const [dragging, setDragging] = useState(false);
   const [dropAt, setDropAt] = useState<number | null>(null);
   const [announcement, setAnnouncement] = useState("");
@@ -356,9 +357,14 @@ export function TabStrip({
               data-drop={dropAt === index ? "before" : dropAt === tabs.length && index === tabs.length - 1 ? "after" : undefined}
               data-dragging={dragId.current === tab.id || undefined}
               draggable={!!onMove}
-              onPointerDown={() => { suppressClick.current = false; }}
+              onPointerDown={event => {
+                suppressClick.current = false;
+                // dragstart targets the draggable tab even when the gesture
+                // began on its close button (including the icon inside it).
+                pressedControl.current = !!(event.target as Element).closest("button");
+              }}
               onDragStart={event => {
-                if (!onMove || (event.target as HTMLElement).closest("button")) { event.preventDefault(); return; }
+                if (!onMove || pressedControl.current || (event.target as Element).closest("button")) { event.preventDefault(); return; }
                 dragId.current = tab.id; suppressClick.current = true; setDragging(true);
                 event.dataTransfer.effectAllowed = "move";
                 event.dataTransfer.setData("text/plain", tab.id);

--- a/packages/ui-kit/src/TabStrip.tsx
+++ b/packages/ui-kit/src/TabStrip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState, type DragEvent, type KeyboardEvent } from "react";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { cx } from "./cx";
 import type { IconComponent } from "./IconButton";
@@ -6,6 +6,8 @@ import { NavIcon } from "./NavIcon";
 import { Popover } from "./Popover";
 import { filled } from "./slot";
 import { toneColor } from "./tone";
+import { Tooltip, TooltipGroup } from "./Tooltip";
+import { useTabStripScroll } from "./useTabStripScroll";
 
 export interface StripTab {
   id: string;
@@ -13,6 +15,10 @@ export interface StripTab {
   title: string;
   /** The quiet tag after the title — the cluster, the namespace, "logs". */
   sub?: string;
+  /** Full context name, even when the visible tag uses a short display name. */
+  context?: string;
+  /** Resource kind and namespace, when the route carries them. */
+  detail?: string;
   /**
    * The glyph for this tab. Taken per tab rather than mapped from a kind:
    * which icon means "workloads" is the product's vocabulary, not the design
@@ -36,6 +42,8 @@ export interface TabStripProps {
   onSelect: (id: string) => void;
   /** Offered per tab when given, and never on a pinned one. Left out, no close at all. */
   onClose?: (id: string) => void;
+  /** Destination index in the resulting array. Does not activate the tab. */
+  onMove?: (id: string, toIndex: number) => void;
   /** Offered at the end of the strip when given. */
   onNew?: () => void;
   /** The right-click menu for one tab. Left out, tabs answer no right-click. */
@@ -148,6 +156,7 @@ export function TabStrip({
   activeId,
   onSelect,
   onClose,
+  onMove,
   onNew,
   menuFor,
   label = "Open tabs",
@@ -166,6 +175,52 @@ export function TabStrip({
   // closed. Held in a ref rather than state: nothing renders differently for
   // it, and it must survive the render that the close causes.
   const pending = useRef<{ closed: string; next: string } | null>(null);
+
+  const edges = useTabStripScroll(listRef, tabs.map(t => t.id).join("|"));
+  const dragId = useRef<string | null>(null);
+  const suppressClick = useRef(false);
+  const [dragging, setDragging] = useState(false);
+  const [dropAt, setDropAt] = useState<number | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const moved = useRef<{ id: string; to: number; focus: boolean } | null>(null);
+  useEffect(() => {
+    const move = moved.current;
+    if (!move || tabs.findIndex(t => t.id === move.id) !== move.to) return;
+    moved.current = null;
+    const tab = tabs[move.to];
+    setAnnouncement(`${tab.title} moved to position ${move.to + 1} of ${tabs.length}`);
+    if (move.focus) refs.current.get(move.id)?.focus();
+    refs.current.get(move.id)?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+  }, [tabs]);
+
+  function requestMove(id: string, to: number, focus: boolean) {
+    const from = tabs.findIndex(t => t.id === id);
+    to = Math.max(0, Math.min(tabs.length - 1, to));
+    if (!onMove || from < 0 || from === to) return;
+    moved.current = { id, to, focus };
+    onMove(id, to);
+  }
+  function dropPosition(event: DragEvent<HTMLDivElement>) {
+    const target = (event.target as HTMLElement).closest('[role="tab"]');
+    const index = tabs.findIndex(t => refs.current.get(t.id) === target);
+    if (index < 0) return tabs.length;
+    const rect = target!.getBoundingClientRect();
+    return index + (event.clientX > rect.left + rect.width / 2 ? 1 : 0);
+  }
+  function endDrag() { dragId.current = null; setDragging(false); setDropAt(null); }
+  function edgeButton(direction: -1 | 1) {
+    return <button type="button" className="tab-new tab-scroll" tabIndex={-1}
+      aria-label={`Scroll tabs ${direction === -1 ? "left" : "right"}`}
+      disabled={direction === -1 ? !edges.left : !edges.right}
+      onPointerDown={event => {
+        if (event.button !== 0) return;
+        event.preventDefault(); event.currentTarget.setPointerCapture?.(event.pointerId); edges.start(direction);
+      }}
+      onPointerUp={edges.stop} onPointerCancel={edges.stop} onLostPointerCapture={edges.stop}
+      onClick={() => edges.click(direction)}>
+      <span aria-hidden style={{ transform: `rotate(${direction === -1 ? 90 : -90}deg)` }}><ChevronGlyph /></span>
+    </button>;
+  }
 
   const closable = onClose !== undefined;
 
@@ -211,6 +266,12 @@ export function TabStrip({
     const from = tabs.findIndex((t) => refs.current.get(t.id) === target);
     if (from < 0) return;
 
+    if (onMove && (event.ctrlKey || event.metaKey) && event.shiftKey && (event.key === "ArrowLeft" || event.key === "ArrowRight")) {
+      event.preventDefault(); event.stopPropagation();
+      requestMove(tabs[from].id, from + (event.key === "ArrowLeft" ? -1 : 1), true);
+      return;
+    }
+
     if (event.key === "Enter" || event.key === " ") {
       // A div is not a button, so neither key clicks it, and Space would scroll
       // the page instead.
@@ -241,7 +302,9 @@ export function TabStrip({
   }
 
   return (
-    <div className={cx("tabstrip", className)}>
+    <TooltipGroup><div className={cx("tabstrip", className)}>
+      {edgeButton(-1)}
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">{announcement}</span>
       {/*
         The tablist is the scrolling half rather than the whole bar, for two
         reasons: a tablist owns tabs and nothing else, so the new and overflow
@@ -254,6 +317,23 @@ export function TabStrip({
         aria-label={label}
         className="flex min-w-0 flex-1 overflow-x-auto"
         onKeyDown={onKeyDown}
+        onDragOver={event => {
+          if (!dragId.current) return;
+          event.preventDefault(); setDropAt(dropPosition(event));
+          const rect = event.currentTarget.getBoundingClientRect();
+          if (event.clientX < rect.left + 24) event.currentTarget.scrollBy?.({ left: -16 });
+          else if (event.clientX > rect.right - 24) event.currentTarget.scrollBy?.({ left: 16 });
+        }}
+        onDragLeave={event => { if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setDropAt(null); }}
+        onDrop={event => {
+          const id = dragId.current;
+          if (!id) return;
+          event.preventDefault();
+          const from = tabs.findIndex(t => t.id === id);
+          const insertion = dropPosition(event);
+          requestMove(id, insertion > from ? insertion - 1 : insertion, false);
+          endDrag();
+        }}
         onBlur={(event) => {
           // Focus has left the strip: the tab stop goes back to the active tab,
           // so returning to the strip lands on the document being read rather
@@ -261,7 +341,7 @@ export function TabStrip({
           if (!event.currentTarget.contains(event.relatedTarget)) setFocusedId(null);
         }}
       >
-        {tabs.map((tab) => {
+        {tabs.map((tab, index) => {
           const current = tab.id === activeId;
           const node = (
             <div
@@ -273,13 +353,25 @@ export function TabStrip({
               role="tab"
               className="tab"
               data-active={current}
+              data-drop={dropAt === index ? "before" : dropAt === tabs.length && index === tabs.length - 1 ? "after" : undefined}
+              data-dragging={dragId.current === tab.id || undefined}
+              draggable={!!onMove}
+              onPointerDown={() => { suppressClick.current = false; }}
+              onDragStart={event => {
+                if (!onMove || (event.target as HTMLElement).closest("button")) { event.preventDefault(); return; }
+                dragId.current = tab.id; suppressClick.current = true; setDragging(true);
+                event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("text/plain", tab.id);
+              }}
+              onDragEnd={endDrag}
               data-preview={tab.preview ? "true" : undefined}
               data-pinned={tab.pinned ? "true" : undefined}
               aria-selected={current}
+              aria-keyshortcuts={onMove ? "Control+Shift+ArrowLeft Control+Shift+ArrowRight Meta+Shift+ArrowLeft Meta+Shift+ArrowRight" : undefined}
               aria-label={tabName(tab)}
               tabIndex={tab.id === roving ? 0 : -1}
               onFocus={() => setFocusedId(tab.id)}
-              onClick={() => onSelect(tab.id)}
+              onClick={() => { if (!suppressClick.current) onSelect(tab.id); }}
               // Kept from the mock, where it was the only way to close a tab
               // that did not go through a window accelerator. It is a shortcut
               // now rather than the sole route, which is what made it a fault.
@@ -330,16 +422,22 @@ export function TabStrip({
             </div>
           );
 
+          const hinted = <Tooltip key={tab.id} side="bottom" disabled={dragging} label={<div className="tab-tooltip">
+            <strong>{tab.title}</strong>
+            {filled(tab.context ?? tab.sub) && <div>{tab.context ?? tab.sub}</div>}
+            {filled(tab.detail) && <div>{tab.detail}</div>}
+          </div>}>{node}</Tooltip>;
           return menuFor ? (
             <ContextMenu key={tab.id} items={menuFor(tab)} label={`${tab.title} actions`}>
-              {node}
+              {hinted}
             </ContextMenu>
           ) : (
-            node
+            hinted
           );
         })}
       </div>
 
+      {edgeButton(1)}
       {filled(onNew ? newLabel : null) && (
         <button
           type="button"
@@ -408,6 +506,6 @@ export function TabStrip({
           )}
         </Popover>
       )}
-    </div>
+    </div></TooltipGroup>
   );
 }

--- a/packages/ui-kit/src/Tooltip.tsx
+++ b/packages/ui-kit/src/Tooltip.tsx
@@ -1,14 +1,22 @@
-import { isValidElement, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, isValidElement, type ComponentProps, type ReactNode } from "react";
 import { Tooltip as RadixTooltip } from "radix-ui";
 import { usePortalContainer } from "./portal";
 import { filled } from "./slot";
 
-export interface TooltipProps {
+export interface TooltipProps extends Omit<ComponentProps<typeof RadixTooltip.Trigger>, "children" | "asChild"> {
   /** The hint. Empty means there is nothing to say, and nothing is shown. */
-  label: string;
+  label: ReactNode;
+  disabled?: boolean;
   /** What the hint is about. A single element becomes the target itself. */
   children: ReactNode;
   side?: "top" | "right" | "bottom" | "left";
+}
+
+const Grouped = createContext(false);
+
+/** Neighbouring hints share the delay window; isolated Tooltip callers need no provider. */
+export function TooltipGroup({ children }: { children: ReactNode }) {
+  return <Grouped.Provider value={true}><RadixTooltip.Provider delayDuration={500} skipDelayDuration={300}>{children}</RadixTooltip.Provider></Grouped.Provider>;
 }
 
 /**
@@ -40,13 +48,9 @@ export interface TooltipProps {
  * size and tokens, minus its `pointer-events: none`, because 1.4.13 also asks
  * that a hint be hoverable.
  *
- * Radix's Tooltip throws unless a `Tooltip.Provider` sits above it, and that
- * provider is rendered here rather than exported for every app to remember. The
- * only thing a shared one buys is a skip-delay window across neighbouring
- * tooltips, and every tooltip in this design is an isolated hint on a single
- * control; a kit primitive that throws because an app forgot a root wrapper is
- * the worse trade. If a dense grid of them ever wants the shared window, the
- * provider can be exported then without changing a single call site.
+ * A standalone hint supplies its own provider. TooltipGroup shares the delay
+ * window for neighbours such as document tabs, without changing other callers.
+ * Trigger props and refs are forwarded so a ContextMenu can share the target.
  *
  * One more thing the mock got wrong: `.tip` is a plain span, so its
  * `:focus-within` fired only when the caller happened to wrap something
@@ -63,12 +67,14 @@ export interface TooltipProps {
  * that is no longer on screen is a caption on the wrong picture, and one line
  * makes the question not arise. Outside a scope nothing changes. (#357)
  */
-export function Tooltip({ label, children, side = "top" }: TooltipProps) {
+export function Tooltip({ label, children, side = "top", disabled = false, ...triggerProps }: TooltipProps) {
   const container = usePortalContainer();
-  return (
-    <RadixTooltip.Provider delayDuration={200}>
-      <RadixTooltip.Root>
-        <RadixTooltip.Trigger asChild>
+  const grouped = useContext(Grouped);
+  const [open, setOpen] = useState(false);
+  useEffect(() => { if (disabled) setOpen(false); }, [disabled]);
+  const content = (
+      <RadixTooltip.Root open={open && !disabled} onOpenChange={setOpen}>
+        <RadixTooltip.Trigger {...triggerProps} asChild>
           {isValidElement(children) ? (
             children
           ) : (
@@ -103,6 +109,6 @@ export function Tooltip({ label, children, side = "top" }: TooltipProps) {
           </RadixTooltip.Portal>
         )}
       </RadixTooltip.Root>
-    </RadixTooltip.Provider>
   );
+  return grouped ? content : <RadixTooltip.Provider delayDuration={200}>{content}</RadixTooltip.Provider>;
 }

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -1347,7 +1347,7 @@
     border-left: 1px solid var(--rule);
   }
   .tab-scroll:disabled { opacity: .3; cursor: default; pointer-events: none; }
-  .tab-tooltip { max-width: min(420px, calc(100vw - 32px)); white-space: normal; overflow-wrap: anywhere; line-height: 1.6; }
+  .tab-tooltip { max-width: min(420px, calc(100vw - 32px)); white-space: nowrap; overflow-x: auto; line-height: 1.6; }
   .tab[data-dragging="true"] { opacity: .55; }
   .tab[data-drop="before"] { box-shadow: inset 2px 0 var(--accent); }
   .tab[data-drop="after"] { box-shadow: inset -2px 0 var(--accent); }

--- a/packages/ui-kit/src/styles/kit.css
+++ b/packages/ui-kit/src/styles/kit.css
@@ -1215,6 +1215,8 @@
     scrollbar-width: none;
   }
   .tabstrip::-webkit-scrollbar { display: none; }
+  .tabstrip > [role="tablist"] { scrollbar-width: none; }
+  .tabstrip > [role="tablist"]::-webkit-scrollbar { display: none; }
   .tab {
     position: relative;
     display: flex;
@@ -1344,6 +1346,11 @@
     color: var(--ink-muted);
     border-left: 1px solid var(--rule);
   }
+  .tab-scroll:disabled { opacity: .3; cursor: default; pointer-events: none; }
+  .tab-tooltip { max-width: min(420px, calc(100vw - 32px)); white-space: normal; overflow-wrap: anywhere; line-height: 1.6; }
+  .tab[data-dragging="true"] { opacity: .55; }
+  .tab[data-drop="before"] { box-shadow: inset 2px 0 var(--accent); }
+  .tab[data-drop="after"] { box-shadow: inset -2px 0 var(--accent); }
   .tab-new:hover { background: var(--field); color: var(--ink); }
 
   .toolbar {

--- a/packages/ui-kit/src/useTabStripScroll.test.ts
+++ b/packages/ui-kit/src/useTabStripScroll.test.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { useTabStripScroll } from "./useTabStripScroll";
+
+it("measures edges, scrolls by a page, and follows resize and scroll events", () => {
+  const node = document.createElement("div");
+  let width = 100;
+  Object.defineProperties(node, { clientWidth: { get: () => width }, scrollWidth: { get: () => 500 } });
+  node.scrollBy = vi.fn();
+  const { result, unmount } = renderHook(() => useTabStripScroll({ current: node }, "a|b"));
+  expect(result.current.left).toBe(false); expect(result.current.right).toBe(true);
+  act(() => result.current.click(1));
+  expect(node.scrollBy).toHaveBeenCalledWith({ left: 80, behavior: "smooth" });
+  act(() => { node.scrollLeft = 400; node.dispatchEvent(new Event("scroll")); });
+  expect(result.current.left).toBe(true); expect(result.current.right).toBe(false);
+  act(() => { width = 500; node.scrollLeft = 0; window.dispatchEvent(new Event("resize")); });
+  expect(result.current.left).toBe(false); expect(result.current.right).toBe(false);
+  unmount();
+});
+
+it("repeats during a hold, stops on release/unmount, and respects reduced motion", () => {
+  vi.useFakeTimers();
+  const original = window.matchMedia;
+  window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+  try {
+    const node = document.createElement("div");
+    Object.defineProperties(node, { clientWidth: { value: 100 }, scrollWidth: { value: 500 } });
+    node.scrollBy = vi.fn();
+    const ref = { current: node };
+    const { result, unmount } = renderHook(() => useTabStripScroll(ref, "a|b"));
+    act(() => result.current.click(1));
+    expect(node.scrollBy).toHaveBeenCalledWith({ left: 80, behavior: "auto" });
+    vi.mocked(node.scrollBy).mockClear();
+    act(() => { result.current.start(1); vi.advanceTimersByTime(550); });
+    expect(node.scrollBy).toHaveBeenCalledTimes(3);
+    act(() => { result.current.stop(); result.current.click(1); vi.advanceTimersByTime(500); });
+    expect(node.scrollBy).toHaveBeenCalledTimes(3);
+    act(() => result.current.start(-1));
+    unmount(); vi.advanceTimersByTime(1000);
+    expect(node.scrollBy).toHaveBeenCalledTimes(3);
+  } finally { window.matchMedia = original; vi.useRealTimers(); }
+});

--- a/packages/ui-kit/src/useTabStripScroll.ts
+++ b/packages/ui-kit/src/useTabStripScroll.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+/** Measure the scrolling region, never the fixed controls beside it. */
+export function useTabStripScroll(ref: RefObject<HTMLDivElement | null>, tabIds: string) {
+  const [edges, setEdges] = useState({ left: false, right: false });
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const repeat = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
+  const held = useRef(false);
+  const holdingDirection = useRef<-1 | 1 | null>(null);
+  function measure() {
+    const node = ref.current;
+    if (!node) return;
+    const left = node.scrollLeft > 1;
+    const right = node.scrollWidth - node.clientWidth - node.scrollLeft > 1;
+    if ((holdingDirection.current === -1 && !left) || (holdingDirection.current === 1 && !right)) stop();
+    setEdges(old => old.left === left && old.right === right ? old : { left, right });
+  }
+  function stop() {
+    clearTimeout(timer.current); clearInterval(repeat.current); holdingDirection.current = null;
+  }
+  function scroll(direction: -1 | 1, continuous = false) {
+    const node = ref.current;
+    if (!node) return;
+    const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    node.scrollBy({ left: direction * Math.max(48, node.clientWidth * (continuous ? .2 : .8)), behavior: continuous || reduced ? "auto" : "smooth" });
+  }
+  function start(direction: -1 | 1) {
+    stop(); held.current = false; holdingDirection.current = direction;
+    timer.current = setTimeout(() => {
+      held.current = true;
+      scroll(direction, true);
+      repeat.current = setInterval(() => scroll(direction, true), 100);
+    }, 350);
+  }
+  function click(direction: -1 | 1) {
+    if (!held.current) scroll(direction);
+    held.current = false;
+  }
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    measure();
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measure);
+    observer?.observe(node);
+    for (const child of node.children) observer?.observe(child);
+    node.addEventListener("scroll", measure);
+    window.addEventListener("resize", measure);
+    window.addEventListener("blur", stop);
+    return () => {
+      observer?.disconnect(); node.removeEventListener("scroll", measure);
+      window.removeEventListener("resize", measure); window.removeEventListener("blur", stop); stop();
+    };
+  }, [ref, tabIds]);
+  return { ...edges, start, stop, click };
+}

--- a/packages/ui-next/src/lib/routes.test.ts
+++ b/packages/ui-next/src/lib/routes.test.ts
@@ -477,3 +477,11 @@ suite("ScreenComponent", () => {
 });
 
 it("registers the app landing page", () => { expect(screenFor("/")?.name).toBe("Home"); });
+
+it("describes resource identity for tab hints without guessing a namespace", async () => {
+  const {tabDetail}=await import("./routes");
+  expect(tabDetail("/edit/prod/ConfigMap/monitoring/config")).toBe("ConfigMap · monitoring");
+  expect(tabDetail("/k/Node/-/node-1")).toBe("Node · Cluster-scoped");
+  expect(tabDetail("/logs/Pod/default/app")).toBe("Pod · default");
+  expect(tabDetail("/overview")).toBeUndefined();
+});

--- a/packages/ui-next/src/lib/routes.ts
+++ b/packages/ui-next/src/lib/routes.ts
@@ -189,6 +189,14 @@ export function describe(route: string, clusterName?: string): RouteInfo {
   return { route, title: route.replace(/^\//, "") || "Untitled", sub, kind: "control" };
 }
 
+/** Extra identity for a document-tab hover card, decoded by the route parsers. */
+export function tabDetail(route: string): string | undefined {
+  const parts = parseEditRoute(route) ?? parseDetailRoute(route) ?? parseLogsRoute(route);
+  if (!parts) return undefined;
+  const kind = "group" in parts && parts.group ? `${parts.group}/${parts.kind}` : parts.kind;
+  return `${kind} · ${parts.namespace ?? "Cluster-scoped"}`;
+}
+
 /** Whether a route follows a cluster rather than being an app-level screen. */
 export function isClusterScopedRoute(route: string): boolean {
   // `describe` is already the one exhaustive parser for route shapes. Passing

--- a/packages/ui-next/src/lib/tabsStore.test.tsx
+++ b/packages/ui-next/src/lib/tabsStore.test.tsx
@@ -636,3 +636,41 @@ describe("no-op actions do not notify", () => {
     expect(store.getState()).not.toBe(before);
   });
 });
+
+describe("moveTab", () => {
+  it("moves pinned tabs without changing selection or other workspace state", () => {
+    seed();
+    store.openTab("/overview");
+    store.openTab("/settings");
+    const before = store.currentWorkspace();
+    const home = before.tabs[0];
+    store.moveTab(home.id, 2);
+    const after = store.currentWorkspace();
+    expect(after.tabs.map(t => t.id)).toEqual([before.tabs[1].id, before.tabs[2].id, home.id]);
+    expect(after.activeId).toBe(before.activeId);
+    expect(after.tabs[2]).toEqual(home);
+    store.moveTab(home.id, 2);
+    expect(store.currentWorkspace()).toBe(after);
+    store.openTab("/notes");
+    expect(routes().at(-1)).toBe("/notes");
+  });
+  it("ignores unknown tabs and invalid indices, and clamps to the ends", () => {
+    seed(); store.openTab("/overview");
+    const before = store.currentWorkspace();
+    store.moveTab("missing", 1);
+    store.moveTab(before.tabs[0].id, NaN);
+    expect(store.currentWorkspace()).toBe(before);
+    store.moveTab(before.tabs[0].id, 99);
+    expect(store.currentWorkspace().tabs.at(-1)?.id).toBe(before.tabs[0].id);
+  });
+});
+
+it("round-trips the chosen document order through persisted state", async () => {
+  const {parseStoredState, STORAGE_VERSION}=await import("./tabsPersist");
+  seed(); store.openTab("/overview");store.openTab("/settings");
+  store.moveTab(active().id,0);
+  const state=store.getState();
+  const restored=parseStoredState(JSON.stringify({version:STORAGE_VERSION,...state}));
+  expect(restored?.workspaces[0].tabs.map(t=>t.id)).toEqual(state.workspaces[0].tabs.map(t=>t.id));
+  expect(restored?.workspaces[0].activeId).toBe(state.workspaces[0].activeId);
+});

--- a/packages/ui-next/src/lib/tabsStore.ts
+++ b/packages/ui-next/src/lib/tabsStore.ts
@@ -295,6 +295,20 @@ export function duplicateTab(id: string): void {
   });
 }
 
+/** Move a document without selecting it; array order is persisted as-is. */
+export function moveTab(id: string, toIndex: number): void {
+  if (!Number.isFinite(toIndex)) return;
+  patchCurrent(w => {
+    const from = w.tabs.findIndex(tab => tab.id === id);
+    const to = Math.max(0, Math.min(w.tabs.length - 1, Math.trunc(toIndex)));
+    if (from < 0 || from === to) return w;
+    const tabs = [...w.tabs];
+    const [tab] = tabs.splice(from, 1);
+    tabs.splice(to, 0, tab);
+    return { ...w, tabs };
+  });
+}
+
 export function togglePin(id: string): void {
   patchCurrent((w) => {
     if (!w.tabs.some((t) => t.id === id)) return w;

--- a/packages/ui-next/src/shell/Window.test.tsx
+++ b/packages/ui-next/src/shell/Window.test.tsx
@@ -1512,3 +1512,22 @@ it("shows saved display names on tabs while retaining the real context for opera
   act(() => setMark("prod", { ...defaultMark("prod"), name: "Production East" }));
   expect(screen.getByRole("tab", { name: /Pods · Production East/ })).toBeDefined();
 });
+
+
+it.each(["/forwards", "/terminals", "/helm"])("shows the active context for a status-opened %s tab", async route => {
+  loadTabsState.mockReturnValue(defaultState([ctx("prod")]));
+  await booted();
+  act(() => { store.openTab(route); });
+  const opened = store.getState().workspaces[0].tabs.find(t => t.route === route)!;
+  expect(opened.sub).toBeUndefined();
+  act(() => { screen.getByRole("tab", { name: opened.title }).focus(); });
+  expect((await screen.findByRole("tooltip")).textContent).toContain("prod");
+});
+
+it("does not label an app-level tab with the active cluster", async () => {
+  loadTabsState.mockReturnValue(defaultState([ctx("prod")]));
+  await booted();
+  act(() => { store.openTab("/settings"); });
+  act(() => { screen.getByRole("tab", { name: "Settings" }).focus(); });
+  expect((await screen.findByRole("tooltip")).textContent).not.toContain("prod");
+});

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -25,7 +25,7 @@ import { loadExpanded, loadNamespaces } from "../lib/workspace";
 import { getInfo, probeCluster } from "../lib/probe";
 import { defaultState, reconcile } from "../lib/tabs";
 import { parseEditRoute, parseNewRoute } from "../lib/detailRoute";
-import { isClusterScopedRoute, keepsManagementWhenPaused } from "../lib/routes";
+import { isClusterScopedRoute, keepsManagementWhenPaused, tabDetail } from "../lib/routes";
 import { flushSave, installFlushOnUnload, loadTabsState, scheduleSave } from "../lib/tabsPersist";
 import {
   activateTab,
@@ -40,6 +40,7 @@ import {
   getState,
   newTab,
   openTab,
+  moveTab,
   reopenClosed,
   selectIndex,
   setState,
@@ -535,11 +536,16 @@ export function Window({
           <TabStrip
             tabs={tabs.map(tab => {
               const context = contexts.find(c => c.name === tab.sub);
-              return context ? { ...tab, sub: getMark(context.stableId, context.name).name } : tab;
+              return { ...tab,
+                sub: context ? getMark(context.stableId, context.name).name : tab.sub,
+                context: parseEditRoute(tab.route)?.cluster ?? parseNewRoute(tab.route)?.cluster ?? tab.sub,
+                detail: tabDetail(tab.route),
+              };
             })}
             activeId={activeId}
             onSelect={activateTab}
             onClose={closeTab}
+            onMove={moveTab}
             menuFor={menuFor}
             onNew={() => run({ type: "new-tab" })}
             newHint={hint("new-tab", apple)}

--- a/packages/ui-next/src/shell/Window.tsx
+++ b/packages/ui-next/src/shell/Window.tsx
@@ -538,7 +538,8 @@ export function Window({
               const context = contexts.find(c => c.name === tab.sub);
               return { ...tab,
                 sub: context ? getMark(context.stableId, context.name).name : tab.sub,
-                context: parseEditRoute(tab.route)?.cluster ?? parseNewRoute(tab.route)?.cluster ?? tab.sub,
+                context: parseEditRoute(tab.route)?.cluster ?? parseNewRoute(tab.route)?.cluster ?? tab.sub
+                  ?? (isClusterScopedRoute(tab.route) ? activeCtx?.name : undefined),
                 detail: tabDetail(tab.route),
               };
             })}


### PR DESCRIPTION
## What changed and why

Crowded document tabs now expose their full title and context on hover or keyboard focus, plus resource kind and namespace when available. Neighbouring hints share the opening delay window.

Tabs can be reordered by dragging with an insertion marker or with Ctrl/Cmd+Shift+Left/Right. Moves preserve selection, announce the new position, and persist through the existing backend workspace storage. Pinned tabs remain freely movable.

Always-present edge chevrons scroll by a page or continuously while held, disable at the ends, and respect reduced motion. New-tab and overflow controls remain fixed outside the scrolling region.

## Related issues

Closes #407

## Validation

- Added failing regression tests before implementation for hover identity, reorder, no-op drags, and scroll controls.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `pnpm test` — 385 files / 6,248 tests passed; 90.77% line coverage. The first run hit an unrelated Topology timing failure; its isolated suite and the full rerun passed.
- `cargo test --workspace --offline` — passed.
- Store tests verify order survives serialization and restore without changing the active tab.

## UI evidence

Ran a local Vite harness using the actual tab strip and workspace store in Chrome. Verified delayed hover, immediate neighbouring hints, Escape dismissal, preserved right-click menus, native drag/drop and insertion marker, unchanged selection after drag, and press-and-hold scrolling. At 380px width, both edge controls, new-tab, and overflow controls stay visible.

The desktop window disables Tauri’s native file-drop interception so HTML tab drops reach the webview. A configuration regression test covers this host setting; the app has no native file-drop consumers.

The rebuilt development app starts successfully. Native gesture verification remains manual: the UI automation tool cannot attach to the unbundled development process.

No settings schema or Rust source changes.

