### PR TITLE
fix(ui): move bulk actions to the left of search

### DIFF
--- a/packages/ui-kit/src/FilterBar.tsx
+++ b/packages/ui-kit/src/FilterBar.tsx
@@ -22,6 +22,8 @@ export interface FilterBarProps {
   invalid?: boolean;
   /** Controls that filter alongside the text — a namespace picker, a toggle. */
   children?: ReactNode;
+  /** Selection actions shown before the search field. */
+  leading?: ReactNode;
   className?: string;
 }
 
@@ -66,6 +68,7 @@ export function FilterBar({
   onRegexChange,
   invalid = false,
   children,
+  leading,
   className,
 }: FilterBarProps) {
   const fieldRef = useRef<HTMLInputElement>(null);
@@ -78,6 +81,7 @@ export function FilterBar({
       className={cx("rule-b flex shrink-0 flex-wrap items-center gap-3 px-2.5 py-1.5", className)}
       style={{ background: "var(--surface-sunk)" }}
     >
+      {leading}
       <div
         className="flex min-w-[200px] flex-1 items-center gap-1.5 rounded border border-transparent px-1"
         data-invalid={invalid ? "true" : undefined}

--- a/packages/ui-next/src/screens/Resources.test.tsx
+++ b/packages/ui-next/src/screens/Resources.test.tsx
@@ -856,6 +856,10 @@ describe("Resources", () => {
 
     await userEvent.click(screen.getByRole("checkbox", { name: "Select default/web-1" }));
     await screen.findByText("1 selected");
+    const filterRow = screen.getByRole("search");
+    const selectionCount = within(filterRow).getByText("1 selected");
+    const search = within(filterRow).getByRole("searchbox");
+    expect(selectionCount.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     act(() => setNamespaces(CTX.stableId, ["billing"]));
 

--- a/packages/ui-next/src/screens/Resources.tsx
+++ b/packages/ui-next/src/screens/Resources.tsx
@@ -519,15 +519,7 @@ function KindList({
         invalid={invalidFilter}
         label={`Filter ${lower}`}
         placeholder={`Filter ${lower}…`}
-      >
-        {!clusterScoped && (
-          <NamespacePicker
-            namespaces={namespaces}
-            selection={selection}
-            onChange={(next) => setNamespaces(context.stableId, next)}
-          />
-        )}
-        {showRows && (
+        leading={showRows && (
           <ResourceBulk
             selected={selected}
             kind={lower}
@@ -535,6 +527,14 @@ function KindList({
             context={name}
             rows={filtered}
             onDone={() => setSelected(new Set())}
+          />
+        )}
+      >
+        {!clusterScoped && (
+          <NamespacePicker
+            namespaces={namespaces}
+            selection={selection}
+            onChange={(next) => setNamespaces(context.stableId, next)}
           />
         )}
       </FilterBar>


### PR DESCRIPTION
## What changed and why

Move the resource selection count and bulk actions to the left of the search field in the new UI. They remain in the filter row, with the namespace picker on the right. A leading slot in FilterBar preserves this order for both the visual layout and keyboard navigation.

## Validation

- Regression assertion failed before the move and passes afterward: selected-row controls precede search within the filter row.
- Resources and FilterBar suites: 88 tests passed.
- Full frontend validation with the init-container changes: 6,302 tests passed, coverage floors passed, typecheck and production build passed.
- Rendered the FilterBar in headless Chrome and verified the action buttons are left of the search field on the same row.
