### PR TITLE
fix(tui): enable text search, match navigation, and highlighting in helm detail view

### DIFF
--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -2393,25 +2393,27 @@ impl App {
                     ActiveView::Logs(logs) => self.filter_buffer = logs.search_query.clone(),
                     ActiveView::Top(top) => self.filter_buffer = top.filter.clone(),
                     ActiveView::Helm(helm) => self.filter_buffer = helm.filter_query.clone(),
-                    ActiveView::HelmDetail(detail) => self.filter_buffer = detail.filter_query.clone(),
+                    ActiveView::HelmDetail(detail) => self.filter_buffer = detail.search_query.clone(),
                     _ => {}
                 }
             }
-            // Next search match in text views (Describe, YAML, Logs)
-            KeyCode::Char('n') if matches!(self.active_view, ActiveView::Describe(_) | ActiveView::Yaml(_) | ActiveView::Logs(_)) => {
+            // Next search match in text views (Describe, YAML, Logs, HelmDetail)
+            KeyCode::Char('n') if matches!(self.active_view, ActiveView::Describe(_) | ActiveView::Yaml(_) | ActiveView::Logs(_) | ActiveView::HelmDetail(_)) => {
                 match &mut self.active_view {
                     ActiveView::Describe(desc) => desc.next_match(),
                     ActiveView::Yaml(yaml) => yaml.next_match(),
                     ActiveView::Logs(logs) => logs.next_match(),
+                    ActiveView::HelmDetail(detail) => detail.next_match(),
                     _ => {}
                 }
             }
-            // Previous search match in text views (Describe, YAML, Logs)
-            KeyCode::Char('N') if matches!(self.active_view, ActiveView::Describe(_) | ActiveView::Yaml(_) | ActiveView::Logs(_)) => {
+            // Previous search match in text views (Describe, YAML, Logs, HelmDetail)
+            KeyCode::Char('N') if matches!(self.active_view, ActiveView::Describe(_) | ActiveView::Yaml(_) | ActiveView::Logs(_) | ActiveView::HelmDetail(_)) => {
                 match &mut self.active_view {
                     ActiveView::Describe(desc) => desc.prev_match(),
                     ActiveView::Yaml(yaml) => yaml.prev_match(),
                     ActiveView::Logs(logs) => logs.prev_match(),
+                    ActiveView::HelmDetail(detail) => detail.prev_match(),
                     _ => {}
                 }
             }
@@ -4364,6 +4366,7 @@ impl App {
                     KeyCode::PageUp => detail.scroll_up(15),
                     KeyCode::PageDown => detail.scroll_down(15),
                     KeyCode::Char('g') => detail.scroll_to_top(),
+                    KeyCode::Char('G') => detail.scroll_to_bottom(),
                     KeyCode::Char('m') => {
                         if detail.active_tab == HelmDetailTab::ValuesDiff {
                             detail.toggle_diff_mode();
@@ -4890,7 +4893,7 @@ impl App {
                 }
             }
             ActiveView::HelmDetail(detail) => {
-                detail.filter_query = filter;
+                detail.set_search_query(&filter);
             }
             _ => {}
         }
@@ -4920,7 +4923,7 @@ impl App {
                 helm.filter_query.clear();
             }
             ActiveView::HelmDetail(detail) => {
-                detail.filter_query.clear();
+                detail.clear_search();
             }
             _ => {}
         }
@@ -7636,6 +7639,7 @@ impl App {
             ActiveView::Logs(logs) => (logs.search_matches.len(), logs.lines.len(), true),
             ActiveView::Helm(helm) => (helm.filtered_indices().len(), helm.releases.len(), false),
             ActiveView::Top(top) => (top.visible_count(), if top.active_tab == top_view::TopTab::Pods { top.pods.len() } else { top.nodes.len() }, false),
+            ActiveView::HelmDetail(detail) => (detail.search_matches.len(), detail.total_lines_for_active_tab(), true),
             _ => (0, 0, false),
         };
 
@@ -7999,6 +8003,9 @@ impl App {
             ][..]),
             ActiveView::HelmDetail(_) => Some(&[
                 ("<:>", "Cmd"),
+                ("</>", "Search"),
+                ("<n/N>", "Next/Prev"),
+                ("<Esc>", "Back"),
                 ("<?>", "Help"),
             ][..]),
             ActiveView::Settings(_) => Some(&[

--- a/apps/tui/src/ui/statusbar.rs
+++ b/apps/tui/src/ui/statusbar.rs
@@ -189,9 +189,21 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
 
             if !props.filter_input.is_empty() {
                 spans.push(Span::raw(" | "));
-                spans.push(Span::styled("Filter: ", Theme::header_label()));
+                let label = if props.is_text_search { "Search: " } else { "Filter: " };
+                spans.push(Span::styled(label, Theme::header_label()));
+                let stats = if props.is_text_search {
+                    if props.matched_count == 0 {
+                        format!("\"{}\" [0 matches]", props.filter_input)
+                    } else if props.matched_count == 1 {
+                        format!("\"{}\" [1 match, n/N]", props.filter_input)
+                    } else {
+                        format!("\"{}\" [{} matches, n/N]", props.filter_input, props.matched_count)
+                    }
+                } else {
+                    format!("\"{}\" [{}/{}]", props.filter_input, props.matched_count, props.total_count)
+                };
                 spans.push(Span::styled(
-                    format!("\"{}\" [{}/{}]", props.filter_input, props.matched_count, props.total_count),
+                    stats,
                     Style::default().fg(Theme::yellow()),
                 ));
             }

--- a/apps/tui/src/views/helm_detail_view.rs
+++ b/apps/tui/src/views/helm_detail_view.rs
@@ -75,6 +75,9 @@ pub struct HelmDetailViewState {
     pub scroll_offset: usize,
     pub values_diff_mode: ValuesDiffMode,
     pub filter_query: String,
+    pub search_query: String,
+    pub search_matches: Vec<usize>,
+    pub current_match_idx: Option<usize>,
 }
 
 impl HelmDetailViewState {
@@ -91,6 +94,9 @@ impl HelmDetailViewState {
             scroll_offset: 0,
             values_diff_mode: ValuesDiffMode::CustomVsComputed,
             filter_query: String::new(),
+            search_query: String::new(),
+            search_matches: Vec::new(),
+            current_match_idx: None,
         }
     }
 
@@ -98,6 +104,9 @@ impl HelmDetailViewState {
         self.detail = Some(detail);
         self.is_loading = false;
         self.error = None;
+        if !self.search_query.is_empty() {
+            self.recompute_search_matches();
+        }
     }
 
     pub fn set_previous_detail(&mut self, detail: HelmReleaseDetail) {
@@ -113,17 +122,20 @@ impl HelmDetailViewState {
         let curr = self.active_tab as usize;
         self.active_tab = HelmDetailTab::from_index((curr + 1) % 5);
         self.scroll_offset = 0;
+        self.recompute_search_matches();
     }
 
     pub fn prev_tab(&mut self) {
         let curr = self.active_tab as usize;
         self.active_tab = HelmDetailTab::from_index(if curr == 0 { 4 } else { curr - 1 });
         self.scroll_offset = 0;
+        self.recompute_search_matches();
     }
 
     pub fn set_tab(&mut self, tab: HelmDetailTab) {
         self.active_tab = tab;
         self.scroll_offset = 0;
+        self.recompute_search_matches();
     }
 
     pub fn toggle_diff_mode(&mut self) {
@@ -133,6 +145,124 @@ impl HelmDetailViewState {
             ValuesDiffMode::RevisionVsPrevious => ValuesDiffMode::CustomVsComputed,
         };
         self.scroll_offset = 0;
+        self.recompute_search_matches();
+    }
+
+    pub fn text_lines_for_active_tab(&self) -> Vec<String> {
+        match self.active_tab {
+            HelmDetailTab::Manifest => self
+                .detail
+                .as_ref()
+                .map(|d| d.manifest.lines().map(super::sanitize_span_text).collect())
+                .unwrap_or_default(),
+            HelmDetailTab::Notes => self
+                .detail
+                .as_ref()
+                .map(|d| d.notes.lines().map(super::sanitize_span_text).collect())
+                .unwrap_or_default(),
+            HelmDetailTab::ValuesDiff => self
+                .compute_values_diff()
+                .into_iter()
+                .map(|dl| super::sanitize_span_text(&dl.text))
+                .collect(),
+            HelmDetailTab::Overview | HelmDetailTab::Revisions => Vec::new(),
+        }
+    }
+
+    pub fn total_lines_for_active_tab(&self) -> usize {
+        match self.active_tab {
+            HelmDetailTab::Manifest => self.detail.as_ref().map(|d| d.manifest.lines().count()).unwrap_or(0),
+            HelmDetailTab::Notes => self.detail.as_ref().map(|d| d.notes.lines().count()).unwrap_or(0),
+            HelmDetailTab::ValuesDiff => self.compute_values_diff().len(),
+            HelmDetailTab::Revisions => self.detail.as_ref().map(|d| d.history.len()).unwrap_or(0),
+            HelmDetailTab::Overview => 0,
+        }
+    }
+
+    pub fn manifest_line_count(&self) -> usize {
+        self.detail.as_ref().map(|d| d.manifest.lines().count()).unwrap_or(0)
+    }
+
+    pub fn set_search_query(&mut self, query: &str) {
+        self.search_query = query.to_string();
+        self.filter_query = query.to_string();
+        if query.is_empty() {
+            self.search_matches.clear();
+            self.current_match_idx = None;
+            return;
+        }
+
+        let lines = self.text_lines_for_active_tab();
+        let q = query.to_lowercase();
+        self.search_matches = lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.to_lowercase().contains(&q))
+            .map(|(i, _)| i)
+            .collect();
+
+        if !self.search_matches.is_empty() {
+            self.current_match_idx = Some(0);
+            self.scroll_offset = self.search_matches[0];
+        } else {
+            self.current_match_idx = None;
+        }
+    }
+
+    pub fn recompute_search_matches(&mut self) {
+        if self.search_query.is_empty() {
+            self.search_matches.clear();
+            self.current_match_idx = None;
+            return;
+        }
+
+        let lines = self.text_lines_for_active_tab();
+        let q = self.search_query.to_lowercase();
+        self.search_matches = lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.to_lowercase().contains(&q))
+            .map(|(i, _)| i)
+            .collect();
+
+        if !self.search_matches.is_empty() {
+            let next_idx = self.current_match_idx.unwrap_or(0).min(self.search_matches.len() - 1);
+            self.current_match_idx = Some(next_idx);
+            self.scroll_offset = self.search_matches[next_idx];
+        } else {
+            self.current_match_idx = None;
+        }
+    }
+
+    pub fn next_match(&mut self) {
+        if self.search_matches.is_empty() {
+            return;
+        }
+        let next_idx = match self.current_match_idx {
+            Some(curr) => (curr + 1) % self.search_matches.len(),
+            None => 0,
+        };
+        self.current_match_idx = Some(next_idx);
+        self.scroll_offset = self.search_matches[next_idx];
+    }
+
+    pub fn prev_match(&mut self) {
+        if self.search_matches.is_empty() {
+            return;
+        }
+        let prev_idx = match self.current_match_idx {
+            Some(0) | None => self.search_matches.len().saturating_sub(1),
+            Some(curr) => curr - 1,
+        };
+        self.current_match_idx = Some(prev_idx);
+        self.scroll_offset = self.search_matches[prev_idx];
+    }
+
+    pub fn clear_search(&mut self) {
+        self.search_query.clear();
+        self.filter_query.clear();
+        self.search_matches.clear();
+        self.current_match_idx = None;
     }
 
     pub fn scroll_down(&mut self, n: usize) {
@@ -145,6 +275,11 @@ impl HelmDetailViewState {
 
     pub fn scroll_to_top(&mut self) {
         self.scroll_offset = 0;
+    }
+
+    pub fn scroll_to_bottom(&mut self) {
+        let total = self.total_lines_for_active_tab();
+        self.scroll_offset = total.saturating_sub(1);
     }
 
     pub fn select_next_revision(&mut self) {
@@ -432,7 +567,22 @@ fn render_values_diff_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState
         ValuesDiffMode::RevisionVsPrevious => "[Mode: Current Revision vs Previous Revision Values]",
     };
 
-    let title = format!(" Values Diff {} (Press <m> to toggle mode) ", mode_desc);
+    let search_badge = if !state.search_query.is_empty() {
+        if state.search_matches.is_empty() {
+            format!(" [Search: \"{}\" (0 matches)]", state.search_query)
+        } else {
+            format!(
+                " [Search: \"{}\" ({}/{} matches, n/N)]",
+                state.search_query,
+                state.current_match_idx.map(|i| i + 1).unwrap_or(0),
+                state.search_matches.len()
+            )
+        }
+    } else {
+        String::new()
+    };
+
+    let title = format!(" Values Diff {} (Press <m> to toggle mode){} ", mode_desc, search_badge);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(Theme::border_type())
@@ -448,6 +598,11 @@ fn render_values_diff_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState
         f.render_widget(msg, inner);
         return;
     }
+
+    let match_style = Style::default()
+        .bg(Theme::YELLOW)
+        .fg(Color::Rgb(20, 20, 20))
+        .add_modifier(Modifier::BOLD);
 
     let viewport_height = inner.height as usize;
     let visible_lines: Vec<Line> = diff_lines
@@ -465,11 +620,22 @@ fn render_values_diff_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState
             let right_str = dl.line_num_right.map(|n| format!("{:>4}", n)).unwrap_or_else(|| "    ".to_string());
 
             let clean_text = super::sanitize_span_text(&dl.text);
-            Line::from(vec![
+            let mut spans = vec![
                 Span::styled(format!("{} {} ", left_str, right_str), Style::default().fg(Theme::dim())),
                 Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
-                Span::styled(clean_text, style),
-            ])
+            ];
+
+            let has_match = !state.search_query.is_empty()
+                && clean_text.to_lowercase().contains(&state.search_query.to_lowercase());
+
+            if has_match {
+                let highlighted = super::highlight_text_matches(&clean_text, &state.search_query, style, match_style);
+                spans.extend(highlighted);
+            } else {
+                spans.push(Span::styled(clean_text, style));
+            }
+
+            Line::from(spans)
         })
         .collect();
 
@@ -575,7 +741,22 @@ fn render_revisions_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) 
 }
 
 fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
