### PR TITLE
feat(logs): support init-container logs in both UIs

### DIFF
--- a/apps/desktop/src/components/LogsView.test.tsx
+++ b/apps/desktop/src/components/LogsView.test.tsx
@@ -46,6 +46,23 @@ afterEach(() => {
 });
 
 describe("LogsView", () => {
+  it("offers init logs while the app container is waiting and can tail the selected init container", async () => {
+    getObjectMock.mockResolvedValue({ object: {
+      spec: { containers: [{ name: "app" }], initContainers: [{ name: "migrate" }] },
+      status: { phase: "Pending" },
+    } });
+    podLogsMock.mockImplementation(async (_c, _n, _p, _i, options) =>
+      options.container === "migrate" ? { logs: "migration failed" } : { error: "PodInitializing" });
+    render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);
+    await userEvent.click(await screen.findByRole("combobox", { name: "Container" }));
+    await userEvent.click(await screen.findByRole("option", { name: "migrate" }));
+    expect(await screen.findByText(/migration failed/)).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Live tail" }));
+    await waitFor(() => expect(startLogStreamMock).toHaveBeenCalledWith(
+      "kind-dev", "default", [{ pod: "web-1", container: "migrate", label: "" }],
+      expect.any(Function), expect.any(Function), expect.any(Object),
+    ));
+  });
   it("fetches and renders logs for the pod's container", async () => {
     podLogsMock.mockResolvedValue({ logs: "line one\nline two" });
     render(<LogsView context="kind-dev" namespace="default" source={{ type: "pod", pod: "web-1" }} />);

--- a/apps/desktop/src/components/LogsView.test.tsx
+++ b/apps/desktop/src/components/LogsView.test.tsx
@@ -46,6 +46,19 @@ afterEach(() => {
 });
 
 describe("LogsView", () => {
+  it("keeps completed init logs visible and labels the finished stream", async () => {
+    startLogStreamMock.mockImplementation(async (_c, _n, _t, onLine, onStatus) => {
+      onLine("", "init finished");
+      onStatus("completed", "");
+      return { stop: vi.fn() };
+    });
+    render(<LogsView context="kind-dev" namespace="default" source={{type:"pod",pod:"web-1"}} initialContainer="setup" />);
+    await screen.findByRole("combobox", { name: "Container" });
+    fireEvent.click(screen.getByRole("button", { name: "Live tail" }));
+    expect(await screen.findByText("completed")).toBeDefined();
+    expect(screen.getByText("init finished")).toBeDefined();
+    expect(screen.queryByText("reconnecting…")).toBeNull();
+  });
   it("offers init logs while the app container is waiting and can tail the selected init container", async () => {
     getObjectMock.mockResolvedValue({ object: {
       spec: { containers: [{ name: "app" }], initContainers: [{ name: "migrate" }] },

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Clock, Download, DownloadCloud, History, Pause, Play, RefreshCw, WrapText } from "lucide-react";
 import { podLogs, podsForSelector } from "@srelens/core";
-import { getObject } from "@srelens/core";
+import { getObject, podContainerChoices } from "@srelens/core";
 import { startLogStream, type LogStream, type LogTarget, type LogStatus } from "@srelens/core";
 import { saveTextFile } from "@srelens/core";
 import { Spinner, Select, IconButton, TextInput, avatarColor } from "../ui";
@@ -198,7 +198,7 @@ export function LogsView({
           .filter((p) => p && !containersByPod[p])
           .map(async (p) => {
             const o = await getObject(context, "Pod", namespace, p);
-            const cs = ((o.object?.spec ?? {}) as { containers?: { name: string }[] }).containers ?? [];
+            const cs = podContainerChoices(o.object).filter((c) => c.kind !== "ephemeral");
             return [p, cs.map((c) => c.name)] as const;
           }),
       );

--- a/apps/desktop/src/components/LogsView.tsx
+++ b/apps/desktop/src/components/LogsView.tsx
@@ -301,6 +301,7 @@ export function LogsView({
     setStreamError("");
     setLoading(true);
     setStreamStatus("connecting");
+    const statuses = new Map<string, LogStatus>();
     void startLogStream(
       context,
       namespace,
@@ -310,8 +311,13 @@ export function LogsView({
         if (next.length > MAX_LINES) next.splice(0, next.length - MAX_LINES);
         setBuffer(next);
       },
-      (status) => {
-        if (!stopped) setStreamStatus(status);
+      (status, source) => {
+        if (stopped) return;
+        statuses.set(source, status);
+        const values = [...statuses.values()];
+        setStreamStatus(values.includes("reconnecting") ? "reconnecting"
+          : statuses.size < targets.length ? "connecting"
+          : values.every((s) => s === "completed") ? "completed" : "live");
       },
       { timestamps, sinceSeconds, tailLines },
     ).then((s) => {
@@ -514,6 +520,9 @@ export function LogsView({
           {loading && <Spinner label="Loading logs" />}
           {follow && streamStatus === "reconnecting" && (
             <span className="text-amber-600 dark:text-amber-400">reconnecting…</span>
+          )}
+          {follow && streamStatus === "completed" && (
+            <span className="text-muted-foreground">completed</span>
           )}
           {follow && streamStatus === "connecting" && (
             <span className="text-muted-foreground">connecting…</span>

--- a/crates/kube/src/logs.rs
+++ b/crates/kube/src/logs.rs
@@ -111,8 +111,8 @@ where
 /// Backoff between log reconnect attempts.
 const LOG_RECONNECT_SECS: u64 = 2;
 
-/// Ordinary init containers are finite. Native sidecars and init containers
-/// still eligible for a retry must keep following after an EOF.
+/// Ordinary init containers are finite. Native sidecars finish with their
+/// Pod; containers still eligible for a retry keep following after an EOF.
 fn init_logs_complete(pod: &Pod, container: &str) -> bool {
     let Some(spec) = pod.spec.as_ref() else {
         return false;
@@ -124,9 +124,6 @@ fn init_logs_complete(pod: &Pod, container: &str) -> bool {
     else {
         return false;
     };
-    if init.restart_policy.as_deref() == Some("Always") {
-        return false;
-    }
     let Some(status) = pod.status.as_ref() else {
         return false;
     };
@@ -139,38 +136,67 @@ fn init_logs_complete(pod: &Pod, container: &str) -> bool {
     else {
         return false;
     };
-    terminated.exit_code == 0
-        || spec.restart_policy.as_deref() == Some("Never")
-        || matches!(status.phase.as_deref(), Some("Failed" | "Succeeded"))
+    matches!(status.phase.as_deref(), Some("Failed" | "Succeeded"))
+        || (init.restart_policy.as_deref() != Some("Always")
+            && (terminated.exit_code == 0 || spec.restart_policy.as_deref() == Some("Never")))
 }
 
-async fn init_logs_finished(
+/// Completion must describe the same already-terminal attempt on both sides
+/// of the read. A running attempt can finish after an early clean EOF, so an
+/// after-only check (even with the same restart count) is insufficient.
+fn same_completed_init(before: &Pod, after: &Pod, container: &str) -> bool {
+    if before.metadata.uid.is_none()
+        || before.metadata.uid != after.metadata.uid
+        || !init_logs_complete(before, container)
+        || !init_logs_complete(after, container)
+    {
+        return false;
+    }
+    let status = |pod: &Pod| {
+        pod.status
+            .as_ref()?
+            .init_container_statuses
+            .as_ref()?
+            .iter()
+            .find(|s| s.name == container)
+            .cloned()
+    };
+    match (status(before), status(after)) {
+        (Some(a), Some(b)) => {
+            a.restart_count == b.restart_count
+                && a.container_id == b.container_id
+                && a.state == b.state
+        }
+        _ => false,
+    }
+}
+
+async fn read_log_pod(
     cache: &ClientCache,
     context: &str,
     namespace: &str,
     pod: &str,
     container: Option<&str>,
-) -> bool {
-    let Some(container) = container else {
-        return false;
-    };
+) -> Option<Pod> {
+    container?;
     let Ok(client) = cache.get(context).await else {
-        return false;
+        return None;
     };
     let api: Api<Pod> = Api::namespaced(client, namespace);
     match tokio::time::timeout(request_timeout(), api.get(pod)).await {
-        Ok(Ok(pod)) => init_logs_complete(&pod, container),
+        Ok(Ok(pod)) => Some(pod),
         // A failed read is not proof of completion. Preserve retry behavior.
-        _ => false,
+        _ => None,
     }
 }
 
 /// Follow a pod/container's logs, transparently reconnecting when the stream
 /// ends (pod restart, network blip). Unlike a resource watch, a log stream is
-/// one-shot, so we loop: the first connect tails `tail_lines`; reconnects tail
-/// `0` (only new lines) to avoid re-printing history. `on_status` fires
-/// "reconnecting"/"live" on transitions. A successful EOF for a terminal
-/// ordinary init container emits "completed" and ends without retrying.
+/// one-shot, so we loop: the first connect tails `tail_lines`; ordinary
+/// reconnects tail `0`. A terminal init attempt is read with the requested
+/// history again, which may replay output but cannot discard its final lines
+/// after an early EOF. Matching terminal states around that read emit
+/// "completed"; other transitions emit "reconnecting"/"live".
 pub async fn stream_pod_logs_resilient<F, G>(
     cache: Arc<ClientCache>,
     context: String,
@@ -186,9 +212,17 @@ pub async fn stream_pod_logs_resilient<F, G>(
 {
     let mut first = true;
     loop {
+        let before = read_log_pod(&cache, &context, &namespace, &pod, container.as_deref()).await;
+        let terminal = before
+            .as_ref()
+            .zip(container.as_deref())
+            .is_some_and(|(p, c)| init_logs_complete(p, c));
         // First connect honors tail + since; reconnects tail 0 with no `since`
         // so we don't re-print history, but keep the timestamps preference.
-        let connect_opts = if first {
+        // Read the requested history again once terminal. A prior EOF might
+        // have preceded completion or belonged to a different attempt; tail 0
+        // would silently discard the final output in either case.
+        let connect_opts = if first || terminal {
             opts
         } else {
             StreamOpts {
@@ -208,11 +242,18 @@ pub async fn stream_pod_logs_resilient<F, G>(
             || on_status("live"),
         )
         .await;
-        if res.is_ok()
-            && init_logs_finished(&cache, &context, &namespace, &pod, container.as_deref()).await
-        {
-            on_status("completed");
-            return;
+        if res.is_ok() {
+            let after =
+                read_log_pod(&cache, &context, &namespace, &pod, container.as_deref()).await;
+            if before
+                .as_ref()
+                .zip(after.as_ref())
+                .zip(container.as_deref())
+                .is_some_and(|((a, b), c)| same_completed_init(a, b, c))
+            {
+                on_status("completed");
+                return;
+            }
         }
         if let Err(e) = res {
             on_line(format!("[error: {}]", e));
@@ -299,6 +340,41 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn completion_requires_the_same_terminal_attempt_and_pod() {
+        let before: Pod = serde_json::from_value(serde_json::json!({
+            "metadata":{"uid":"pod-1"},
+            "spec":{"containers":[{"name":"app"}],"initContainers":[{"name":"setup"}]},
+            "status":{"initContainerStatuses":[{"name":"setup","containerID":"container-1","image":"init","imageID":"init","ready":false,"restartCount":0,"state":{"terminated":{"exitCode":0}}}]}
+        })).unwrap();
+        assert!(same_completed_init(&before, &before, "setup"));
+        let mut after = before.clone();
+        after
+            .status
+            .as_mut()
+            .unwrap()
+            .init_container_statuses
+            .as_mut()
+            .unwrap()[0]
+            .restart_count = 1;
+        assert!(!same_completed_init(&before, &after, "setup"));
+        after = before.clone();
+        after
+            .status
+            .as_mut()
+            .unwrap()
+            .init_container_statuses
+            .as_mut()
+            .unwrap()[0]
+            .container_id = Some("container-2".into());
+        assert!(!same_completed_init(&before, &after, "setup"));
+        after = before.clone();
+        after.metadata.uid = Some("pod-2".into());
+        assert!(!same_completed_init(&before, &after, "setup"));
+        after.metadata.uid = None;
+        assert!(!same_completed_init(&after, &after, "setup"));
+    }
+
+    #[test]
     fn init_completion_preserves_retries_and_native_sidecars() {
         let mut value = serde_json::json!({
             "spec":{"containers":[{"name":"app"}],"initContainers":[{"name":"setup"}]},
@@ -329,6 +405,25 @@ mod tests {
 
     #[tokio::test]
     async fn completed_init_logs_finish_without_reconnecting() {
+        assert_init_completion(0, false).await;
+    }
+
+    #[tokio::test]
+    async fn clean_disconnect_before_init_completion_reads_the_final_snapshot() {
+        assert_init_completion(1, false).await;
+    }
+
+    #[tokio::test]
+    async fn a_later_successful_init_attempt_is_read_before_completion() {
+        assert_init_completion(2, false).await;
+    }
+
+    #[tokio::test]
+    async fn native_sidecar_logs_complete_when_the_pod_is_terminal() {
+        assert_init_completion(0, true).await;
+    }
+
+    async fn assert_init_completion(race: u8, sidecar: bool) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -339,19 +434,36 @@ mod tests {
         )).unwrap();
         let server = tokio::spawn(async move {
             let mut requests = Vec::new();
-            for _ in 0..2 {
+            for index in 0..if race > 0 { 6 } else { 3 } {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 let mut bytes = vec![0; 8192];
                 let count = socket.read(&mut bytes).await.unwrap();
                 let request = String::from_utf8_lossy(&bytes[..count]).to_string();
                 let body = if request.contains("/log?") {
-                    "setup complete\n".to_string()
+                    if race > 0 && index < 3 {
+                        "partial output\n".to_string()
+                    } else {
+                        "setup complete\n".to_string()
+                    }
                 } else {
-                    serde_json::json!({
-                        "apiVersion":"v1", "kind":"Pod", "metadata":{"name":"web"},
+                    let mut value = serde_json::json!({
+                        "apiVersion":"v1", "kind":"Pod", "metadata":{"name":"web","uid":"pod-1"},
                         "spec":{"containers":[{"name":"app"}],"initContainers":[{"name":"setup"}]},
-                        "status":{"initContainerStatuses":[{"name":"setup","image":"init","imageID":"init","ready":false,"restartCount":0,"state":{"terminated":{"exitCode":0}}}]}
-                    }).to_string()
+                        "status":{"initContainerStatuses":[{"name":"setup","containerID":"container-1","image":"init","imageID":"init","ready":false,"restartCount":0,"state":{"terminated":{"exitCode":0}}}]}
+                    });
+                    if sidecar {
+                        value["spec"]["initContainers"][0]["restartPolicy"] = "Always".into();
+                        value["status"]["phase"] = "Succeeded".into();
+                    }
+                    if race > 0 && index == 0 {
+                        value["status"]["initContainerStatuses"][0]["state"] =
+                            serde_json::json!({"running":{}});
+                    } else if race == 2 {
+                        value["status"]["initContainerStatuses"][0]["restartCount"] = 1.into();
+                        value["status"]["initContainerStatuses"][0]["containerID"] =
+                            "container-2".into();
+                    }
+                    value.to_string()
                 };
                 requests.push(request);
                 socket.write_all(format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes()).await.unwrap();
@@ -361,7 +473,7 @@ mod tests {
         let mut lines = Vec::new();
         let mut statuses = Vec::new();
         let result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
+            std::time::Duration::from_secs(10),
             stream_pod_logs_resilient(
                 ClientCache::new(config),
                 "test".into(),
@@ -381,9 +493,23 @@ mod tests {
             result.is_ok(),
             "a completed init container must not enter the retry loop"
         );
-        assert_eq!(lines, ["setup complete"]);
-        assert_eq!(statuses, ["live", "completed"]);
-        assert_eq!(server.await.unwrap().len(), 2);
+        assert!(
+            lines.contains(&"setup complete".to_string()),
+            "must read the final attempt, got {lines:?}"
+        );
+        assert_eq!(statuses.last(), Some(&"completed"));
+        if race == 0 {
+            assert_eq!(statuses, ["live", "completed"]);
+        }
+        let requests = tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("all expected API reads must happen")
+            .unwrap();
+        let final_read = requests.iter().rev().find(|r| r.contains("/log?")).unwrap();
+        assert!(
+            final_read.contains("tailLines=200"),
+            "must not discard the final attempt with tailLines=0"
+        );
     }
 
     #[test]

--- a/crates/kube/src/logs.rs
+++ b/crates/kube/src/logs.rs
@@ -2,13 +2,13 @@
 
 use std::sync::Arc;
 
-use srelens_capability::{Annotations, Capability, CapabilityError};
+use futures::{AsyncBufReadExt, StreamExt};
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::LogParams;
 use kube::Api;
-use futures::{AsyncBufReadExt, StreamExt};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use srelens_capability::{Annotations, Capability, CapabilityError};
 
 use crate::client_cache::ClientCache;
 use crate::connect::request_timeout;
@@ -27,7 +27,11 @@ pub struct StreamOpts {
 
 impl Default for StreamOpts {
     fn default() -> Self {
-        Self { tail_lines: DEFAULT_TAIL_LINES, since_seconds: None, timestamps: false }
+        Self {
+            tail_lines: DEFAULT_TAIL_LINES,
+            since_seconds: None,
+            timestamps: false,
+        }
     }
 }
 
@@ -107,11 +111,66 @@ where
 /// Backoff between log reconnect attempts.
 const LOG_RECONNECT_SECS: u64 = 2;
 
+/// Ordinary init containers are finite. Native sidecars and init containers
+/// still eligible for a retry must keep following after an EOF.
+fn init_logs_complete(pod: &Pod, container: &str) -> bool {
+    let Some(spec) = pod.spec.as_ref() else {
+        return false;
+    };
+    let Some(init) = spec
+        .init_containers
+        .as_ref()
+        .and_then(|cs| cs.iter().find(|c| c.name == container))
+    else {
+        return false;
+    };
+    if init.restart_policy.as_deref() == Some("Always") {
+        return false;
+    }
+    let Some(status) = pod.status.as_ref() else {
+        return false;
+    };
+    let Some(terminated) = status
+        .init_container_statuses
+        .as_ref()
+        .and_then(|cs| cs.iter().find(|c| c.name == container))
+        .and_then(|c| c.state.as_ref())
+        .and_then(|s| s.terminated.as_ref())
+    else {
+        return false;
+    };
+    terminated.exit_code == 0
+        || spec.restart_policy.as_deref() == Some("Never")
+        || matches!(status.phase.as_deref(), Some("Failed" | "Succeeded"))
+}
+
+async fn init_logs_finished(
+    cache: &ClientCache,
+    context: &str,
+    namespace: &str,
+    pod: &str,
+    container: Option<&str>,
+) -> bool {
+    let Some(container) = container else {
+        return false;
+    };
+    let Ok(client) = cache.get(context).await else {
+        return false;
+    };
+    let api: Api<Pod> = Api::namespaced(client, namespace);
+    match tokio::time::timeout(request_timeout(), api.get(pod)).await {
+        Ok(Ok(pod)) => init_logs_complete(&pod, container),
+        // A failed read is not proof of completion. Preserve retry behavior.
+        _ => false,
+    }
+}
+
 /// Follow a pod/container's logs, transparently reconnecting when the stream
 /// ends (pod restart, network blip). Unlike a resource watch, a log stream is
 /// one-shot, so we loop: the first connect tails `tail_lines`; reconnects tail
 /// `0` (only new lines) to avoid re-printing history. `on_status` fires
-/// "reconnecting"/"live" on transitions. Runs until the task is aborted.
+/// "reconnecting"/"live" on transitions. A successful EOF for a terminal
+/// ordinary init container emits "completed" and ends without retrying.
 pub async fn stream_pod_logs_resilient<F, G>(
     cache: Arc<ClientCache>,
     context: String,
@@ -132,7 +191,11 @@ pub async fn stream_pod_logs_resilient<F, G>(
         let connect_opts = if first {
             opts
         } else {
-            StreamOpts { tail_lines: 0, since_seconds: None, timestamps: opts.timestamps }
+            StreamOpts {
+                tail_lines: 0,
+                since_seconds: None,
+                timestamps: opts.timestamps,
+            }
         };
         let res = stream_pod_logs(
             cache.clone(),
@@ -145,6 +208,12 @@ pub async fn stream_pod_logs_resilient<F, G>(
             || on_status("live"),
         )
         .await;
+        if res.is_ok()
+            && init_logs_finished(&cache, &context, &namespace, &pod, container.as_deref()).await
+        {
+            on_status("completed");
+            return;
+        }
         if let Err(e) = res {
             on_line(format!("[error: {}]", e));
         }
@@ -230,6 +299,94 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn init_completion_preserves_retries_and_native_sidecars() {
+        let mut value = serde_json::json!({
+            "spec":{"containers":[{"name":"app"}],"initContainers":[{"name":"setup"}]},
+            "status":{"initContainerStatuses":[{"name":"setup","image":"init","imageID":"init","ready":false,"restartCount":0,"state":{"terminated":{"exitCode":0}}}]}
+        });
+        let complete = |v: &serde_json::Value, name| {
+            init_logs_complete(&serde_json::from_value(v.clone()).unwrap(), name)
+        };
+        assert!(complete(&value, "setup"));
+        assert!(!complete(&value, "app"));
+        value["spec"]["initContainers"][0]["restartPolicy"] = "Always".into();
+        assert!(!complete(&value, "setup"));
+        value["spec"]["initContainers"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("restartPolicy");
+        value["status"]["initContainerStatuses"][0]["state"]["terminated"]["exitCode"] = 1.into();
+        assert!(!complete(&value, "setup"));
+        value["spec"]["restartPolicy"] = "Never".into();
+        assert!(complete(&value, "setup"));
+        value["spec"]["restartPolicy"] = "OnFailure".into();
+        value["status"]["phase"] = "Failed".into();
+        assert!(complete(&value, "setup"));
+        value["status"]["initContainerStatuses"][0]["state"] = serde_json::json!({"waiting":{}});
+        assert!(!complete(&value, "setup"));
+        assert!(!init_logs_complete(&Pod::default(), "setup"));
+    }
+
+    #[tokio::test]
+    async fn completed_init_logs_finish_without_reconnecting() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config");
+        std::fs::write(&config, format!(
+            "apiVersion: v1\nkind: Config\ncurrent-context: test\nclusters:\n- name: c\n  cluster:\n    server: http://{address}\nusers:\n- name: u\n  user: {{}}\ncontexts:\n- name: test\n  context: {{cluster: c, user: u}}\n"
+        )).unwrap();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut bytes = vec![0; 8192];
+                let count = socket.read(&mut bytes).await.unwrap();
+                let request = String::from_utf8_lossy(&bytes[..count]).to_string();
+                let body = if request.contains("/log?") {
+                    "setup complete\n".to_string()
+                } else {
+                    serde_json::json!({
+                        "apiVersion":"v1", "kind":"Pod", "metadata":{"name":"web"},
+                        "spec":{"containers":[{"name":"app"}],"initContainers":[{"name":"setup"}]},
+                        "status":{"initContainerStatuses":[{"name":"setup","image":"init","imageID":"init","ready":false,"restartCount":0,"state":{"terminated":{"exitCode":0}}}]}
+                    }).to_string()
+                };
+                requests.push(request);
+                socket.write_all(format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes()).await.unwrap();
+            }
+            requests
+        });
+        let mut lines = Vec::new();
+        let mut statuses = Vec::new();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            stream_pod_logs_resilient(
+                ClientCache::new(config),
+                "test".into(),
+                "default".into(),
+                "web".into(),
+                Some("setup".into()),
+                StreamOpts::default(),
+                |line| lines.push(line),
+                |status| statuses.push(status),
+            ),
+        )
+        .await;
+        if result.is_err() {
+            server.abort();
+        }
+        assert!(
+            result.is_ok(),
+            "a completed init container must not enter the retry loop"
+        );
+        assert_eq!(lines, ["setup complete"]);
+        assert_eq!(statuses, ["live", "completed"]);
+        assert_eq!(server.await.unwrap().len(), 2);
+    }
+
+    #[test]
     fn capability_has_expected_id_and_annotations() {
         let cap = pod_logs_capability(ClientCache::new(PathBuf::from("/x")));
         assert_eq!(cap.id, "k8s.podLogs");
@@ -283,7 +440,14 @@ mod tests {
         assert_eq!(o.since_seconds, None);
         assert!(!o.timestamps);
         // The streaming params always follow and are never `previous`.
-        let p = build_log_params(None, true, Some(o.tail_lines), o.since_seconds, o.timestamps, false);
+        let p = build_log_params(
+            None,
+            true,
+            Some(o.tail_lines),
+            o.since_seconds,
+            o.timestamps,
+            false,
+        );
         assert!(p.follow && !p.previous);
     }
 }

--- a/packages/core/src/lib/logConnectionStatus.test.ts
+++ b/packages/core/src/lib/logConnectionStatus.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import { logConnectionStatus } from "./logConnectionStatus";
 
 describe("logConnectionStatus", () => {
+  it("labels a finite completed stream without an outage tone", () => {
+    expect(logConnectionStatus("completed")).toEqual({ label: "Completed", health: "neutral" });
+  });
   it("reads 'connecting' as an info-toned 'Connecting'", () => {
     expect(logConnectionStatus("connecting")).toEqual({ label: "Connecting", health: "info" });
   });

--- a/packages/core/src/lib/logConnectionStatus.ts
+++ b/packages/core/src/lib/logConnectionStatus.ts
@@ -1,15 +1,15 @@
 /**
  * A log stream's connection state, turned into a word and a tone — the ONE
- * place that does this, so a screen never hand-pairs one of these four states
+ * place that does this, so a screen never hand-pairs one of these states
  * with a colour itself.
  *
  * Core has no other vocabulary for this: `k8sStatus.ts` and `k8sHealth.ts`
  * cover Kubernetes *resources* — a Pod's phase, a Node's readiness — and a
  * stream's connection is not one. `startLogStream` (`./logsStream`) only ever
- * reports `LogStatus` ("live" | "reconnecting") once a connection exists;
+ * reports `LogStatus` ("live" | "reconnecting" | "completed") once a connection exists;
  * "connecting" (before the first status arrives) and "error" (the stream
  * gave up) are states only the caller that opened the stream can observe, so
- * this module's own union names all four rather than importing a narrower
+ * this module's own union names all states rather than importing a narrower
  * one and widening it ad hoc.
  *
  * Shaped after `StatusVerdict` in `k8sStatus.ts`: the word and the tone are
@@ -46,6 +46,8 @@ export function logConnectionStatus(status: LogConnectionStatus): LogConnectionV
       return CONNECTING;
     case "live":
       return LIVE;
+    case "completed":
+      return { label: "Completed", health: "neutral" };
     case "reconnecting":
       return RECONNECTING;
     case "error":

--- a/packages/core/src/lib/logsStream.ts
+++ b/packages/core/src/lib/logsStream.ts
@@ -13,7 +13,7 @@ export interface LogStream {
 }
 
 /** Connection health of a live-tail stream. */
-export type LogStatus = "live" | "reconnecting";
+export type LogStatus = "live" | "reconnecting" | "completed";
 
 /** Per-stream options: how much history to tail and whether to timestamp. */
 export interface LogStreamOptions {

--- a/packages/ui-next/src/lib/logStream.test.ts
+++ b/packages/ui-next/src/lib/logStream.test.ts
@@ -66,6 +66,24 @@ beforeEach(() => {
 });
 
 describe("useLogStream", () => {
+  it("retains completed init logs without counting them as reconnecting or streaming", async () => {
+    const s = fakeStream();
+    const targets = fanOut(2);
+    const { result } = renderHook(() => useLogStream("kind-dev", "default", targets));
+    await s.connect();
+    act(() => {
+      s.line("web-1", "setup complete");
+      s.status("completed", "web-1");
+      s.status("live", "web-2");
+    });
+    await waitFor(() => expect(result.current.lines).toHaveLength(1));
+    expect(result.current.status).toBe("live");
+    expect(result.current.liveTargets).toBe(1);
+    expect(result.current.completedTargets).toBe(1);
+    expect(result.current.reconnectingTargets).toBe(0);
+    act(() => s.status("completed", "web-2"));
+    expect(result.current.status).toBe("completed");
+  });
   it("lands lines in order", async () => {
     const s = fakeStream();
     const { result } = renderHook(() => useLogStream("kind-dev", "default", [target]));

--- a/packages/ui-next/src/lib/logStream.ts
+++ b/packages/ui-next/src/lib/logStream.ts
@@ -91,6 +91,7 @@ export type LogStreamStatus = "connecting" | LogStatus | "error";
  *  denominator for both counts; targets that have not reported yet are
  *  neither `live` nor `reconnecting`. */
 export interface LogTargetCounts {
+  readonly completed?: number;
   readonly live: number;
   readonly reconnecting: number;
   readonly total: number;
@@ -114,7 +115,8 @@ export interface LogTargetCounts {
  */
 export function aggregateLogStatus(counts: LogTargetCounts): "connecting" | LogStatus {
   if (counts.reconnecting > 0) return "reconnecting";
-  if (counts.total > 0 && counts.live >= counts.total) return "live";
+  if (counts.total > 0 && (counts.completed ?? 0) >= counts.total) return "completed";
+  if (counts.total > 0 && counts.live + (counts.completed ?? 0) >= counts.total) return "live";
   return "connecting";
 }
 
@@ -126,6 +128,8 @@ export interface UseLogStreamResult {
   status: LogStreamStatus;
   /** How many of this stream's targets are streaming right now. */
   liveTargets: number;
+  /** Finite init-container logs that have been fully read. */
+  completedTargets: number;
   /** How many are down and retrying — every one of them a gap in the tail. */
   reconnectingTargets: number;
   /** How many targets this stream follows: the denominator for both counts. */
@@ -312,11 +316,13 @@ export function useLogStream(
         seen.set(source, s);
         let live = 0;
         let reconnecting = 0;
+        let completed = 0;
         for (const state of seen.values()) {
           if (state === "live") live += 1;
+          else if (state === "completed") completed += 1;
           else reconnecting += 1;
         }
-        setCounts({ live, reconnecting, total });
+        setCounts({ live, reconnecting, completed, total });
       },
       { timestamps, sinceSeconds, tailLines },
     ).then(
@@ -354,6 +360,7 @@ export function useLogStream(
       status: error !== undefined ? "error" : aggregateLogStatus(counts),
       liveTargets: counts.live,
       reconnectingTargets: counts.reconnecting,
+      completedTargets: counts.completed ?? 0,
       totalTargets: counts.total,
       error,
       paused,

--- a/packages/ui-next/src/lib/logSubject.test.ts
+++ b/packages/ui-next/src/lib/logSubject.test.ts
@@ -60,6 +60,29 @@ const workloadSubject: LogSubject = {
 };
 
 describe("resolveLogSubject", () => {
+  it.each([podSubject, workloadSubject])("includes completed and failed init containers for $type logs", async (subject) => {
+    const result = await resolveLogSubject(subject, fakeInvoke({
+      objects: {
+        "Deployment/web": workloadObject({ app: "web" }),
+        "Pod/web-1": {
+          spec: { containers: [{ name: "app" }], initContainers: [{ name: "setup" }, { name: "migrate" }] },
+          status: {
+            phase: "Pending",
+            containerStatuses: [{ name: "app", state: { waiting: { reason: "PodInitializing" } } }],
+            initContainerStatuses: [
+              { name: "setup", state: { terminated: { exitCode: 0 } } },
+              { name: "migrate", state: { terminated: { exitCode: 1 } } },
+            ],
+          },
+        },
+      },
+      pods: { pods: [{ name: "web-1" }] },
+    }));
+    if (result.status !== "resolved") throw new Error("expected resolved");
+    expect(result.targets.map((t) => t.container)).toEqual(["app", "setup", "migrate"]);
+    // A current termination is read with ordinary logs, not previous=true.
+    expect(result.previous).toEqual([]);
+  });
   it("resolves a pod subject to itself, unlabelled", async () => {
     const invoke = fakeInvoke({ objects: { "Pod/web-1": podObject(["app"]) } });
     const result = await resolveLogSubject(podSubject, invoke);
@@ -151,12 +174,11 @@ describe("resolveLogSubject", () => {
     expect(result.detail).toContain("Deployment/web");
   });
 
-  it("says a workload whose pods exist but have no app container is empty, not resolved to nothing", async () => {
+  it("says a workload whose pods exist but have no containers is empty, not resolved to nothing", async () => {
     const invoke = fakeInvoke({
       objects: {
         "Deployment/web": workloadObject({ app: "web" }),
-        // The pod exists and answers, but has no app container to follow —
-        // e.g. every container it does have is an init container.
+        // The pod exists and answers, but has no containers to follow.
         "Pod/web-abc": podObject([]),
       },
       pods: { pods: [{ name: "web-abc" }] },
@@ -422,10 +444,7 @@ describe("resolveLogSubject's previous instances", () => {
     expect(result.previous).toEqual([]);
   });
 
-  it("leaves out a container that is not followed, whose logs no toggle can reach", async () => {
-    // An init container's status carries a `lastState` like any other, and it
-    // is not one of this stream's targets — offering its corpse would be
-    // offering a buffer the screen has no target to draw it against.
+  it("offers a restarted init container's previous instance", async () => {
     const invoke = fakeInvoke({
       objects: {
         "Pod/web-1": {
@@ -441,7 +460,10 @@ describe("resolveLogSubject's previous instances", () => {
     });
     const result = await resolveLogSubject(podSubject, invoke);
     if (result.status !== "resolved") throw new Error("expected resolved");
-    expect(result.previous).toEqual([]);
+    expect(result.previous).toEqual([{
+      pod: "web-1", container: "migrate", exitCode: 137,
+      reason: "OOMKilled", finishedAt: "2026-08-24T14:07:42Z",
+    }]);
   });
 });
 

--- a/packages/ui-next/src/lib/logSubject.ts
+++ b/packages/ui-next/src/lib/logSubject.ts
@@ -141,9 +141,8 @@ export interface LogSubjectPod {
  * One entry per TARGET, not per pod. A pod running two containers can have one
  * corpse and one healthy process, and `podLogs` fetches a previous buffer per
  * container; an entry per pod would offer the live container's buffer under
- * the dead one's name. Only followed containers appear: an init container's
- * status carries a `lastState` like any other and is not something this stream
- * has a target for.
+ * the dead one's name. Init containers use the same last-state semantics,
+ * read from `initContainerStatuses`.
  *
  * Presence is what makes a buffer readable — a container that has terminated
  * once has a previous instance, whatever else its status did or did not carry.
@@ -268,14 +267,14 @@ export async function resolveLogSubject(
 
   const raw = scope.pods.flatMap((pod, i) =>
     podContainerChoices(objects[i].object)
-      .filter((c) => c.kind === "app")
+      .filter((c) => c.kind !== "ephemeral")
       // The object's index rides along: the previous-instance facts below are
       // read off the very same object, and looking the pod up again by name
       // would be a second index over a list already in hand.
       .map((c) => ({ pod, container: c.name, object: i })),
   );
 
-  // Every in-scope pod answered, but none of them had an app container to
+  // Every in-scope pod answered, but none of them had an app or init container to
   // follow — as unfollowable as no pods at all, and "resolved" with an empty
   // target list would say otherwise. Gate on what a caller can actually use.
   if (raw.length === 0) {
@@ -312,7 +311,8 @@ export async function resolveLogSubject(
   // target order, and only for followed containers: a corpse the screen has no
   // target to draw is a buffer it could never show.
   const previous: PreviousInstance[] = raw.flatMap(({ pod, container, object }) => {
-    const statuses = asArray(asRecord(asRecord(objects[object].object).status).containerStatuses);
+    const podStatus = asRecord(asRecord(objects[object].object).status);
+    const statuses = [...asArray(podStatus.containerStatuses), ...asArray(podStatus.initContainerStatuses)];
     const status = statuses.find((s) => asRecord(s).name === container);
     const termination = terminationOf(status);
     return termination === undefined ? [] : [{ pod, container, ...termination }];

--- a/packages/ui-next/src/screens/Logs.test.tsx
+++ b/packages/ui-next/src/screens/Logs.test.tsx
@@ -528,6 +528,23 @@ describe("Logs", () => {
     expect(rendered(region).map((r) => r.split("|")[3])).toEqual(["warn exporter queue is full"]);
   });
 
+  it("shows init-container lines and fetches that container's previous logs", async () => {
+    const init = { pod: "api-7", container: "migrate", label: "api-7/migrate" };
+    h.resolve.mockResolvedValue({
+      status: "resolved", targets: [...TARGETS, init], pods: PODS,
+      previous: [{ pod: "api-7", container: "migrate", exitCode: 1 }],
+    });
+    const region = await (draw(), body());
+    push(...LINES, { source: init.label, text: "2026-08-24T14:07:11Z error migration failed" });
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /container/i }), "migrate");
+    expect(rendered(region).map((r) => r.split("|")[3])).toEqual(["error migration failed"]);
+    await userEvent.click(screen.getByRole("button", { name: /previous instance/i }));
+    await waitFor(() => expect(h.fetched).toHaveBeenCalledWith(
+      expect.any(String), expect.any(String), "api-7", undefined,
+      expect.objectContaining({ container: "migrate", previous: true }),
+    ));
+  });
+
   it("filters by container when the label names the pod alone", async () => {
     // The ORDINARY workload: a Deployment with three replicas of one
     // container. Every in-scope target shares that container name, so

--- a/packages/ui-next/src/screens/Logs.test.tsx
+++ b/packages/ui-next/src/screens/Logs.test.tsx
@@ -31,6 +31,7 @@ const h = vi.hoisted(() => {
       /** Per-target truth: how many are streaming, how many are down, of how
        *  many altogether. */
       live: 4,
+      completed: 0,
       reconnecting: 0,
       total: 4,
       restarts: 0,
@@ -88,6 +89,7 @@ vi.mock("../lib/logStream", async () => {
         paused: h.state.paused,
         pendingWhilePaused: h.state.pending,
         liveTargets: h.state.live,
+        completedTargets: h.state.completed,
         reconnectingTargets: h.state.reconnecting,
         totalTargets: h.state.total,
         togglePause: () => {
@@ -237,6 +239,7 @@ beforeEach(() => {
     paused: false,
     pending: 0,
     live: 4,
+    completed: 0,
     reconnecting: 0,
     total: 4,
     restarts: 0,
@@ -526,6 +529,13 @@ describe("Logs", () => {
     push(...LINES);
     await userEvent.selectOptions(screen.getByRole("combobox", { name: /container/i }), "otel-sidecar");
     expect(rendered(region).map((r) => r.split("|")[3])).toEqual(["warn exporter queue is full"]);
+  });
+
+  it("reports completed sources separately from the live count", async () => {
+    h.state.live = 3;
+    h.state.completed = 1;
+    await (draw(), body());
+    expect(screen.getByText("Following — 3 of 4 streaming, 1 completed")).toBeDefined();
   });
 
   it("shows init-container lines and fetches that container's previous logs", async () => {

--- a/packages/ui-next/src/screens/Logs.tsx
+++ b/packages/ui-next/src/screens/Logs.tsx
@@ -207,8 +207,9 @@ function connectionLabel(
   verdict: LogConnectionVerdict,
   live: number,
   total: number,
+  completed = 0,
 ): string {
-  return `${verdict.label} — ${live} of ${total} streaming`;
+  return `${verdict.label} — ${live} of ${total} streaming${completed > 0 ? `, ${completed} completed` : ""}`;
 }
 
 /**
@@ -1263,6 +1264,7 @@ function LogsStream({
                 signal,
                 stream.liveTargets,
                 stream.totalTargets,
+                stream.completedTargets,
               )}
               tone={statusTone(signal.health)}
             />


### PR DESCRIPTION
## What changed and why

Both classic and new log views now include init containers alongside application containers. A failed or completed init container remains available even when the application container is waiting to start. The new UI also discovers previous instances from init-container statuses; a current termination still uses ordinary logs.

The shared backend stops retrying only when the same terminal init attempt is observed before and after reading its logs (Pod UID, restart count, container ID, and terminal state). If a disconnect precedes completion or a retry advances, it reads the final requested history before completing. That final read may replay output already shown. Native sidecars complete when their Pod reaches Succeeded or Failed; active sidecars and retryable failures continue following. Failed status reads do not imply completion.

A `completed` stream status keeps logs readable and separates finished sources from streaming/reconnecting counts in both UIs.

## Related issues

Closes #496

## Validation

- Regression tests failed before the fix for init-container discovery in both UIs and previous-instance discovery.
- `pnpm test`: 6,306 tests passed; coverage floors passed (90.83% lines).
- `pnpm typecheck` and `pnpm build`: passed.
- `cargo test --workspace`: passed with local socket access enabled for the existing server tests.
- Mock Kubernetes HTTP regressions cover stable completed init logs, early clean disconnects, later successful attempts, and terminal-Pod native sidecars. Identity tests reject changed Pod UIDs, restart counts, and container IDs. Lifecycle tests preserve active-sidecar and retryable-failure behavior.
- Rendered both actual log components in a local Vite harness with synthetic pod responses and log streams; verified retained init output, classic completion, and separate streaming/completed counts in the new UI.
