### PR TITLE
fix(tui): execute highlighted suggestion when pressing enter in command mode

### DIFF
--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -2212,22 +2212,23 @@ impl App {
                 }
                 KeyCode::Enter => {
                     let trimmed = self.command_buffer.trim().trim_start_matches(':').trim();
-                    if trimmed.is_empty() {
-                        self.input_mode = InputMode::Normal;
-                        self.command_buffer.clear();
-                        self.command_suggestion_idx = 0;
-                        return;
-                    }
 
                     // Special contextual colon commands handled directly by execute_colon_command
-                    if trimmed == "save-ai" || trimmed == "export-ai"
-                        || (trimmed == "save" && matches!(self.active_view, ActiveView::Assistant))
-                        || trimmed == "clear-ai"
-                        || (trimmed == "clear" && matches!(self.active_view, ActiveView::Assistant))
-                        || trimmed == "tree" || trimmed == "lineage" || trimmed == "related"
-                        || trimmed == "actions" || trimmed == "act"
-                        || trimmed == "metrics" || trimmed == "metric"
-                        || trimmed == "reasons" || trimmed == "reason"
+                    if !trimmed.is_empty()
+                        && (trimmed == "save-ai"
+                            || trimmed == "export-ai"
+                            || (trimmed == "save" && matches!(self.active_view, ActiveView::Assistant))
+                            || trimmed == "clear-ai"
+                            || (trimmed == "clear" && matches!(self.active_view, ActiveView::Assistant))
+                            || trimmed == "tree"
+                            || trimmed == "lineage"
+                            || trimmed == "related"
+                            || trimmed == "actions"
+                            || trimmed == "act"
+                            || trimmed == "metrics"
+                            || trimmed == "metric"
+                            || trimmed == "reasons"
+                            || trimmed == "reason")
                     {
                         let cmd = self.command_buffer.clone();
                         self.input_mode = InputMode::Normal;
@@ -2249,7 +2250,7 @@ impl App {
                     self.command_suggestion_idx = 0;
                     if let Some(target) = target {
                         self.execute_command_target(target).await;
-                    } else {
+                    } else if !fallback_cmd.trim().trim_start_matches(':').trim().is_empty() {
                         self.execute_colon_command(&fallback_cmd).await;
                     }
                 }

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -1118,6 +1118,67 @@ async fn command_enter_runs_the_command_and_unknown_commands_toast() {
 }
 
 #[tokio::test]
+async fn empty_command_enter_runs_highlighted_suggestion_and_arrow_selection() {
+    let (mut app, _rx) = common::app().await;
+
+    // 1. ':' + Esc returns to Normal with no view change
+    press(&mut app, ch(':')).await;
+    assert_eq!(app.input_mode, InputMode::Command);
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+
+    // 2. ':' with empty buffer + Enter on index 0 executes the first suggestion (themes)
+    press(&mut app, ch(':')).await;
+    assert_eq!(app.input_mode, InputMode::Command);
+    assert_eq!(app.command_suggestion_idx, 0);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert!(
+        matches!(app.modal, Some(Modal::ThemePicker { .. })),
+        "expected ThemePicker modal, got {:?}",
+        app.modal
+    );
+    // Dismiss theme modal
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
+
+    // 3. ':' + Down until highlighted suggestion is pods + Enter -> opens Pods
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "nodes").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Nodes);
+
+    press(&mut app, ch(':')).await;
+    assert_eq!(app.input_mode, InputMode::Command);
+    assert_eq!(app.command_buffer, "");
+    let suggestions = command_suggestions_with_crds("", &app.crds);
+    let pods_idx = suggestions
+        .iter()
+        .position(|(def, _)| def.name == "pods")
+        .expect("pods must be in command suggestions");
+    for _ in 0..pods_idx {
+        press(&mut app, key(KeyCode::Down)).await;
+    }
+    assert_eq!(app.command_suggestion_idx, pods_idx);
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+
+    // 4. Non-empty :po + Enter still opens pods
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "po").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(table(&app).kind, ResourceKind::Pods);
+
+    // 5. Non-empty :zzzz + Enter still toasts unknown
+    press(&mut app, ch(':')).await;
+    type_str(&mut app, "zzzz").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(toast(&app).starts_with("Unknown command: 'zzzz'"));
+}
+
+#[tokio::test]
 async fn colon_commands_that_need_a_selection_warn_when_the_table_is_empty() {
     let (mut app, _rx) = common::app().await;
     for (cmd, expected) in [


### PR DESCRIPTION
## What changed and why

In command mode (`:`), pressing Enter with an empty buffer previously returned early without executing anything, even when a command was suggested and selected (such as the default first suggestion or an arrow-highlighted item).

This change removes the empty-buffer early return on `KeyCode::Enter` so that pressing `:` followed by `Enter` immediately executes the selected suggestion (or arrow-navigated suggestion), matching user expectations. Non-empty unmatched queries continue to report unknown command errors.

## Validation

- Added integration test `empty_command_enter_runs_highlighted_suggestion_and_arrow_selection` in `apps/tui/tests/app_input_tests.rs`.
- `cargo test -p srelens-tui` passes.
- `cargo test --workspace` passes.