-    let title = " Rendered Kubernetes Manifests (YAML) (<c> Copy  </> Search) ";
+    let search_badge = if !state.search_query.is_empty() {
+        if state.search_matches.is_empty() {
+            format!(" [Search: \"{}\" (0 matches)]", state.search_query)
+        } else {
+            format!(
+                " [Search: \"{}\" ({}/{} matches, n/N)]",
+                state.search_query,
+                state.current_match_idx.map(|i| i + 1).unwrap_or(0),
+                state.search_matches.len()
+            )
+        }
+    } else {
+        String::new()
+    };
+
+    let title = format!(" Rendered Kubernetes Manifests (YAML) (<c> Copy  </> Search){} ", search_badge);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(Theme::border_type())
@@ -590,6 +771,11 @@ fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         f.render_widget(msg, inner);
         return;
     }
+
+    let match_style = Style::default()
+        .bg(Theme::YELLOW)
+        .fg(Color::Rgb(20, 20, 20))
+        .add_modifier(Modifier::BOLD);
 
     let viewport_height = inner.height as usize;
     let lines: Vec<Line> = d
@@ -613,10 +799,21 @@ fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
             };
 
             let clean_l = super::sanitize_span_text(l);
-            Line::from(vec![
+            let mut spans = vec![
                 Span::styled(format!("{:>5} │ ", line_idx), Style::default().fg(Theme::dim())),
-                Span::styled(clean_l, style),
-            ])
+            ];
+
+            let has_match = !state.search_query.is_empty()
+                && clean_l.to_lowercase().contains(&state.search_query.to_lowercase());
+
+            if has_match {
+                let highlighted = super::highlight_text_matches(&clean_l, &state.search_query, style, match_style);
+                spans.extend(highlighted);
+            } else {
+                spans.push(Span::styled(clean_l, style));
+            }
+
+            Line::from(spans)
         })
         .collect();
 
@@ -625,7 +822,22 @@ fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
 }
 
 fn render_notes_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
-    let title = " Chart Release Notes (NOTES.txt) ";
+    let search_badge = if !state.search_query.is_empty() {
+        if state.search_matches.is_empty() {
+            format!(" [Search: \"{}\" (0 matches)]", state.search_query)
+        } else {
+            format!(
+                " [Search: \"{}\" ({}/{} matches, n/N)]",
+                state.search_query,
+                state.current_match_idx.map(|i| i + 1).unwrap_or(0),
+                state.search_matches.len()
+            )
+        }
+    } else {
+        String::new()
+    };
+
+    let title = format!(" Chart Release Notes (NOTES.txt) (<c> Copy  </> Search){} ", search_badge);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(Theme::border_type())
@@ -642,13 +854,34 @@ fn render_notes_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         return;
     }
 
+    let match_style = Style::default()
+        .bg(Theme::YELLOW)
+        .fg(Color::Rgb(20, 20, 20))
+        .add_modifier(Modifier::BOLD);
+
     let viewport_height = inner.height as usize;
     let lines: Vec<Line> = d
         .notes
         .lines()
         .skip(state.scroll_offset)
         .take(viewport_height)
-        .map(|l| Line::from(Span::styled(super::sanitize_span_text(l), Style::default().fg(Theme::fg()))))
+        .map(|l| {
+            let clean_l = super::sanitize_span_text(l);
+            let has_match = !state.search_query.is_empty()
+                && clean_l.to_lowercase().contains(&state.search_query.to_lowercase());
+
+            if has_match {
+                let highlighted = super::highlight_text_matches(
+                    &clean_l,
+                    &state.search_query,
+                    Style::default().fg(Theme::fg()),
+                    match_style,
+                );
+                Line::from(highlighted)
+            } else {
+                Line::from(Span::styled(clean_l, Style::default().fg(Theme::fg())))
+            }
+        })
         .collect();
 
     let para = Paragraph::new(lines);
@@ -658,10 +891,10 @@ fn render_notes_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
 fn render_bottom_hints(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
     let hints = match state.active_tab {
         HelmDetailTab::Overview => "<Tab> Switch Tab  <1-5> Jump Tab  <Esc> Back to Releases",
-        HelmDetailTab::ValuesDiff => "<Tab> Switch Tab  <m> Toggle Diff Mode  <j/k> Scroll  <g/G> Top/Bottom  <Esc> Back",
+        HelmDetailTab::ValuesDiff => "<Tab> Switch Tab  <m> Toggle Diff Mode  </> Search  <n/N> Next/Prev  <j/k> Scroll  <g/G> Top/Bottom  <Esc> Back",
         HelmDetailTab::Revisions => "<Tab> Switch Tab  <j/k> Select Rev  <r> Rollback to Selected  <Enter>/<v> View  <Esc> Back",
-        HelmDetailTab::Manifest => "<Tab> Switch Tab  <j/k> Scroll  <c> Copy  </> Search  <Esc> Back",
-        HelmDetailTab::Notes => "<Tab> Switch Tab  <j/k> Scroll  <c> Copy  <Esc> Back",
+        HelmDetailTab::Manifest => "<Tab> Switch Tab  <j/k> Scroll  <g/G> Top/Bottom  <c> Copy  </> Search  <n/N> Next/Prev  <Esc> Back",
+        HelmDetailTab::Notes => "<Tab> Switch Tab  <j/k> Scroll  <g/G> Top/Bottom  <c> Copy  </> Search  <n/N> Next/Prev  <Esc> Back",
     };
 
     let p = Paragraph::new(format!(" {}", hints))

--- a/apps/tui/src/views/helm_detail_view.rs
+++ b/apps/tui/src/views/helm_detail_view.rs
@@ -604,6 +604,7 @@ fn render_values_diff_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState
         .fg(Color::Rgb(20, 20, 20))
         .add_modifier(Modifier::BOLD);
 
+    let query_lower = state.search_query.to_lowercase();
     let viewport_height = inner.height as usize;
     let visible_lines: Vec<Line> = diff_lines
         .iter()
@@ -625,8 +626,8 @@ fn render_values_diff_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState
                 Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
             ];
 
-            let has_match = !state.search_query.is_empty()
-                && clean_text.to_lowercase().contains(&state.search_query.to_lowercase());
+            let has_match = !query_lower.is_empty()
+                && clean_text.to_lowercase().contains(&query_lower);
 
             if has_match {
                 let highlighted = super::highlight_text_matches(&clean_text, &state.search_query, style, match_style);
@@ -777,6 +778,7 @@ fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         .fg(Color::Rgb(20, 20, 20))
         .add_modifier(Modifier::BOLD);
 
+    let query_lower = state.search_query.to_lowercase();
     let viewport_height = inner.height as usize;
     let lines: Vec<Line> = d
         .manifest
@@ -803,8 +805,8 @@ fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
                 Span::styled(format!("{:>5} │ ", line_idx), Style::default().fg(Theme::dim())),
             ];
 
-            let has_match = !state.search_query.is_empty()
-                && clean_l.to_lowercase().contains(&state.search_query.to_lowercase());
+            let has_match = !query_lower.is_empty()
+                && clean_l.to_lowercase().contains(&query_lower);
 
             if has_match {
                 let highlighted = super::highlight_text_matches(&clean_l, &state.search_query, style, match_style);
@@ -859,6 +861,7 @@ fn render_notes_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         .fg(Color::Rgb(20, 20, 20))
         .add_modifier(Modifier::BOLD);
 
+    let query_lower = state.search_query.to_lowercase();
     let viewport_height = inner.height as usize;
     let lines: Vec<Line> = d
         .notes
@@ -867,8 +870,8 @@ fn render_notes_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         .take(viewport_height)
         .map(|l| {
             let clean_l = super::sanitize_span_text(l);
-            let has_match = !state.search_query.is_empty()
-                && clean_l.to_lowercase().contains(&state.search_query.to_lowercase());
+            let has_match = !query_lower.is_empty()
+                && clean_l.to_lowercase().contains(&query_lower);
 
             if has_match {
                 let highlighted = super::highlight_text_matches(

--- a/apps/tui/src/views/mod.rs
+++ b/apps/tui/src/views/mod.rs
@@ -78,12 +78,12 @@ use ratatui::text::Span;
 
 /// Splits `text` into Spans, highlighting every case-insensitive occurrence of `query`
 /// with `match_style` while styling non-matching portions with `base_style`.
-pub fn highlight_text_matches<'a>(
-    text: &'a str,
+pub fn highlight_text_matches(
+    text: &str,
     query: &str,
     base_style: Style,
     match_style: Style,
-) -> Vec<Span<'a>> {
+) -> Vec<Span<'static>> {
     if query.is_empty() {
         return vec![Span::styled(text.to_string(), base_style)];
     }

--- a/apps/tui/src/views/mod.rs
+++ b/apps/tui/src/views/mod.rs
@@ -76,6 +76,88 @@ pub fn sanitize_span_text(text: &str) -> String {
 use ratatui::style::Style;
 use ratatui::text::Span;
 
+/// Finds non-overlapping `(start_byte, end_byte)` slices in `text` that case-insensitively match `query`.
+/// Guarantees that every returned `start_byte` and `end_byte` lies on a valid UTF-8 character boundary
+/// of `text`, preventing panics even when case conversion changes character or byte length.
+fn find_case_insensitive_matches(text: &str, query: &str) -> Vec<(usize, usize)> {
+    if query.is_empty() || text.is_empty() {
+        return Vec::new();
+    }
+
+    // Fast path for ASCII strings
+    if text.is_ascii() && query.is_ascii() {
+        let text_lower = text.to_ascii_lowercase();
+        let query_lower = query.to_ascii_lowercase();
+        let q_len = query.len();
+        let mut matches = Vec::new();
+        let mut curr = 0;
+        while let Some(idx) = text_lower[curr..].find(&query_lower) {
+            let start = curr + idx;
+            let end = start + q_len;
+            matches.push((start, end));
+            curr = end;
+        }
+        return matches;
+    }
+
+    // Unicode-safe path: walk character boundaries of `text`
+    let query_lower_chars: Vec<char> = query.to_lowercase().chars().collect();
+    if query_lower_chars.is_empty() {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    let char_indices: Vec<(usize, char)> = text.char_indices().collect();
+    let n_chars = char_indices.len();
+    let mut i = 0;
+
+    while i < n_chars {
+        let start_byte = char_indices[i].0;
+        let mut q_idx = 0;
+        let mut j = i;
+        let mut matched = false;
+        let mut end_byte = start_byte;
+
+        while j < n_chars && q_idx < query_lower_chars.len() {
+            let next_byte_pos = if j + 1 < n_chars {
+                char_indices[j + 1].0
+            } else {
+                text.len()
+            };
+
+            let mut ch_mismatch = false;
+            for lower_c in char_indices[j].1.to_lowercase() {
+                if q_idx < query_lower_chars.len() && query_lower_chars[q_idx] == lower_c {
+                    q_idx += 1;
+                } else {
+                    ch_mismatch = true;
+                    break;
+                }
+            }
+
+            if ch_mismatch {
+                break;
+            }
+
+            end_byte = next_byte_pos;
+            if q_idx == query_lower_chars.len() {
+                matched = true;
+                break;
+            }
+            j += 1;
+        }
+
+        if matched {
+            matches.push((start_byte, end_byte));
+            i = j + 1;
+        } else {
+            i += 1;
+        }
+    }
+
+    matches
+}
+
 /// Splits `text` into Spans, highlighting every case-insensitive occurrence of `query`
 /// with `match_style` while styling non-matching portions with `base_style`.
 pub fn highlight_text_matches(
@@ -87,29 +169,28 @@ pub fn highlight_text_matches(
     if query.is_empty() {
         return vec![Span::styled(text.to_string(), base_style)];
     }
-    let query_lower = query.to_lowercase();
-    let text_lower = text.to_lowercase();
+
+    let matches = find_case_insensitive_matches(text, query);
+    if matches.is_empty() {
+        return vec![Span::styled(text.to_string(), base_style)];
+    }
+
     let mut spans = Vec::new();
     let mut last_idx = 0;
 
-    for (match_start, _) in text_lower.match_indices(&query_lower) {
-        if match_start > last_idx {
-            spans.push(Span::styled(text[last_idx..match_start].to_string(), base_style));
+    for (start, end) in matches {
+        if start > last_idx {
+            spans.push(Span::styled(text[last_idx..start].to_string(), base_style));
         }
-        let match_end = (match_start + query.len()).min(text.len());
-        spans.push(Span::styled(text[match_start..match_end].to_string(), match_style));
-        last_idx = match_end;
+        spans.push(Span::styled(text[start..end].to_string(), match_style));
+        last_idx = end;
     }
 
     if last_idx < text.len() {
         spans.push(Span::styled(text[last_idx..].to_string(), base_style));
     }
 
-    if spans.is_empty() {
-        vec![Span::styled(text.to_string(), base_style)]
-    } else {
-        spans
-    }
+    spans
 }
 
 pub use assistant_view::{render_assistant_view, AssistantViewState};

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -3095,3 +3095,79 @@ async fn non_pod_and_custom_resources_reject_pod_actions() {
     }
 }
 
+#[tokio::test]
+async fn helm_detail_manifest_search_and_navigation_input_flow() {
+    let (mut app, _rx) = common::app().await;
+    let mut detail_state = srelens_tui::views::HelmDetailViewState::new("my-release".into(), "default".into());
+    detail_state.set_detail(srelens_kube::helm::HelmReleaseDetail {
+        name: "my-release".into(),
+        namespace: "default".into(),
+        revision: 1,
+        status: "deployed".into(),
+        chart: "my-chart".into(),
+        chart_version: "1.0.0".into(),
+        app_version: "1.0.0".into(),
+        updated: "2026-09-10T12:00:00Z".into(),
+        values_yaml: "".into(),
+        chart_values_yaml: "".into(),
+        computed_values_yaml: "".into(),
+        manifest: "---\napiVersion: v1\nkind: Secret\nmetadata:\n  name: app-token\ndata:\n  github_token: Z2hw...\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n".into(),
+        notes: "".into(),
+        history: vec![],
+    });
+    detail_state.set_tab(srelens_tui::views::HelmDetailTab::Manifest);
+    app.active_view = srelens_tui::app::ActiveView::HelmDetail(detail_state);
+
+    // 1. Press '/' to enter search mode
+    press(&mut app, ch('/')).await;
+    assert_eq!(app.input_mode, srelens_tui::ui::statusbar::InputMode::Filter);
+
+    // 2. Type "token"
+    for c in "token".chars() {
+        press(&mut app, ch(c)).await;
+    }
+    assert_eq!(app.filter_buffer, "token");
+    if let srelens_tui::app::ActiveView::HelmDetail(ref detail) = app.active_view {
+        assert_eq!(detail.search_query, "token");
+        assert_eq!(detail.search_matches.len(), 2);
+        assert_eq!(detail.current_match_idx, Some(0));
+        assert_eq!(detail.scroll_offset, detail.search_matches[0]);
+    } else {
+        panic!("expected HelmDetail view");
+    }
+
+    // 3. Press Enter to return to Normal mode with search query active
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.input_mode, srelens_tui::ui::statusbar::InputMode::Normal);
+    assert_eq!(app.filter_buffer, "token");
+
+    // 4. Press 'n' to go to next match
+    press(&mut app, ch('n')).await;
+    if let srelens_tui::app::ActiveView::HelmDetail(ref detail) = app.active_view {
+        assert_eq!(detail.current_match_idx, Some(1));
+        assert_eq!(detail.scroll_offset, detail.search_matches[1]);
+    } else {
+        panic!("expected HelmDetail view");
+    }
+
+    // 5. Press 'N' to go to previous match
+    press(&mut app, ch('N')).await;
+    if let srelens_tui::app::ActiveView::HelmDetail(ref detail) = app.active_view {
+        assert_eq!(detail.current_match_idx, Some(0));
+        assert_eq!(detail.scroll_offset, detail.search_matches[0]);
+    } else {
+        panic!("expected HelmDetail view");
+    }
+
+    // 6. Press Esc to clear filter
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.filter_buffer.is_empty());
+    if let srelens_tui::app::ActiveView::HelmDetail(ref detail) = app.active_view {
+        assert!(detail.search_query.is_empty());
+        assert!(detail.search_matches.is_empty());
+        assert!(detail.current_match_idx.is_none());
+    } else {
+        panic!("expected HelmDetail view");
+    }
+}
+

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -968,6 +968,34 @@ fn normal_mode_prefixes_a_toast_and_appends_the_active_filter() {
 }
 
 #[test]
+fn normal_mode_appends_active_search_when_is_text_search_is_true() {
+    let mode = InputMode::Normal;
+    let mut props = status_props(&mode);
+    props.filter_input = "token";
+    props.matched_count = 2;
+    props.total_count = 100;
+    props.is_text_search = true;
+    let text = statusbar_text(props);
+    assert!(text.contains(" | Search: \"token\" [2 matches, n/N]"), "{text}");
+
+    let mut props = status_props(&mode);
+    props.filter_input = "token";
+    props.matched_count = 1;
+    props.total_count = 100;
+    props.is_text_search = true;
+    let text = statusbar_text(props);
+    assert!(text.contains(" | Search: \"token\" [1 match, n/N]"), "{text}");
+
+    let mut props = status_props(&mode);
+    props.filter_input = "token";
+    props.matched_count = 0;
+    props.total_count = 100;
+    props.is_text_search = true;
+    let text = statusbar_text(props);
+    assert!(text.contains(" | Search: \"token\" [0 matches]"), "{text}");
+}
+
+#[test]
 fn normal_mode_uses_custom_hints_when_a_view_supplies_them() {
     let mode = InputMode::Normal;
     let mut props = status_props(&mode);
@@ -2190,6 +2218,16 @@ async fn the_app_renders_helm_and_helm_detail_views_across_all_tabs() {
     detail_state.set_tab(HelmDetailTab::Manifest);
     let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
     assert!(text.contains("Rendered Kubernetes Manifests") && text.contains("kind: Deployment"), "{text}");
+
+    // Manifest search rendering
+    detail_state.set_search_query("Deployment");
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("[Search: \"Deployment\" (1/1 matches, n/N)]"), "{text}");
+
+    detail_state.set_search_query("nonexistent");
+    let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
+    assert!(text.contains("[Search: \"nonexistent\" (0 matches)]"), "{text}");
+    detail_state.clear_search();
 
     // Notes tab
     detail_state.set_tab(HelmDetailTab::Notes);

--- a/apps/tui/tests/tui_tests.rs
+++ b/apps/tui/tests/tui_tests.rs
@@ -6723,6 +6723,83 @@ mod tests {
         assert!(res.is_ok());
         assert!(matches!(app.active_view, ActiveView::HelmDetail(_)));
     }
+
+    #[tokio::test]
+    async fn helm_detail_search_matches_and_navigates_across_tabs() {
+        use srelens_tui::views::helm_detail_view::{HelmDetailTab, HelmDetailViewState};
+        use srelens_kube::helm::{HelmReleaseDetail, HelmRevision};
+
+        let mut detail_state = HelmDetailViewState::new("app".to_string(), "default".to_string());
+        let mock_detail = HelmReleaseDetail {
+            name: "app".to_string(),
+            namespace: "default".to_string(),
+            revision: 1,
+            status: "deployed".to_string(),
+            chart: "app-chart".to_string(),
+            chart_version: "1.0.0".to_string(),
+            app_version: "1.0.0".to_string(),
+            updated: "2026-09-10T12:00:00Z".to_string(),
+            values_yaml: "apiKey: secret-token-123\nport: 8080\n".to_string(),
+            chart_values_yaml: "port: 80\n".to_string(),
+            computed_values_yaml: "apiKey: secret-token-123\nport: 8080\n".to_string(),
+            manifest: "---\napiVersion: v1\nkind: Secret\nmetadata:\n  name: app-token\ndata:\n  github_token: Z2hw...\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n".to_string(),
+            notes: "Please copy your auth token from app-token Secret to proceed.\nEnjoy the app!".to_string(),
+            history: vec![
+                HelmRevision {
+                    revision: 1,
+                    status: "deployed".to_string(),
+                    updated: "2026-09-10T12:00:00Z".to_string(),
+                    chart_version: "app-chart-1.0.0".to_string(),
+                    description: "Initial install".to_string(),
+                },
+            ],
+        };
+        detail_state.set_detail(mock_detail);
+
+        // Switch to Manifest tab (tab 4)
+        detail_state.set_tab(HelmDetailTab::Manifest);
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Manifest);
+
+        // Search for "token"
+        detail_state.set_search_query("token");
+        assert_eq!(detail_state.search_query, "token");
+        // Manifest contains "app-token" on line 4 (idx 4) and "github_token" on line 6 (idx 6)
+        assert_eq!(detail_state.search_matches.len(), 2);
+        assert_eq!(detail_state.current_match_idx, Some(0));
+        assert_eq!(detail_state.scroll_offset, detail_state.search_matches[0]);
+
+        // Navigate to next match
+        detail_state.next_match();
+        assert_eq!(detail_state.current_match_idx, Some(1));
+        assert_eq!(detail_state.scroll_offset, detail_state.search_matches[1]);
+
+        // Next wraps around to 0
+        detail_state.next_match();
+        assert_eq!(detail_state.current_match_idx, Some(0));
+        assert_eq!(detail_state.scroll_offset, detail_state.search_matches[0]);
+
+        // Previous wraps to last match
+        detail_state.prev_match();
+        assert_eq!(detail_state.current_match_idx, Some(1));
+        assert_eq!(detail_state.scroll_offset, detail_state.search_matches[1]);
+
+        // Scroll to bottom
+        detail_state.scroll_to_bottom();
+        assert_eq!(detail_state.scroll_offset, detail_state.manifest_line_count() - 1);
+
+        // Switch to Notes tab (tab 5) - should automatically recompute search for "token" in notes!
+        detail_state.set_tab(HelmDetailTab::Notes);
+        assert_eq!(detail_state.active_tab, HelmDetailTab::Notes);
+        // Notes has "Please copy your auth token from app-token Secret..." on line 0
+        assert_eq!(detail_state.search_matches.len(), 1);
+        assert_eq!(detail_state.search_matches[0], 0);
+
+        // Clear search
+        detail_state.clear_search();
+        assert!(detail_state.search_query.is_empty());
+        assert!(detail_state.search_matches.is_empty());
+        assert!(detail_state.current_match_idx.is_none());
+    }
 }
 
 

--- a/apps/tui/tests/views_panels_tests.rs
+++ b/apps/tui/tests/views_panels_tests.rs
@@ -161,6 +161,70 @@ fn highlight_text_matches_handles_a_match_that_ends_the_text() {
     assert_eq!(parts, vec!["abc", "XYZ"]);
 }
 
+#[test]
+fn highlight_text_matches_safely_handles_unicode_and_case_expansion_without_panicking() {
+    let base = Style::default().fg(Color::White);
+    let hit = Style::default().fg(Color::Yellow);
+
+    // 1. Multibyte emoji and accented characters
+    let spans = highlight_text_matches("Prefix ⚡ Bolt", "bolt", base, hit);
+    let parts: Vec<(&str, Option<Color>)> = spans
+        .iter()
+        .map(|s| (s.content.as_ref(), s.style.fg))
+        .collect();
+    assert_eq!(
+        parts,
+        vec![("Prefix ⚡ ", Some(Color::White)), ("Bolt", Some(Color::Yellow))]
+    );
+
+    let spans = highlight_text_matches("café LATTE", "latte", base, hit);
+    let parts: Vec<(&str, Option<Color>)> = spans
+        .iter()
+        .map(|s| (s.content.as_ref(), s.style.fg))
+        .collect();
+    assert_eq!(
+        parts,
+        vec![("café ", Some(Color::White)), ("LATTE", Some(Color::Yellow))]
+    );
+
+    let spans = highlight_text_matches("CAFÉ Latte", "café", base, hit);
+    let parts: Vec<(&str, Option<Color>)> = spans
+        .iter()
+        .map(|s| (s.content.as_ref(), s.style.fg))
+        .collect();
+    assert_eq!(
+        parts,
+        vec![("CAFÉ", Some(Color::Yellow)), (" Latte", Some(Color::White))]
+    );
+
+    // 2. German capital sharp S (ẞ) which lowercases to 'ß'
+    let spans = highlight_text_matches("GROẞE Halle", "große", base, hit);
+    let parts: Vec<(&str, Option<Color>)> = spans
+        .iter()
+        .map(|s| (s.content.as_ref(), s.style.fg))
+        .collect();
+    assert_eq!(
+        parts,
+        vec![("GROẞE", Some(Color::Yellow)), (" Halle", Some(Color::White))]
+    );
+
+    // 3. Turkish dotted I (\u{0130}) where lowercasing expands from 2 bytes to 3 bytes
+    let spans = highlight_text_matches("T\u{0130}TLE", "\u{0130}", base, hit);
+    let parts: Vec<(&str, Option<Color>)> = spans
+        .iter()
+        .map(|s| (s.content.as_ref(), s.style.fg))
+        .collect();
+    assert_eq!(
+        parts,
+        vec![("T", Some(Color::White)), ("\u{0130}", Some(Color::Yellow)), ("TLE", Some(Color::White))]
+    );
+
+    // 4. Multibyte with no matches
+    let spans = highlight_text_matches("⚡ Bolt ❄", "zzz", base, hit);
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].content, "⚡ Bolt ❄");
+}
+
 // ---------------------------------------------------------------------------
 // logs_view
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the search functionality in the Helm Deep Inspector (`:helm` -> `HelmDetailViewState`), specifically in the **Rendered Kubernetes Manifests (YAML)** tab (`4: Manifest`), as well as **Chart Release Notes** (`5: Notes`) and **Values Diff** (`2: Values Diff`).

Previously, pressing `/` in `ActiveView::HelmDetail` updated an inert string field (`filter_query`) without computing matching line indices, without scrolling to matches, and without highlighting matching spans. The statusbar also lacked an `ActiveView::HelmDetail` branch, falling through to `_ => (0, 0, false)` and displaying `Filter: "<query>" [0/0]`.

## Changes

- **Search State & Navigation in `HelmDetailViewState`**:
  - Added `search_query`, `search_matches: Vec<usize>`, and `current_match_idx: Option<usize>`.
  - Implemented `set_search_query`, `recompute_search_matches`, `next_match`, `prev_match`, and `clear_search`.
  - Added auto-recomputation of search matches when switching tabs or diff modes so search terms carry across tabs.
  - Added `scroll_to_bottom()` bound to `G`.
- **Search Highlighting & Header Badges**:
  - In `render_manifest_tab`, `render_notes_tab`, and `render_values_diff_tab`, case-insensitively highlight query occurrences with `super::highlight_text_matches` and `Theme::YELLOW` (bold black on yellow), while preserving base YAML/diff token styles.
  - Added search badge to titles: `[Search: "<query>" (X/Y matches, n/N)]` or `[Search: "<query>" (0 matches)]`.
  - Updated `render_bottom_hints` with `</> Search  <n/N> Next/Prev  <g/G> Top/Bottom`.
- **App & Statusbar Integration**:
  - Wired `/` in `ActiveView::HelmDetail` to populate search state from `search_query`.
  - Added `ActiveView::HelmDetail` to `n` / `N` match navigation keybindings.
  - Updated `apply_current_filter` and `clear_current_filter` to invoke `detail.set_search_query` and `detail.clear_search`.
  - Added `ActiveView::HelmDetail` to statusbar metrics reporting `(detail.search_matches.len(), detail.total_lines_for_active_tab(), true)`.
  - Updated normal-mode statusbar to render `Search: "<query>" [X matches, n/N]` when `is_text_search` is true.
  - Updated `highlight_text_matches` to return `Vec<Span<'static>>` for clean use with dynamically sanitized strings.

## Verification

- `helm_detail_search_matches_and_navigates_across_tabs` in `apps/tui/tests/tui_tests.rs`.
- `helm_detail_manifest_search_and_navigation_input_flow` in `apps/tui/tests/app_input_tests.rs`.
- `normal_mode_appends_active_search_when_is_text_search_is_true` and manifest search badge rendering in `apps/tui/tests/chrome_tests.rs`.
- All tests passing (`cargo test -p srelens-tui -p srelens-kube`).