### PR TITLE
feat(tui): add :config menu, text scale slider, and startup feature banner

### DIFF
--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -44,6 +44,7 @@ pub enum ActiveView {
     Toolbox(ToolboxViewState),
     Assistant,
     Settings(SettingsViewState),
+    TuiConfig(TuiConfigViewState),
     Tree(tree_view::TreeViewState),
     NodeInspector(node_inspector_view::NodeInspectorState),
     Topology(topology_view::TopologyViewState),
@@ -92,6 +93,7 @@ pub struct App {
     pub connection_attempt_start: std::time::Instant,
     pub cluster_unreachable: bool,
     pub ai_settings: crate::ai_config::AiSettings,
+    pub tui_config: crate::tui_config::TuiConfig,
     pub assistant_state: AssistantViewState,
     pub assistant_states: HashMap<String, AssistantViewState>,
     pub pod_metrics_tick_counter: usize,
@@ -256,6 +258,7 @@ impl App {
             connection_attempt_start: Instant::now(),
             cluster_unreachable: false,
             ai_settings: crate::ai_config::AiSettings::load(),
+            tui_config: crate::tui_config::TuiConfig::load(),
             assistant_state: AssistantViewState::for_context(&active_context),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -2395,6 +2398,16 @@ impl App {
             return;
         }
 
+        if matches!(self.active_view, ActiveView::TuiConfig(_)) {
+            if key.code == KeyCode::Char(':') {
+                self.input_mode = InputMode::Command;
+                self.command_buffer.clear();
+                return;
+            }
+            self.handle_view_key_event(key).await;
+            return;
+        }
+
         // 6. Normal Mode - k9s Global & View Keybindings
         match key.code {
             // Enter Command Mode
@@ -3860,6 +3873,36 @@ impl App {
                         }
                         _ => {}
                     }
+                }
+            }
+            ActiveView::TuiConfig(cfg_state) => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        if let Some(prev) = self.nav_stack.pop() {
+                            self.active_view = prev;
+                        } else {
+                            self.switch_view_to_kind(ResourceKind::Pods).await;
+                        }
+                    }
+                    KeyCode::Char('j') | KeyCode::Down | KeyCode::Tab => cfg_state.select_next_field(),
+                    KeyCode::Char('k') | KeyCode::Up | KeyCode::BackTab => cfg_state.select_prev_field(),
+                    KeyCode::Char('h') | KeyCode::Left | KeyCode::Char('-') => {
+                        cfg_state.adjust_current(-1, &mut self.tui_config);
+                    }
+                    KeyCode::Char('l') | KeyCode::Right | KeyCode::Char('+') | KeyCode::Char('=') => {
+                        cfg_state.adjust_current(1, &mut self.tui_config);
+                    }
+                    KeyCode::Char('[') | KeyCode::Char('{') => {
+                        cfg_state.adjust_current(-5, &mut self.tui_config);
+                    }
+                    KeyCode::Char(']') | KeyCode::Char('}') => {
+                        cfg_state.adjust_current(5, &mut self.tui_config);
+                    }
+                    KeyCode::Char('r') | KeyCode::Char('R') | KeyCode::Char('d') => {
+                        cfg_state.reset_defaults(&mut self.tui_config);
+                        self.set_toast("Reset TUI settings to defaults".to_string(), Theme::status_ok());
+                    }
+                    _ => {}
                 }
             }
             ActiveView::Tree(tree) => {
@@ -5377,6 +5420,7 @@ impl App {
             ResourceKind::Toolbox => ActiveView::Toolbox(ToolboxViewState::new()),
             ResourceKind::Assistant => ActiveView::Assistant,
             ResourceKind::Settings => ActiveView::Settings(SettingsViewState::new()),
+            ResourceKind::TuiConfig => ActiveView::TuiConfig(TuiConfigViewState::new()),
             ResourceKind::Topology => {
                 let namespaces = if self.active_namespace.is_empty() {
                     vec![]
@@ -7589,6 +7633,7 @@ impl App {
             ActiveView::Toolbox(_) => "Toolbox",
             ActiveView::Assistant => "AI Assistant",
             ActiveView::Settings(_) => "AI Settings",
+            ActiveView::TuiConfig(_) => "TUI Configuration",
             ActiveView::Tree(_) => "Resource Relationship Tree",
             ActiveView::NodeInspector(_) => "Node & GPU Hardware Inspector",
             ActiveView::Topology(_) => "Workload & Traffic Topology Flow",
@@ -7669,6 +7714,7 @@ impl App {
             ActiveView::Toolbox(tb) => render_toolbox_view(f, chunks[1], tb),
             ActiveView::Assistant => render_assistant_view(f, chunks[1], &self.assistant_state, &self.ai_settings),
             ActiveView::Settings(s) => render_settings_view(f, chunks[1], s),
+            ActiveView::TuiConfig(s) => render_tui_config_view(f, chunks[1], s, &self.tui_config),
             ActiveView::Tree(tree) => render_tree_view(f, chunks[1], tree),
             ActiveView::NodeInspector(ni) => render_node_inspector_view(f, chunks[1], ni),
             ActiveView::Topology(topo) => topology_view::render_topology_view(f, chunks[1], topo),
@@ -8058,6 +8104,14 @@ impl App {
                 ("<:>", "Cmd"),
                 ("<?>", "Help"),
             ][..]),
+            ActiveView::TuiConfig(_) => Some(&[
+                ("<:>", "Cmd"),
+                ("<j/k>", "Select"),
+                ("<h/l>", "Adjust"),
+                ("<r>", "Reset"),
+                ("<Esc>", "Back"),
+                ("<?>", "Help"),
+            ][..]),
             ActiveView::Toolbox(_) => Some(&[
                 ("<:>", "Cmd"),
                 ("<c>", "CopyPath"),
@@ -8081,6 +8135,8 @@ impl App {
                 suggestions: suggestions_prop,
                 close_pf_button: close_pf_button_data.as_ref().map(|(l, s)| (l.as_str(), *s)),
                 close_pf_rect: Some(&self.close_pf_button_rect),
+                command_popup_max_width: Some(self.tui_config.command_popup_max_width),
+                command_popup_max_visible: Some(self.tui_config.command_popup_max_visible),
             },
         );
 

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -3893,7 +3893,7 @@ impl App {
                         cfg_state.adjust_current(1, &mut self.tui_config);
                     }
                     KeyCode::Enter | KeyCode::Char(' ') => {
-                        cfg_state.adjust_current(1, &mut self.tui_config);
+                        cfg_state.cycle_current(&mut self.tui_config);
                     }
                     KeyCode::Char('[') | KeyCode::Char('{') => {
                         cfg_state.adjust_current(-5, &mut self.tui_config);

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -3892,6 +3892,9 @@ impl App {
                     KeyCode::Char('l') | KeyCode::Right | KeyCode::Char('+') | KeyCode::Char('=') => {
                         cfg_state.adjust_current(1, &mut self.tui_config);
                     }
+                    KeyCode::Enter | KeyCode::Char(' ') => {
+                        cfg_state.adjust_current(1, &mut self.tui_config);
+                    }
                     KeyCode::Char('[') | KeyCode::Char('{') => {
                         cfg_state.adjust_current(-5, &mut self.tui_config);
                     }
@@ -8137,6 +8140,7 @@ impl App {
                 close_pf_rect: Some(&self.close_pf_button_rect),
                 command_popup_max_width: Some(self.tui_config.command_popup_max_width),
                 command_popup_max_visible: Some(self.tui_config.command_popup_max_visible),
+                command_popup_density: Some(self.tui_config.command_popup_density),
             },
         );
 

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -218,6 +218,8 @@ impl App {
             active_namespace.clone()
         };
 
+        let tui_config = crate::tui_config::TuiConfig::load();
+
         let mut app = Self {
             active_context: active_context.clone(),
             active_namespace,
@@ -258,7 +260,7 @@ impl App {
             connection_attempt_start: Instant::now(),
             cluster_unreachable: false,
             ai_settings: crate::ai_config::AiSettings::load(),
-            tui_config: crate::tui_config::TuiConfig::load(),
+            tui_config,
             assistant_state: AssistantViewState::for_context(&active_context),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -1525,6 +1527,66 @@ impl App {
         // 2. Interactive Dialog Modal Open
         if let Some(modal) = self.modal.clone() {
             match modal {
+                Modal::FeatureBanner { .. } => {
+                    if key.modifiers.contains(KeyModifiers::CONTROL) || key.modifiers.contains(KeyModifiers::ALT) {
+                        return;
+                    }
+                    match key.code {
+                        KeyCode::Esc | KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('q') | KeyCode::Char('Q') => {
+                            self.modal = None;
+                        }
+                        KeyCode::Char('t') | KeyCode::Char('T') => {
+                            self.tui_config.show_feature_banner = !self.tui_config.show_feature_banner;
+                            let _ = self.tui_config.save();
+                            let is_enabled = self.tui_config.show_feature_banner;
+                            self.modal = Some(Modal::FeatureBanner { show_on_startup: is_enabled });
+                            if is_enabled {
+                                self.set_toast("Startup feature banner: Enabled".to_string(), Theme::status_ok());
+                            } else {
+                                self.set_toast("Startup feature banner: Disabled".to_string(), Theme::status_warn());
+                            }
+                        }
+                        KeyCode::Char(':') => {
+                            self.modal = None;
+                            self.input_mode = InputMode::Command;
+                            self.command_buffer.clear();
+                        }
+                        KeyCode::Char('/') => {
+                            self.modal = None;
+                            self.input_mode = InputMode::Filter;
+                            self.filter_buffer.clear();
+                        }
+                        KeyCode::Char('1') => {
+                            self.modal = None;
+                            self.switch_view_to_kind(ResourceKind::HelmReleases).await;
+                        }
+                        KeyCode::Char('2') => {
+                            self.modal = None;
+                            self.switch_view_to_kind(ResourceKind::Overview).await;
+                        }
+                        KeyCode::Char('3') => {
+                            self.modal = None;
+                            self.switch_view_to_kind(ResourceKind::GpuInfo).await;
+                        }
+                        KeyCode::Char('4') => {
+                            self.modal = None;
+                            self.switch_view_to_kind(ResourceKind::Workloads).await;
+                        }
+                        KeyCode::Char('5') => {
+                            self.modal = None;
+                            self.switch_view_to_kind(ResourceKind::Assistant).await;
+                        }
+                        KeyCode::Char('6') => {
+                            self.modal = None;
+                            self.switch_view_to_kind(ResourceKind::Settings).await;
+                        }
+                        KeyCode::Char('7') => {
+                            self.modal = None;
+                            self.switch_view_to_kind(ResourceKind::TuiConfig).await;
+                        }
+                        _ => {}
+                    }
+                }
                 Modal::Confirm { action_name, .. } => {
                     match key.code {
                         KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
@@ -5206,6 +5268,11 @@ impl App {
                 } else {
                     self.set_toast(format!("Unknown theme '{}'. Try :themes to pick.", theme_name), Theme::status_warn());
                 }
+            }
+            CommandTarget::FeatureBanner => {
+                self.modal = Some(Modal::FeatureBanner {
+                    show_on_startup: self.tui_config.show_feature_banner,
+                });
             }
             CommandTarget::OpenUrl(_) => {}
         }

--- a/apps/tui/src/commands.rs
+++ b/apps/tui/src/commands.rs
@@ -39,6 +39,7 @@ pub enum ResourceKind {
     Toolbox,
     Assistant,
     Settings,
+    TuiConfig,
     Workloads,
     Topology,
     GpuInfo,
@@ -106,6 +107,7 @@ impl ResourceKind {
             Self::Toolbox => "Toolbox Diagnostics",
             Self::Assistant => "SRElens Assistant",
             Self::Settings => "AI & Assistant Settings",
+            Self::TuiConfig => "TUI Configuration",
             Self::Workloads => "Workloads",
             Self::Topology => "Workload & Traffic Topology",
             Self::GpuInfo => "GPU Info & VRAM Allocation",
@@ -448,9 +450,15 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
     },
     CommandDef {
         name: "ai-settings",
-        aliases: &["settings", "config", "ai-config"],
+        aliases: &["settings", "ai-config"],
         description: "AI & Assistant Settings",
         target: CommandTarget::Resource(ResourceKind::Settings),
+    },
+    CommandDef {
+        name: "config",
+        aliases: &["tui-config", "tui"],
+        description: "TUI Configuration & Popup Size",
+        target: CommandTarget::Resource(ResourceKind::TuiConfig),
     },
     CommandDef {
         name: "help",

--- a/apps/tui/src/commands.rs
+++ b/apps/tui/src/commands.rs
@@ -223,6 +223,7 @@ pub enum CommandTarget {
     OpenUrl(String),
     ThemePicker,
     SetTheme(String),
+    FeatureBanner,
 }
 
 pub const COMMAND_REGISTRY: &[CommandDef] = &[
@@ -461,6 +462,12 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
         target: CommandTarget::Resource(ResourceKind::TuiConfig),
     },
     CommandDef {
+        name: "features",
+        aliases: &["banner", "guide", "welcome"],
+        description: "Show SRElens feature highlights banner (:helm, :overview, :gpuinfo, :workloads, :ai, :ai-settings, :config)",
+        target: CommandTarget::FeatureBanner,
+    },
+    CommandDef {
         name: "help",
         aliases: &["?"],
         description: "Show interactive keybindings palette and command cheatsheet",
@@ -577,6 +584,7 @@ impl DynamicCommandDef {
             CommandTarget::Contexts => "Context",
             CommandTarget::Namespaces => "Namespace",
             CommandTarget::Help => "Help",
+            CommandTarget::FeatureBanner => "Guide",
             CommandTarget::Quit => "System",
             CommandTarget::OpenUrl(_) => "Navigation",
         }
@@ -604,6 +612,7 @@ impl DynamicCommandDef {
             CommandTarget::Namespaces => ":namespaces",
             CommandTarget::Contexts => ":contexts",
             CommandTarget::Help => ":help",
+            CommandTarget::FeatureBanner => ":features",
             CommandTarget::Quit => ":quit",
             CommandTarget::OpenUrl(_) => ":open <url>",
             _ => "",

--- a/apps/tui/src/commands.rs
+++ b/apps/tui/src/commands.rs
@@ -271,205 +271,205 @@ pub const COMMAND_REGISTRY: &[CommandDef] = &[
     CommandDef {
         name: "pods",
         aliases: &["po", "pod"],
-        description: "Pods view",
+        description: "List, inspect, and tail Kubernetes pods across namespaces",
         target: CommandTarget::Resource(ResourceKind::Pods),
     },
     CommandDef {
         name: "deployments",
         aliases: &["dp", "deploy"],
-        description: "Deployments view",
+        description: "Manage, inspect, and scale deployment workloads",
         target: CommandTarget::Resource(ResourceKind::Deployments),
     },
     CommandDef {
         name: "statefulsets",
         aliases: &["sts", "statefulset"],
-        description: "StatefulSets view",
+        description: "Stateful set workloads and distributed replicas",
         target: CommandTarget::Resource(ResourceKind::StatefulSets),
     },
     CommandDef {
         name: "daemonsets",
         aliases: &["ds", "daemonset"],
-        description: "DaemonSets view",
+        description: "Node-local daemonset agent workloads",
         target: CommandTarget::Resource(ResourceKind::DaemonSets),
     },
     CommandDef {
         name: "jobs",
         aliases: &["job"],
-        description: "Jobs view",
+        description: "Batch job runs and execution completion status",
         target: CommandTarget::Resource(ResourceKind::Jobs),
     },
     CommandDef {
         name: "cronjobs",
         aliases: &["cj", "cronjob"],
-        description: "CronJobs view",
+        description: "Scheduled cron jobs and recurring execution history",
         target: CommandTarget::Resource(ResourceKind::CronJobs),
     },
     CommandDef {
         name: "services",
         aliases: &["svc", "service"],
-        description: "Services view",
+        description: "Service routing, cluster IPs, NodePorts and LoadBalancers",
         target: CommandTarget::Resource(ResourceKind::Services),
     },
     CommandDef {
         name: "ingresses",
         aliases: &["ing", "ingress"],
-        description: "Ingresses view",
+        description: "HTTP/HTTPS ingress routing rules and TLS certs",
         target: CommandTarget::Resource(ResourceKind::Ingresses),
     },
     CommandDef {
         name: "endpointslices",
         aliases: &["ep", "eps", "endpointslice"],
-        description: "EndpointSlices view",
+        description: "Scalable network endpoints for Kubernetes services",
         target: CommandTarget::Resource(ResourceKind::EndpointSlices),
     },
     CommandDef {
         name: "networkpolicies",
         aliases: &["np", "netpol"],
-        description: "NetworkPolicies view",
+        description: "Pod network traffic filtering and isolation rules",
         target: CommandTarget::Resource(ResourceKind::NetworkPolicies),
     },
     CommandDef {
         name: "configmaps",
         aliases: &["cm", "configmap"],
-        description: "ConfigMaps view",
+        description: "Key-value configuration maps and application data",
         target: CommandTarget::Resource(ResourceKind::ConfigMaps),
     },
     CommandDef {
         name: "secrets",
         aliases: &["sec", "secret"],
-        description: "Secrets view",
+        description: "Kubernetes secrets with masked base64 credentials",
         target: CommandTarget::Resource(ResourceKind::Secrets),
     },
     CommandDef {
         name: "persistentvolumeclaims",
         aliases: &["pvc"],
-        description: "PersistentVolumeClaims view",
+        description: "Persistent storage volume claims by namespace",
         target: CommandTarget::Resource(ResourceKind::PersistentVolumeClaims),
     },
     CommandDef {
         name: "persistentvolumes",
         aliases: &["pv"],
-        description: "PersistentVolumes view",
+        description: "Cluster-wide persistent storage volumes",
         target: CommandTarget::Resource(ResourceKind::PersistentVolumes),
     },
     CommandDef {
         name: "storageclasses",
         aliases: &["sc", "storageclass"],
-        description: "StorageClasses view",
+        description: "Storage provisioners, volume plugins & reclaim policies",
         target: CommandTarget::Resource(ResourceKind::StorageClasses),
     },
     CommandDef {
         name: "nodes",
         aliases: &["no", "node"],
-        description: "Nodes view",
+        description: "Cluster worker and control-plane node hardware and status",
         target: CommandTarget::Resource(ResourceKind::Nodes),
     },
     CommandDef {
         name: "namespaces",
         aliases: &["ns", "namespace"],
-        description: "Namespaces view / Switcher",
+        description: "Cluster tenancy namespaces switcher and viewer",
         target: CommandTarget::Namespaces,
     },
     CommandDef {
         name: "events",
         aliases: &["ev", "event"],
-        description: "Cluster Events stream",
+        description: "Cluster-wide event stream, errors, warnings & scheduling",
         target: CommandTarget::Resource(ResourceKind::Events),
     },
     CommandDef {
         name: "serviceaccounts",
         aliases: &["sa", "serviceaccount"],
-        description: "ServiceAccounts view",
+        description: "Service account identities and RBAC token bindings",
         target: CommandTarget::Resource(ResourceKind::ServiceAccounts),
     },
     CommandDef {
         name: "roles",
         aliases: &["role"],
-        description: "Roles view",
+        description: "Namespace-scoped RBAC roles and resource permissions",
         target: CommandTarget::Resource(ResourceKind::Roles),
     },
     CommandDef {
         name: "clusterroles",
         aliases: &["cr", "clusterrole"],
-        description: "ClusterRoles view",
+        description: "Cluster-wide RBAC roles and resource permissions",
         target: CommandTarget::Resource(ResourceKind::ClusterRoles),
     },
     CommandDef {
         name: "rolebindings",
         aliases: &["rb", "rolebinding"],
-        description: "RoleBindings view",
+        description: "Bindings granting roles to users and service accounts",
         target: CommandTarget::Resource(ResourceKind::RoleBindings),
     },
     CommandDef {
         name: "clusterrolebindings",
         aliases: &["crb", "clusterrolebinding"],
-        description: "ClusterRoleBindings view",
+        description: "Cluster-level role bindings for cluster roles",
         target: CommandTarget::Resource(ResourceKind::ClusterRoleBindings),
     },
     CommandDef {
         name: "crds",
         aliases: &["crd", "customresourcedefinitions"],
-        description: "Custom Resource Definitions",
+        description: "Custom Resource Definitions registered in cluster",
         target: CommandTarget::Resource(ResourceKind::CustomResourceDefinitions),
     },
     CommandDef {
         name: "helm",
         aliases: &["helmreleases", "releases"],
-        description: "Helm 3 Releases",
+        description: "Helm 3 release revisions, status, values and manifests",
         target: CommandTarget::Resource(ResourceKind::HelmReleases),
     },
     CommandDef {
         name: "portforwards",
         aliases: &["pf", "portforward"],
-        description: "Active Port Forwards",
+        description: "Active port forwards",
         target: CommandTarget::Resource(ResourceKind::PortForwards),
     },
     CommandDef {
         name: "contexts",
         aliases: &["ctx", "context"],
-        description: "Cluster Contexts Switcher",
+        description: "Kubeconfig context switcher for multi-cluster management",
         target: CommandTarget::Contexts,
     },
     CommandDef {
         name: "overview",
         aliases: &["info", "cluster"],
-        description: "Cluster Overview & Health",
+        description: "Cluster overview, health summary and node/pod capacity",
         target: CommandTarget::Resource(ResourceKind::Overview),
     },
     CommandDef {
         name: "toolbox",
         aliases: &["tb", "tools"],
-        description: "Toolbox diagnostics (kubectl, helm, krew)",
+        description: "Toolbox diagnostics (kubectl, helm, krew plugins)",
         target: CommandTarget::Resource(ResourceKind::Toolbox),
     },
     CommandDef {
         name: "assistant",
         aliases: &["ai", "chat"],
-        description: "SRElens AI Assistant Chat",
+        description: "SRElens AI Assistant Chat for troubleshooting",
         target: CommandTarget::Resource(ResourceKind::Assistant),
     },
     CommandDef {
         name: "ai-settings",
         aliases: &["settings", "ai-config"],
-        description: "AI & Assistant Settings",
+        description: "AI & Assistant Settings (provider, model, API keys)",
         target: CommandTarget::Resource(ResourceKind::Settings),
     },
     CommandDef {
         name: "config",
         aliases: &["tui-config", "tui"],
-        description: "TUI Configuration & Popup Size",
+        description: "TUI Configuration (popup dimensions, visible rows & text size)",
         target: CommandTarget::Resource(ResourceKind::TuiConfig),
     },
     CommandDef {
         name: "help",
         aliases: &["?"],
-        description: "Show keybindings and command help",
+        description: "Show interactive keybindings palette and command cheatsheet",
         target: CommandTarget::Help,
     },
     CommandDef {
         name: "quit",
         aliases: &["q", "exit"],
-        description: "Quit srelens",
+        description: "Quit SRElens TUI session",
         target: CommandTarget::Quit,
     },
     CommandDef {
@@ -524,6 +524,89 @@ impl From<&CrdMeta> for DynamicCommandDef {
             aliases,
             description: format!("CRD: {} ({})", crd.kind, crd.group),
             target: CommandTarget::CustomResource(crd.clone()),
+        }
+    }
+}
+
+impl DynamicCommandDef {
+    pub fn category(&self) -> &'static str {
+        match &self.target {
+            CommandTarget::Resource(kind) => match kind {
+                ResourceKind::Pods
+                | ResourceKind::Deployments
+                | ResourceKind::StatefulSets
+                | ResourceKind::DaemonSets
+                | ResourceKind::Jobs
+                | ResourceKind::CronJobs
+                | ResourceKind::Workloads => "Workload",
+                ResourceKind::Services
+                | ResourceKind::Endpoints
+                | ResourceKind::EndpointSlices
+                | ResourceKind::Ingresses
+                | ResourceKind::NetworkPolicies => "Network",
+                ResourceKind::ConfigMaps
+                | ResourceKind::Secrets
+                | ResourceKind::ResourceQuotas
+                | ResourceKind::LimitRanges => "Config",
+                ResourceKind::PersistentVolumeClaims
+                | ResourceKind::PersistentVolumes
+                | ResourceKind::StorageClasses => "Storage",
+                ResourceKind::ServiceAccounts
+                | ResourceKind::Roles
+                | ResourceKind::ClusterRoles
+                | ResourceKind::RoleBindings
+                | ResourceKind::ClusterRoleBindings => "Auth / RBAC",
+                ResourceKind::Nodes
+                | ResourceKind::Namespaces
+                | ResourceKind::Events
+                | ResourceKind::CustomResourceDefinitions => "Cluster",
+                ResourceKind::HelmReleases => "Helm",
+                ResourceKind::PortForwards => "Forward",
+                ResourceKind::Overview => "Overview",
+                ResourceKind::Toolbox => "Diagnostic",
+                ResourceKind::Assistant => "AI Assistant",
+                ResourceKind::Settings => "Settings",
+                ResourceKind::TuiConfig => "Configuration",
+                ResourceKind::Topology => "Topology",
+                ResourceKind::GpuInfo => "GPU / Hardware",
+                ResourceKind::TopPods | ResourceKind::TopNodes => "Hotspots",
+                ResourceKind::CustomResource(_) => "Custom Resource",
+            },
+            CommandTarget::CustomResource(_) => "CRD",
+            CommandTarget::ThemePicker | CommandTarget::SetTheme(_) => "Themes",
+            CommandTarget::Contexts => "Context",
+            CommandTarget::Namespaces => "Namespace",
+            CommandTarget::Help => "Help",
+            CommandTarget::Quit => "System",
+            CommandTarget::OpenUrl(_) => "Navigation",
+        }
+    }
+
+    pub fn syntax_hint(&self) -> &'static str {
+        match &self.target {
+            CommandTarget::Resource(ResourceKind::Pods) => ":pods [namespace]",
+            CommandTarget::Resource(ResourceKind::Deployments) => ":deployments [ns]",
+            CommandTarget::Resource(ResourceKind::Services) => ":services [ns]",
+            CommandTarget::Resource(ResourceKind::ConfigMaps) => ":configmaps [ns]",
+            CommandTarget::Resource(ResourceKind::Secrets) => ":secrets [ns]",
+            CommandTarget::Resource(ResourceKind::Nodes) => ":nodes",
+            CommandTarget::Resource(ResourceKind::Events) => ":events [ns]",
+            CommandTarget::Resource(ResourceKind::HelmReleases) => ":helm [ns]",
+            CommandTarget::Resource(ResourceKind::Workloads) => ":workloads [ns]",
+            CommandTarget::Resource(ResourceKind::Ingresses) => ":ingresses [ns]",
+            CommandTarget::Resource(ResourceKind::TopPods) => ":toppods [ns]",
+            CommandTarget::Resource(ResourceKind::TopNodes) => ":topnodes",
+            CommandTarget::Resource(ResourceKind::TuiConfig) => ":config",
+            CommandTarget::Resource(ResourceKind::Assistant) => ":assistant",
+            CommandTarget::Resource(ResourceKind::Toolbox) => ":toolbox",
+            CommandTarget::ThemePicker => ":themes",
+            CommandTarget::SetTheme(_) => ":theme <name>",
+            CommandTarget::Namespaces => ":namespaces",
+            CommandTarget::Contexts => ":contexts",
+            CommandTarget::Help => ":help",
+            CommandTarget::Quit => ":quit",
+            CommandTarget::OpenUrl(_) => ":open <url>",
+            _ => "",
         }
     }
 }

--- a/apps/tui/src/deep_link.rs
+++ b/apps/tui/src/deep_link.rs
@@ -58,6 +58,7 @@ impl DeepLink {
                     CommandTarget::Quit => "quit".to_string(),
                     CommandTarget::ThemePicker => "themes".to_string(),
                     CommandTarget::SetTheme(t) => format!("theme/{}", t),
+                    CommandTarget::FeatureBanner => "features".to_string(),
                     CommandTarget::OpenUrl(u) => format!("open/{}", u),
                 };
                 format!("srelens://view/{}/{}/{}", ctx, ns, target_name)

--- a/apps/tui/src/deep_link.rs
+++ b/apps/tui/src/deep_link.rs
@@ -48,6 +48,7 @@ impl DeepLink {
                         crate::commands::ResourceKind::Overview => "overview".to_string(),
                         crate::commands::ResourceKind::Toolbox => "toolbox".to_string(),
                         crate::commands::ResourceKind::Settings => "settings".to_string(),
+                        crate::commands::ResourceKind::TuiConfig => "config".to_string(),
                         other => other.to_string().to_lowercase(),
                     },
                     CommandTarget::CustomResource(crd) => crd.plural.to_lowercase(),

--- a/apps/tui/src/lib.rs
+++ b/apps/tui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod event;
 pub mod self_update;
 pub mod sink;
 pub mod theme;
+pub mod tui_config;
 pub mod ui;
 pub mod views;
 
@@ -17,3 +18,4 @@ pub use ai_config::{AiProvider, AiSettings};
 pub use ai_skills::SkillDef;
 pub use app::App;
 pub use deep_link::DeepLink;
+pub use tui_config::TuiConfig;

--- a/apps/tui/src/lib.rs
+++ b/apps/tui/src/lib.rs
@@ -18,4 +18,4 @@ pub use ai_config::{AiProvider, AiSettings};
 pub use ai_skills::SkillDef;
 pub use app::App;
 pub use deep_link::DeepLink;
-pub use tui_config::TuiConfig;
+pub use tui_config::{CommandPopupDensity, TuiConfig};

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -29,6 +29,7 @@ mod deep_link;
 mod event;
 mod sink;
 mod theme;
+mod tui_config;
 mod ui;
 mod views;
 

--- a/apps/tui/src/main.rs
+++ b/apps/tui/src/main.rs
@@ -232,6 +232,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await
     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
+    if parsed_target.is_none() && app.tui_config.show_feature_banner {
+        app.modal = Some(ui::Modal::FeatureBanner {
+            show_on_startup: true,
+        });
+    }
+
     if let Some(link) = parsed_target {
         let _ = app.navigate_deep_link(&link).await;
     }

--- a/apps/tui/src/tui_config.rs
+++ b/apps/tui/src/tui_config.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_COMMAND_POPUP_MAX_WIDTH: u16 = 65;
+pub const MIN_COMMAND_POPUP_MAX_WIDTH: u16 = 40;
+pub const MAX_COMMAND_POPUP_MAX_WIDTH: u16 = 200;
+
+pub const DEFAULT_COMMAND_POPUP_MAX_VISIBLE: usize = 6;
+pub const MIN_COMMAND_POPUP_MAX_VISIBLE: usize = 3;
+pub const MAX_COMMAND_POPUP_MAX_VISIBLE: usize = 20;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct TuiConfig {
+    pub command_popup_max_width: u16,
+    pub command_popup_max_visible: usize,
+}
+
+impl Default for TuiConfig {
+    fn default() -> Self {
+        Self {
+            command_popup_max_width: DEFAULT_COMMAND_POPUP_MAX_WIDTH,
+            command_popup_max_visible: DEFAULT_COMMAND_POPUP_MAX_VISIBLE,
+        }
+    }
+}
+
+impl TuiConfig {
+    pub fn clamp(&mut self) {
+        self.command_popup_max_width = self
+            .command_popup_max_width
+            .clamp(MIN_COMMAND_POPUP_MAX_WIDTH, MAX_COMMAND_POPUP_MAX_WIDTH);
+        self.command_popup_max_visible = self
+            .command_popup_max_visible
+            .clamp(MIN_COMMAND_POPUP_MAX_VISIBLE, MAX_COMMAND_POPUP_MAX_VISIBLE);
+    }
+
+    pub fn config_file_path() -> PathBuf {
+        if let Ok(custom) = std::env::var("SRELENS_TUI_CONFIG_PATH") {
+            if !custom.trim().is_empty() {
+                return PathBuf::from(custom);
+            }
+        }
+        if let Ok(custom_dir) = std::env::var("SRELENS_CONFIG_DIR") {
+            if !custom_dir.trim().is_empty() {
+                return PathBuf::from(custom_dir).join("tui.json");
+            }
+        }
+        dirs::config_dir()
+            .map(|p| p.join("srelens").join("tui.json"))
+            .unwrap_or_else(|| PathBuf::from(".srelens-tui.json"))
+    }
+
+    pub fn load() -> Self {
+        let path = Self::config_file_path();
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Ok(mut config) = serde_json::from_str::<TuiConfig>(&content) {
+                config.clamp();
+                return config;
+            }
+        }
+        Self::default()
+    }
+
+    pub fn save(&self) -> Result<(), String> {
+        let path = Self::config_file_path();
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let mut to_save = self.clone();
+        to_save.clamp();
+        let json = serde_json::to_string_pretty(&to_save)
+            .map_err(|e| format!("Failed to serialize TuiConfig: {}", e))?;
+        std::fs::write(&path, json)
+            .map_err(|e| format!("Failed to write {}: {}", path.display(), e))
+    }
+}

--- a/apps/tui/src/tui_config.rs
+++ b/apps/tui/src/tui_config.rs
@@ -13,6 +13,8 @@ pub const DEFAULT_COMMAND_POPUP_TEXT_SCALE: u8 = 1;
 pub const MIN_COMMAND_POPUP_TEXT_SCALE: u8 = 1;
 pub const MAX_COMMAND_POPUP_TEXT_SCALE: u8 = 4;
 
+pub const DEFAULT_SHOW_FEATURE_BANNER: bool = true;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CommandPopupDensity {
     #[default]
@@ -143,6 +145,7 @@ pub struct TuiConfig {
     pub command_popup_max_visible: usize,
     #[serde(alias = "commandPopupTextScale")]
     pub command_popup_density: CommandPopupDensity,
+    pub show_feature_banner: bool,
 }
 
 impl Default for TuiConfig {
@@ -151,6 +154,7 @@ impl Default for TuiConfig {
             command_popup_max_width: DEFAULT_COMMAND_POPUP_MAX_WIDTH,
             command_popup_max_visible: DEFAULT_COMMAND_POPUP_MAX_VISIBLE,
             command_popup_density: CommandPopupDensity::default(),
+            show_feature_banner: DEFAULT_SHOW_FEATURE_BANNER,
         }
     }
 }

--- a/apps/tui/src/tui_config.rs
+++ b/apps/tui/src/tui_config.rs
@@ -9,11 +9,40 @@ pub const DEFAULT_COMMAND_POPUP_MAX_VISIBLE: usize = 6;
 pub const MIN_COMMAND_POPUP_MAX_VISIBLE: usize = 3;
 pub const MAX_COMMAND_POPUP_MAX_VISIBLE: usize = 20;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CommandPopupDensity {
+    #[default]
+    Compact,
+    Large,
+}
+
+impl CommandPopupDensity {
+    pub fn is_large(&self) -> bool {
+        matches!(self, Self::Large)
+    }
+
+    pub fn item_height(&self) -> u16 {
+        match self {
+            Self::Compact => 1,
+            Self::Large => 2,
+        }
+    }
+
+    pub fn toggle(&self) -> Self {
+        match self {
+            Self::Compact => Self::Large,
+            Self::Large => Self::Compact,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct TuiConfig {
     pub command_popup_max_width: u16,
     pub command_popup_max_visible: usize,
+    pub command_popup_density: CommandPopupDensity,
 }
 
 impl Default for TuiConfig {
@@ -21,6 +50,7 @@ impl Default for TuiConfig {
         Self {
             command_popup_max_width: DEFAULT_COMMAND_POPUP_MAX_WIDTH,
             command_popup_max_visible: DEFAULT_COMMAND_POPUP_MAX_VISIBLE,
+            command_popup_density: CommandPopupDensity::default(),
         }
     }
 }

--- a/apps/tui/src/tui_config.rs
+++ b/apps/tui/src/tui_config.rs
@@ -9,30 +9,129 @@ pub const DEFAULT_COMMAND_POPUP_MAX_VISIBLE: usize = 6;
 pub const MIN_COMMAND_POPUP_MAX_VISIBLE: usize = 3;
 pub const MAX_COMMAND_POPUP_MAX_VISIBLE: usize = 20;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "lowercase")]
+pub const DEFAULT_COMMAND_POPUP_TEXT_SCALE: u8 = 1;
+pub const MIN_COMMAND_POPUP_TEXT_SCALE: u8 = 1;
+pub const MAX_COMMAND_POPUP_TEXT_SCALE: u8 = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CommandPopupDensity {
     #[default]
     Compact,
+    Standard,
     Large,
+    ExtraLarge,
+}
+
+impl Serialize for CommandPopupDensity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Compact => serializer.serialize_str("compact"),
+            Self::Standard => serializer.serialize_str("standard"),
+            Self::Large => serializer.serialize_str("large"),
+            Self::ExtraLarge => serializer.serialize_str("extralarge"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CommandPopupDensity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = CommandPopupDensity;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(
+                    "a density string ('compact', 'standard', 'large', 'extralarge') or scale number (1..=4)",
+                )
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<CommandPopupDensity, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(CommandPopupDensity::from_scale(v.clamp(1, 4) as u8))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<CommandPopupDensity, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(CommandPopupDensity::from_scale(v.clamp(1, 4) as u8))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<CommandPopupDensity, E>
+            where
+                E: serde::de::Error,
+            {
+                match v.to_ascii_lowercase().as_str() {
+                    "compact" | "small" | "1" => Ok(CommandPopupDensity::Compact),
+                    "standard" | "normal" | "medium" | "2" => Ok(CommandPopupDensity::Standard),
+                    "large" | "3" => Ok(CommandPopupDensity::Large),
+                    "extralarge" | "extra_large" | "extra-large" | "huge" | "4" => {
+                        Ok(CommandPopupDensity::ExtraLarge)
+                    }
+                    _ => Ok(CommandPopupDensity::default()),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
 }
 
 impl CommandPopupDensity {
+    pub fn scale(&self) -> u8 {
+        match self {
+            Self::Compact => 1,
+            Self::Standard => 2,
+            Self::Large => 3,
+            Self::ExtraLarge => 4,
+        }
+    }
+
+    pub fn from_scale(scale: u8) -> Self {
+        match scale {
+            1 => Self::Compact,
+            2 => Self::Standard,
+            3 => Self::Large,
+            _ => Self::ExtraLarge,
+        }
+    }
+
     pub fn is_large(&self) -> bool {
-        matches!(self, Self::Large)
+        matches!(self, Self::Large | Self::ExtraLarge)
     }
 
     pub fn item_height(&self) -> u16 {
         match self {
-            Self::Compact => 1,
+            Self::Compact | Self::Standard => 1,
             Self::Large => 2,
+            Self::ExtraLarge => 3,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Compact => "Compact (1-line dense)",
+            Self::Standard => "Standard (1-line enriched)",
+            Self::Large => "Large (2-line cards)",
+            Self::ExtraLarge => "Extra Large (3-line cards)",
         }
     }
 
     pub fn toggle(&self) -> Self {
         match self {
-            Self::Compact => Self::Large,
-            Self::Large => Self::Compact,
+            Self::Compact => Self::Standard,
+            Self::Standard => Self::Large,
+            Self::Large => Self::ExtraLarge,
+            Self::ExtraLarge => Self::Compact,
         }
     }
 }
@@ -42,6 +141,7 @@ impl CommandPopupDensity {
 pub struct TuiConfig {
     pub command_popup_max_width: u16,
     pub command_popup_max_visible: usize,
+    #[serde(alias = "commandPopupTextScale")]
     pub command_popup_density: CommandPopupDensity,
 }
 
@@ -63,6 +163,16 @@ impl TuiConfig {
         self.command_popup_max_visible = self
             .command_popup_max_visible
             .clamp(MIN_COMMAND_POPUP_MAX_VISIBLE, MAX_COMMAND_POPUP_MAX_VISIBLE);
+    }
+
+    pub fn text_scale(&self) -> u8 {
+        self.command_popup_density.scale()
+    }
+
+    pub fn set_text_scale(&mut self, scale: u8) {
+        self.command_popup_density = CommandPopupDensity::from_scale(
+            scale.clamp(MIN_COMMAND_POPUP_TEXT_SCALE, MAX_COMMAND_POPUP_TEXT_SCALE),
+        );
     }
 
     pub fn config_file_path() -> PathBuf {

--- a/apps/tui/src/ui/dialogs.rs
+++ b/apps/tui/src/ui/dialogs.rs
@@ -74,6 +74,9 @@ pub enum Modal {
         selected_idx: usize,
         initial_theme_idx: usize,
     },
+    FeatureBanner {
+        show_on_startup: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -748,5 +751,129 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
             ])).alignment(Alignment::Center);
             f.render_widget(footer, chunks[1]);
         }
+        Modal::FeatureBanner { show_on_startup } => {
+            render_feature_banner_modal(f, area, *show_on_startup);
+        }
     }
+}
+
+pub fn render_feature_banner_modal(f: &mut Frame, area: Rect, show_on_startup: bool) {
+    let modal_width = (area.width.saturating_sub(4)).min(94).max(48);
+    let modal_height = (area.height.saturating_sub(2)).min(21).max(14);
+    let modal_x = area.x + (area.width.saturating_sub(modal_width)) / 2;
+    let modal_y = area.y + (area.height.saturating_sub(modal_height)) / 2;
+    let modal_area = Rect::new(modal_x, modal_y, modal_width, modal_height);
+
+    f.render_widget(Clear, modal_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::cyan()))
+        .title(Span::styled(
+            " ✨ Welcome to SRElens — Feature Highlights ✨ ",
+            Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
+        ));
+
+    let inner = block.inner(modal_area);
+    f.render_widget(block, modal_area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // Top description
+            Constraint::Min(7),   // Features list
+            Constraint::Length(3), // Checkbox and key hints
+        ])
+        .split(inner);
+
+    // 1. Header description
+    let header_lines = vec![
+        Line::from(vec![
+            Span::styled(
+                "Kubernetes control room with high-velocity SRE troubleshooting capabilities.",
+                Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "Key built-in features you should know (press [1-7] to jump directly, or type ':' for command prompt):",
+                Style::default().fg(Theme::dim()),
+            ),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(header_lines), chunks[0]);
+
+    // 2. Feature highlights
+    let features: &[(&str, &str, &str, &str, &str)] = &[
+        ("[1]", ":helm",        "[Helm 3]",        "Helm 3 release revisions, rollback status, values & manifests", ":helm [ns]"),
+        ("[2]", ":overview",    "[Cluster]",       "Cluster overview, health summary & node/pod capacity",          ":overview"),
+        ("[3]", ":gpuinfo",     "[Hardware]",      "GPU hardware inspector, specs & per-pod VRAM allocations",     ":gpuinfo"),
+        ("[4]", ":workloads",   "[Workload]",      "Unified workloads view (Pods, Deployments, STS, DS, Jobs)",     ":workloads [ns]"),
+        ("[5]", ":ai",          "[AI Assistant]",  "Interactive AI troubleshooting chat for automated RCA",         ":ai"),
+        ("[6]", ":ai-settings", "[AI Config]",     "Configure AI providers (Claude, OpenAI, Gemini), models & keys", ":ai-settings"),
+        ("[7]", ":config",      "[Lens Settings]", "Lens settings: popup width, visible rows, text scale & banner",  ":config"),
+    ];
+
+    let inner_w = chunks[1].width as usize;
+    let items: Vec<ListItem> = features
+        .iter()
+        .map(|(num, cmd, cat, desc, syntax)| {
+            let mut spans = vec![
+                Span::styled(format!("{num} "), Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("{:<13}", cmd), Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("{:<15}", cat), Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("{:<desc_len$}", desc, desc_len = if inner_w >= 85 { 44 } else { 32 }), Style::default().fg(Theme::fg())),
+            ];
+            if inner_w >= 80 {
+                spans.push(Span::styled(format!("  ({})", syntax), Style::default().fg(Theme::dim())));
+            }
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+
+    f.render_widget(List::new(items), chunks[1]);
+
+    // 3. Footer with Startup Checkbox & Key hints
+    let checkbox_spans = if show_on_startup {
+        vec![
+            Span::styled(" [●] ", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+            Span::styled("Show this feature banner on startup", Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)),
+            Span::styled(" (Press ", Style::default().fg(Theme::dim())),
+            Span::styled("t", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            Span::styled(" to toggle)", Style::default().fg(Theme::dim())),
+        ]
+    } else {
+        vec![
+            Span::styled(" [○] ", Style::default().fg(Theme::dim())),
+            Span::styled("Show this feature banner on startup", Style::default().fg(Theme::dim())),
+            Span::styled(" (Currently ", Style::default().fg(Theme::dim())),
+            Span::styled("Disabled", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            Span::styled(" • Press ", Style::default().fg(Theme::dim())),
+            Span::styled("t", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            Span::styled(" to enable)", Style::default().fg(Theme::dim())),
+        ]
+    };
+
+    let footer_lines = vec![
+        Line::from(vec![
+            Span::styled("─".repeat(inner_w.min(90)), Style::default().fg(Theme::border())),
+        ]),
+        Line::from(checkbox_spans),
+        Line::from(vec![
+            Span::styled(" Press ", Style::default().fg(Theme::dim())),
+            Span::styled("Enter", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            Span::styled(", ", Style::default().fg(Theme::dim())),
+            Span::styled("Esc", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            Span::styled(", or ", Style::default().fg(Theme::dim())),
+            Span::styled("q", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+            Span::styled(" to dismiss  |  Press ", Style::default().fg(Theme::dim())),
+            Span::styled("1-7", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)),
+            Span::styled(" to jump directly  |  ", Style::default().fg(Theme::dim())),
+            Span::styled(":banner", Style::default().fg(Theme::accent())),
+            Span::styled(" to reopen anytime", Style::default().fg(Theme::dim())),
+        ]),
+    ];
+
+    f.render_widget(Paragraph::new(footer_lines), chunks[2]);
 }

--- a/apps/tui/src/ui/help.rs
+++ b/apps/tui/src/ui/help.rs
@@ -58,7 +58,7 @@ pub fn render_help_modal(f: &mut Frame, area: Rect) {
         ]),
         Row::new(vec![
             Cell::from(Span::styled("  : <command>", Theme::key_hint_key())),
-            Cell::from("Open command prompt (:pod, :deploy, :top, :toppods, :topnodes, :gpuinfo, :svc, :topo, :no, :ns, :helm, :pf, :ai, :ctx, :q)"),
+            Cell::from("Open command prompt (:pod, :deploy, :top, :toppods, :topnodes, :gpuinfo, :svc, :topo, :no, :ns, :helm, :pf, :ai, :config, :ctx, :q)"),
         ]),
         Row::new(vec![
             Cell::from(Span::styled("  :top / :toppods / :topnodes", Theme::key_hint_key())),

--- a/apps/tui/src/ui/mod.rs
+++ b/apps/tui/src/ui/mod.rs
@@ -3,7 +3,7 @@ pub mod header;
 pub mod help;
 pub mod statusbar;
 
-pub use dialogs::{render_modal, Modal, ContainerAction};
+pub use dialogs::{render_feature_banner_modal, render_modal, ContainerAction, Modal};
 pub use header::{render_header, HeaderProps};
 pub use help::render_help_modal;
 pub use statusbar::{command_popup_rect, render_statusbar, InputMode, StatusBarProps};

--- a/apps/tui/src/ui/mod.rs
+++ b/apps/tui/src/ui/mod.rs
@@ -6,4 +6,4 @@ pub mod statusbar;
 pub use dialogs::{render_modal, Modal, ContainerAction};
 pub use header::{render_header, HeaderProps};
 pub use help::render_help_modal;
-pub use statusbar::{render_statusbar, InputMode, StatusBarProps};
+pub use statusbar::{command_popup_rect, render_statusbar, InputMode, StatusBarProps};

--- a/apps/tui/src/ui/statusbar.rs
+++ b/apps/tui/src/ui/statusbar.rs
@@ -28,6 +28,25 @@ pub struct StatusBarProps<'a> {
     pub suggestions: Option<(&'a [(crate::commands::DynamicCommandDef, usize)], usize)>,
     pub close_pf_button: Option<(&'a str, Style)>,
     pub close_pf_rect: Option<&'a std::cell::RefCell<Option<Rect>>>,
+    pub command_popup_max_width: Option<u16>,
+    pub command_popup_max_visible: Option<usize>,
+}
+
+pub fn command_popup_rect(
+    area: Rect,
+    item_count: usize,
+    max_width: u16,
+    max_visible: usize,
+) -> Rect {
+    let visible_count = item_count.min(max_visible);
+    let popup_height = visible_count as u16 + 2;
+    let popup_width = area.width.saturating_sub(4).min(max_width);
+    Rect {
+        x: area.x + 2,
+        y: area.y.saturating_sub(popup_height),
+        width: popup_width,
+        height: popup_height,
+    }
 }
 
 pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
@@ -57,15 +76,10 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
             // Render autocomplete suggestions if typing
             if let Some((suggs, selected_idx)) = props.suggestions {
                 if !suggs.is_empty() {
-                    let max_visible = 6usize;
+                    let max_width = props.command_popup_max_width.unwrap_or(65);
+                    let max_visible = props.command_popup_max_visible.unwrap_or(6);
+                    let popup_area = command_popup_rect(area, suggs.len(), max_width, max_visible);
                     let visible_count = suggs.len().min(max_visible);
-                    let popup_height = (visible_count as u16 + 2).min(8);
-                    let popup_area = Rect {
-                        x: area.x + 2,
-                        y: area.y.saturating_sub(popup_height),
-                        width: area.width.saturating_sub(4).min(65),
-                        height: popup_height,
-                    };
                     f.render_widget(Clear, popup_area);
 
                     // Compute window offset to keep selected_idx visible

--- a/apps/tui/src/ui/statusbar.rs
+++ b/apps/tui/src/ui/statusbar.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use crate::commands::{command_suggestions, CommandDef};
 use crate::theme::Theme;
+use crate::tui_config::CommandPopupDensity;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum InputMode {
@@ -30,6 +31,7 @@ pub struct StatusBarProps<'a> {
     pub close_pf_rect: Option<&'a std::cell::RefCell<Option<Rect>>>,
     pub command_popup_max_width: Option<u16>,
     pub command_popup_max_visible: Option<usize>,
+    pub command_popup_density: Option<CommandPopupDensity>,
 }
 
 pub fn command_popup_rect(
@@ -37,9 +39,12 @@ pub fn command_popup_rect(
     item_count: usize,
     max_width: u16,
     max_visible: usize,
+    density: CommandPopupDensity,
 ) -> Rect {
     let visible_count = item_count.min(max_visible);
-    let popup_height = visible_count as u16 + 2;
+    let item_h = density.item_height();
+    let content_height = (visible_count as u16) * item_h;
+    let popup_height = content_height + 2;
     let popup_width = area.width.saturating_sub(4).min(max_width);
     Rect {
         x: area.x + 2,
@@ -78,18 +83,25 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                 if !suggs.is_empty() {
                     let max_width = props.command_popup_max_width.unwrap_or(65);
                     let max_visible = props.command_popup_max_visible.unwrap_or(6);
-                    let popup_area = command_popup_rect(area, suggs.len(), max_width, max_visible);
-                    let visible_count = suggs.len().min(max_visible);
+                    let density = props.command_popup_density.unwrap_or_default();
+                    let popup_area = command_popup_rect(area, suggs.len(), max_width, max_visible, density);
                     f.render_widget(Clear, popup_area);
 
+                    let is_large = density.is_large();
+                    let inner_height = popup_area.height.saturating_sub(2);
+                    let item_lines = density.item_height();
+                    let max_fits = (inner_height / item_lines) as usize;
+                    let visible_count = suggs.len().min(max_visible).min(max_fits.max(1));
+
                     // Compute window offset to keep selected_idx visible
-                    let scroll_offset = if selected_idx >= max_visible {
-                        selected_idx + 1 - max_visible
+                    let scroll_offset = if selected_idx >= visible_count {
+                        selected_idx + 1 - visible_count
                     } else {
                         0
                     };
 
                     let visible_slice = &suggs[scroll_offset..(scroll_offset + visible_count).min(suggs.len())];
+                    let popup_inner_w = popup_area.width.saturating_sub(2) as usize;
 
                     let items: Vec<ListItem> = visible_slice
                         .iter()
@@ -98,34 +110,139 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                             let abs_i = scroll_offset + rel_i;
                             let is_selected = abs_i == selected_idx;
                             let prefix = if is_selected { "▶ " } else { "  " };
-                            let alias_str = if !cmd.aliases.is_empty() {
-                                format!(" ({})", cmd.aliases.join(", "))
+
+                            if is_large {
+                                // 2-line spacious card layout with bold large typography
+                                let alias_str = if !cmd.aliases.is_empty() {
+                                    format!(" ({})", cmd.aliases.join(", "))
+                                } else {
+                                    String::new()
+                                };
+                                let cat_badge = format!("[{}]", cmd.category());
+                                let name_text = format!("{}{}{}", prefix, cmd.name.to_uppercase(), alias_str);
+
+                                let name_len = name_text.chars().count();
+                                let badge_len = cat_badge.chars().count();
+                                let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
+                                let spacer = " ".repeat(spacer_len);
+
+                                let line1 = Line::from(vec![
+                                    Span::styled(
+                                        name_text,
+                                        if is_selected {
+                                            Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                        } else {
+                                            Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                                        },
+                                    ),
+                                    Span::raw(spacer),
+                                    Span::styled(
+                                        cat_badge,
+                                        if is_selected {
+                                            Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+                                        } else {
+                                            Style::default().fg(Theme::dim())
+                                        },
+                                    ),
+                                ]);
+
+                                let mut line2_spans = vec![
+                                    Span::raw("    "),
+                                    Span::styled(
+                                        cmd.description.clone(),
+                                        if is_selected {
+                                            Style::default().fg(Theme::fg())
+                                        } else {
+                                            Style::default().fg(Theme::dim())
+                                        },
+                                    ),
+                                ];
+
+                                let syntax = cmd.syntax_hint();
+                                if !syntax.is_empty() && popup_inner_w >= 65 {
+                                    line2_spans.push(Span::styled("  •  ", Style::default().fg(Theme::dim())));
+                                    line2_spans.push(Span::styled(
+                                        syntax.to_string(),
+                                        if is_selected {
+                                            Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
+                                        } else {
+                                            Style::default().fg(Theme::yellow())
+                                        },
+                                    ));
+                                }
+
+                                let line2 = Line::from(line2_spans);
+
+                                ListItem::new(vec![line1, line2]).style(if is_selected {
+                                    Theme::selected_row()
+                                } else {
+                                    Style::default()
+                                })
                             } else {
-                                String::new()
-                            };
-                            let line = Line::from(vec![
-                                Span::styled(
-                                    format!("{}{}{:<20}", prefix, cmd.name, alias_str),
+                                // 1-line compact layout with rich column expansion
+                                let alias_str = if !cmd.aliases.is_empty() {
+                                    format!(" ({})", cmd.aliases.join(", "))
+                                } else {
+                                    String::new()
+                                };
+                                let name_col = format!("{}{}{}", prefix, cmd.name, alias_str);
+                                let pad_width = if popup_inner_w >= 90 { 26 } else { 20 };
+                                let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
+
+                                let mut spans = vec![
+                                    Span::styled(
+                                        padded_name,
+                                        if is_selected {
+                                            Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                        } else {
+                                            Style::default().fg(Theme::fg())
+                                        },
+                                    ),
+                                ];
+
+                                if popup_inner_w >= 70 {
+                                    spans.push(Span::styled(
+                                        format!("[{}] ", cmd.category()),
+                                        if is_selected {
+                                            Style::default().fg(Theme::accent())
+                                        } else {
+                                            Style::default().fg(Theme::dim())
+                                        },
+                                    ));
+                                }
+
+                                spans.push(Span::styled(
+                                    format!(" {}", cmd.description),
                                     if is_selected {
-                                        Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
-                                    } else {
                                         Style::default().fg(Theme::fg())
+                                    } else {
+                                        Style::default().fg(Theme::dim())
                                     },
-                                ),
-                                Span::styled(
-                                    format!("  {}", cmd.description),
-                                    Style::default().fg(Theme::dim()),
-                                ),
-                            ]);
-                            ListItem::new(line).style(if is_selected {
-                                Theme::selected_row()
-                            } else {
-                                Style::default()
-                            })
+                                ));
+
+                                let syntax = cmd.syntax_hint();
+                                if !syntax.is_empty() && popup_inner_w >= 95 {
+                                    spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                                    spans.push(Span::styled(
+                                        syntax.to_string(),
+                                        if is_selected {
+                                            Style::default().fg(Theme::yellow())
+                                        } else {
+                                            Style::default().fg(Theme::dim())
+                                        },
+                                    ));
+                                }
+
+                                ListItem::new(Line::from(spans)).style(if is_selected {
+                                    Theme::selected_row()
+                                } else {
+                                    Style::default()
+                                })
+                            }
                         })
                         .collect();
 
-                    let title = if suggs.len() > max_visible {
+                    let title = if suggs.len() > visible_count {
                         format!(" Commands [{}/{}] (Tab: complete, Enter: run) ", selected_idx + 1, suggs.len())
                     } else {
                         " Commands (Tab to complete, Enter to run) ".to_string()

--- a/apps/tui/src/ui/statusbar.rs
+++ b/apps/tui/src/ui/statusbar.rs
@@ -86,8 +86,6 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                     let density = props.command_popup_density.unwrap_or_default();
                     let popup_area = command_popup_rect(area, suggs.len(), max_width, max_visible, density);
                     f.render_widget(Clear, popup_area);
-
-                    let is_large = density.is_large();
                     let inner_height = popup_area.height.saturating_sub(2);
                     let item_lines = density.item_height();
                     let max_fits = (inner_height / item_lines) as usize;
@@ -111,133 +109,264 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                             let is_selected = abs_i == selected_idx;
                             let prefix = if is_selected { "▶ " } else { "  " };
 
-                            if is_large {
-                                // 2-line spacious card layout with bold large typography
-                                let alias_str = if !cmd.aliases.is_empty() {
-                                    format!(" ({})", cmd.aliases.join(", "))
-                                } else {
-                                    String::new()
-                                };
-                                let cat_badge = format!("[{}]", cmd.category());
-                                let name_text = format!("{}{}{}", prefix, cmd.name.to_uppercase(), alias_str);
-
-                                let name_len = name_text.chars().count();
-                                let badge_len = cat_badge.chars().count();
-                                let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
-                                let spacer = " ".repeat(spacer_len);
-
-                                let line1 = Line::from(vec![
-                                    Span::styled(
-                                        name_text,
-                                        if is_selected {
-                                            Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
-                                        } else {
-                                            Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
-                                        },
-                                    ),
-                                    Span::raw(spacer),
-                                    Span::styled(
-                                        cat_badge,
-                                        if is_selected {
-                                            Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
-                                        } else {
-                                            Style::default().fg(Theme::dim())
-                                        },
-                                    ),
-                                ]);
-
-                                let mut line2_spans = vec![
-                                    Span::raw("    "),
-                                    Span::styled(
-                                        cmd.description.clone(),
-                                        if is_selected {
-                                            Style::default().fg(Theme::fg())
-                                        } else {
-                                            Style::default().fg(Theme::dim())
-                                        },
-                                    ),
-                                ];
-
-                                let syntax = cmd.syntax_hint();
-                                if !syntax.is_empty() && popup_inner_w >= 65 {
-                                    line2_spans.push(Span::styled("  •  ", Style::default().fg(Theme::dim())));
-                                    line2_spans.push(Span::styled(
-                                        syntax.to_string(),
-                                        if is_selected {
-                                            Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
-                                        } else {
-                                            Style::default().fg(Theme::yellow())
-                                        },
-                                    ));
-                                }
-
-                                let line2 = Line::from(line2_spans);
-
-                                ListItem::new(vec![line1, line2]).style(if is_selected {
-                                    Theme::selected_row()
-                                } else {
-                                    Style::default()
-                                })
-                            } else {
-                                // 1-line compact layout with rich column expansion
-                                let alias_str = if !cmd.aliases.is_empty() {
-                                    format!(" ({})", cmd.aliases.join(", "))
-                                } else {
-                                    String::new()
-                                };
-                                let name_col = format!("{}{}{}", prefix, cmd.name, alias_str);
-                                let pad_width = if popup_inner_w >= 90 { 26 } else { 20 };
-                                let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
-
-                                let mut spans = vec![
-                                    Span::styled(
-                                        padded_name,
-                                        if is_selected {
-                                            Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
-                                        } else {
-                                            Style::default().fg(Theme::fg())
-                                        },
-                                    ),
-                                ];
-
-                                if popup_inner_w >= 70 {
-                                    spans.push(Span::styled(
-                                        format!("[{}] ", cmd.category()),
-                                        if is_selected {
-                                            Style::default().fg(Theme::accent())
-                                        } else {
-                                            Style::default().fg(Theme::dim())
-                                        },
-                                    ));
-                                }
-
-                                spans.push(Span::styled(
-                                    format!(" {}", cmd.description),
-                                    if is_selected {
-                                        Style::default().fg(Theme::fg())
+                            match density {
+                                CommandPopupDensity::ExtraLarge => {
+                                    // 3-line spacious card layout with maximum readability & detail
+                                    let alias_str = if !cmd.aliases.is_empty() {
+                                        format!(" ({})", cmd.aliases.join(", "))
                                     } else {
-                                        Style::default().fg(Theme::dim())
-                                    },
-                                ));
+                                        String::new()
+                                    };
+                                    let cat_badge = format!("[{}]", cmd.category());
+                                    let name_text = format!("{}{}{}", prefix, cmd.name.to_uppercase(), alias_str);
 
-                                let syntax = cmd.syntax_hint();
-                                if !syntax.is_empty() && popup_inner_w >= 95 {
-                                    spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                                    let name_len = name_text.chars().count();
+                                    let badge_len = cat_badge.chars().count();
+                                    let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
+                                    let spacer = " ".repeat(spacer_len);
+
+                                    let line1 = Line::from(vec![
+                                        Span::styled(
+                                            name_text,
+                                            if is_selected {
+                                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                                            },
+                                        ),
+                                        Span::raw(spacer),
+                                        Span::styled(
+                                            cat_badge,
+                                            if is_selected {
+                                                Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ),
+                                    ]);
+
+                                    let line2 = Line::from(vec![
+                                        Span::raw("    "),
+                                        Span::styled(
+                                            cmd.description.clone(),
+                                            if is_selected {
+                                                Style::default().fg(Theme::fg())
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ),
+                                    ]);
+
+                                    let syntax = cmd.syntax_hint();
+                                    let mut line3_spans = vec![
+                                        Span::raw("    "),
+                                        Span::styled("Usage: ", Style::default().fg(Theme::dim())),
+                                        Span::styled(
+                                            if !syntax.is_empty() { syntax.to_string() } else { format!(":{}", cmd.name) },
+                                            if is_selected {
+                                                Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::yellow())
+                                            },
+                                        ),
+                                    ];
+                                    if !cmd.aliases.is_empty() {
+                                        line3_spans.push(Span::styled("  |  Aliases: ", Style::default().fg(Theme::dim())));
+                                        line3_spans.push(Span::styled(
+                                            cmd.aliases.join(", "),
+                                            if is_selected {
+                                                Style::default().fg(Theme::fg())
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ));
+                                    }
+                                    let line3 = Line::from(line3_spans);
+
+                                    ListItem::new(vec![line1, line2, line3]).style(if is_selected {
+                                        Theme::selected_row()
+                                    } else {
+                                        Style::default()
+                                    })
+                                }
+                                CommandPopupDensity::Large => {
+                                    // 2-line spacious card layout with bold large typography
+                                    let alias_str = if !cmd.aliases.is_empty() {
+                                        format!(" ({})", cmd.aliases.join(", "))
+                                    } else {
+                                        String::new()
+                                    };
+                                    let cat_badge = format!("[{}]", cmd.category());
+                                    let name_text = format!("{}{}{}", prefix, cmd.name.to_uppercase(), alias_str);
+
+                                    let name_len = name_text.chars().count();
+                                    let badge_len = cat_badge.chars().count();
+                                    let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
+                                    let spacer = " ".repeat(spacer_len);
+
+                                    let line1 = Line::from(vec![
+                                        Span::styled(
+                                            name_text,
+                                            if is_selected {
+                                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                                            },
+                                        ),
+                                        Span::raw(spacer),
+                                        Span::styled(
+                                            cat_badge,
+                                            if is_selected {
+                                                Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ),
+                                    ]);
+
+                                    let mut line2_spans = vec![
+                                        Span::raw("    "),
+                                        Span::styled(
+                                            cmd.description.clone(),
+                                            if is_selected {
+                                                Style::default().fg(Theme::fg())
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ),
+                                    ];
+
+                                    let syntax = cmd.syntax_hint();
+                                    if !syntax.is_empty() && popup_inner_w >= 65 {
+                                        line2_spans.push(Span::styled("  •  ", Style::default().fg(Theme::dim())));
+                                        line2_spans.push(Span::styled(
+                                            syntax.to_string(),
+                                            if is_selected {
+                                                Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::yellow())
+                                            },
+                                        ));
+                                    }
+
+                                    let line2 = Line::from(line2_spans);
+
+                                    ListItem::new(vec![line1, line2]).style(if is_selected {
+                                        Theme::selected_row()
+                                    } else {
+                                        Style::default()
+                                    })
+                                }
+                                CommandPopupDensity::Standard => {
+                                    // 1-line enriched layout with category badge and syntax hint
+                                    let alias_str = if !cmd.aliases.is_empty() {
+                                        format!(" ({})", cmd.aliases.join(", "))
+                                    } else {
+                                        String::new()
+                                    };
+                                    let name_col = format!("{}{}{}", prefix, cmd.name, alias_str);
+                                    let pad_width = if popup_inner_w >= 90 { 26 } else { 20 };
+                                    let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
+
+                                    let mut spans = vec![
+                                        Span::styled(
+                                            padded_name,
+                                            if is_selected {
+                                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                                            },
+                                        ),
+                                    ];
+
+                                    if popup_inner_w >= 60 {
+                                        spans.push(Span::styled(
+                                            format!("[{}] ", cmd.category()),
+                                            if is_selected {
+                                                Style::default().fg(Theme::accent())
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ));
+                                    }
+
                                     spans.push(Span::styled(
-                                        syntax.to_string(),
+                                        format!(" {}", cmd.description),
                                         if is_selected {
-                                            Style::default().fg(Theme::yellow())
+                                            Style::default().fg(Theme::fg())
                                         } else {
                                             Style::default().fg(Theme::dim())
                                         },
                                     ));
-                                }
 
-                                ListItem::new(Line::from(spans)).style(if is_selected {
-                                    Theme::selected_row()
-                                } else {
-                                    Style::default()
-                                })
+                                    let syntax = cmd.syntax_hint();
+                                    if !syntax.is_empty() && popup_inner_w >= 85 {
+                                        spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                                        spans.push(Span::styled(
+                                            syntax.to_string(),
+                                            if is_selected {
+                                                Style::default().fg(Theme::yellow())
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ));
+                                    }
+
+                                    ListItem::new(Line::from(spans)).style(if is_selected {
+                                        Theme::selected_row()
+                                    } else {
+                                        Style::default()
+                                    })
+                                }
+                                CommandPopupDensity::Compact => {
+                                    // 1-line compact layout: clean, condensed
+                                    let alias_str = if !cmd.aliases.is_empty() {
+                                        format!(" ({})", cmd.aliases.join(", "))
+                                    } else {
+                                        String::new()
+                                    };
+                                    let name_col = format!("{}{}{}", prefix, cmd.name, alias_str);
+                                    let pad_width = if popup_inner_w >= 90 { 24 } else { 18 };
+                                    let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
+
+                                    let mut spans = vec![
+                                        Span::styled(
+                                            padded_name,
+                                            if is_selected {
+                                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Theme::fg())
+                                            },
+                                        ),
+                                        Span::styled(
+                                            format!(" {}", cmd.description),
+                                            if is_selected {
+                                                Style::default().fg(Theme::fg())
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ),
+                                    ];
+
+                                    let syntax = cmd.syntax_hint();
+                                    if !syntax.is_empty() && popup_inner_w >= 95 {
+                                        spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                                        spans.push(Span::styled(
+                                            syntax.to_string(),
+                                            if is_selected {
+                                                Style::default().fg(Theme::yellow())
+                                            } else {
+                                                Style::default().fg(Theme::dim())
+                                            },
+                                        ));
+                                    }
+
+                                    ListItem::new(Line::from(spans)).style(if is_selected {
+                                        Theme::selected_row()
+                                    } else {
+                                        Style::default()
+                                    })
+                                }
                             }
                         })
                         .collect();

--- a/apps/tui/src/views/mod.rs
+++ b/apps/tui/src/views/mod.rs
@@ -17,6 +17,7 @@ pub mod node_inspector_view;
 pub mod topology_view;
 pub mod gpu_view;
 pub mod top_view;
+pub mod tui_config_view;
 pub mod yaml_view;
 
 /// Strip everything from cluster-controlled text that would desynchronise
@@ -208,5 +209,6 @@ pub use resource_table::{render_resource_table, ResourceTableState};
 pub use settings_view::{render_settings_view, SettingField, SettingsViewState};
 pub use toolbox_view::{render_toolbox_view, ToolboxViewState};
 pub use tree_view::{render_tree_view, TreeViewState};
+pub use tui_config_view::{render_tui_config_view, TuiConfigViewState};
 pub use node_inspector_view::{render_node_inspector_view, NodeInspectorState};
 pub use yaml_view::{render_yaml_view, YamlViewState};

--- a/apps/tui/src/views/tui_config_view.rs
+++ b/apps/tui/src/views/tui_config_view.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use crate::theme::Theme;
-use crate::tui_config::TuiConfig;
+use crate::tui_config::{CommandPopupDensity, TuiConfig};
 use crate::ui::command_popup_rect;
 
 pub const SAMPLE_SUGGESTIONS: &[(&str, &[&str], &str, &str, &str)] = &[
@@ -78,6 +78,26 @@ impl TuiConfigViewState {
                 let current = config.command_popup_max_visible as i32;
                 let next = (current + delta).clamp(3, 20) as usize;
                 config.command_popup_max_visible = next;
+            }
+            2 => {
+                let current = config.command_popup_density.scale() as i32;
+                let next = (current + delta).clamp(1, 4) as u8;
+                config.command_popup_density = CommandPopupDensity::from_scale(next);
+            }
+            _ => {}
+        }
+        let _ = config.save();
+    }
+
+    pub fn cycle_current(&mut self, config: &mut TuiConfig) {
+        match self.selected_field {
+            0 => {
+                let current = config.command_popup_max_width;
+                config.command_popup_max_width = if current >= 200 { 40 } else { (current + 20).min(200) };
+            }
+            1 => {
+                let current = config.command_popup_max_visible;
+                config.command_popup_max_visible = if current >= 20 { 3 } else { (current + 3).min(20) };
             }
             2 => {
                 config.command_popup_density = config.command_popup_density.toggle();
@@ -296,41 +316,33 @@ pub fn render_tui_config_view(
     let density_inner = density_block.inner(control_chunks[2]);
     f.render_widget(density_block, control_chunks[2]);
 
-    let is_large_cfg = config.command_popup_density.is_large();
+    let scale_val = config.command_popup_density.scale();
+    let scale_pct = (scale_val - 1) as f32 / 3.0;
+    let slider_density = (density_inner.width.saturating_sub(4) as usize).min(24).max(10);
     let density_lines = vec![
         Line::from(vec![
-            Span::styled("Size:  ", Style::default().fg(Theme::dim())),
-            if !is_large_cfg {
-                Span::styled(
-                    "[● Compact (1-line)] ",
-                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
-                )
-            } else {
-                Span::styled(
-                    " ○ Compact (1-line)  ",
-                    Style::default().fg(Theme::dim()),
-                )
-            },
-            if is_large_cfg {
-                Span::styled(
-                    "[● Large (2-line cards)]",
-                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
-                )
-            } else {
-                Span::styled(
-                    " ○ Large (2-line cards) ",
-                    Style::default().fg(Theme::dim()),
-                )
-            },
+            Span::styled("Scale: ", Style::default().fg(Theme::dim())),
+            Span::styled(
+                format!("{scale_val} / 4  "),
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(render_slider(scale_pct, slider_density), Style::default().fg(Theme::accent())),
+            Span::styled(" [1..=4] ", Style::default().fg(Theme::dim())),
+            Span::styled(
+                format!("({})", config.command_popup_density.label()),
+                Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD),
+            ),
         ]),
         Line::from(vec![
-            Span::styled("Toggle: Use ", Style::default().fg(Theme::dim())),
-            Span::styled("Space", Style::default().fg(Theme::yellow())),
-            Span::styled(", ", Style::default().fg(Theme::dim())),
-            Span::styled("Enter", Style::default().fg(Theme::yellow())),
-            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("Step: ±1  |  Use ", Style::default().fg(Theme::dim())),
             Span::styled("h/l", Style::default().fg(Theme::yellow())),
-            Span::styled(" to switch", Style::default().fg(Theme::dim())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("←/→", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("-/+", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("Enter", Style::default().fg(Theme::yellow())),
+            Span::styled(" to adjust", Style::default().fg(Theme::dim())),
         ]),
     ];
     f.render_widget(Paragraph::new(density_lines), density_inner);
@@ -388,7 +400,6 @@ pub fn render_tui_config_view(
         f.render_widget(Clear, popup_area);
 
         let density = config.command_popup_density;
-        let is_large = density.is_large();
         let inner_height = popup_area.height.saturating_sub(2);
         let item_lines = density.item_height();
         let max_fits = (inner_height / item_lines) as usize;
@@ -406,129 +417,256 @@ pub fn render_tui_config_view(
                 let is_selected = i == 0;
                 let prefix = if is_selected { "▶ " } else { "  " };
 
-                if is_large {
-                    let alias_str = if !aliases.is_empty() {
-                        format!(" ({})", aliases.join(", "))
-                    } else {
-                        String::new()
-                    };
-                    let cat_badge = format!("[{}]", cat);
-                    let name_text = format!("{}{}{}", prefix, name.to_uppercase(), alias_str);
-
-                    let name_len = name_text.chars().count();
-                    let badge_len = cat_badge.chars().count();
-                    let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
-                    let spacer = " ".repeat(spacer_len);
-
-                    let line1 = Line::from(vec![
-                        Span::styled(
-                            name_text,
-                            if is_selected {
-                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
-                            } else {
-                                Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
-                            },
-                        ),
-                        Span::raw(spacer),
-                        Span::styled(
-                            cat_badge,
-                            if is_selected {
-                                Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
-                            } else {
-                                Style::default().fg(Theme::dim())
-                            },
-                        ),
-                    ]);
-
-                    let mut line2_spans = vec![
-                        Span::raw("    "),
-                        Span::styled(
-                            *desc,
-                            if is_selected {
-                                Style::default().fg(Theme::fg())
-                            } else {
-                                Style::default().fg(Theme::dim())
-                            },
-                        ),
-                    ];
-
-                    if !syntax.is_empty() && popup_inner_w >= 65 {
-                        line2_spans.push(Span::styled("  •  ", Style::default().fg(Theme::dim())));
-                        line2_spans.push(Span::styled(
-                            *syntax,
-                            if is_selected {
-                                Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
-                            } else {
-                                Style::default().fg(Theme::yellow())
-                            },
-                        ));
-                    }
-
-                    let line2 = Line::from(line2_spans);
-
-                    ListItem::new(vec![line1, line2]).style(if is_selected {
-                        Theme::selected_row()
-                    } else {
-                        Style::default()
-                    })
-                } else {
-                    let alias_str = if !aliases.is_empty() {
-                        format!(" ({})", aliases.join(", "))
-                    } else {
-                        String::new()
-                    };
-                    let name_col = format!("{}{}{}", prefix, name, alias_str);
-                    let pad_width = if popup_inner_w >= 90 { 26 } else { 20 };
-                    let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
-
-                    let mut spans = vec![
-                        Span::styled(
-                            padded_name,
-                            if is_selected {
-                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
-                            } else {
-                                Style::default().fg(Theme::fg())
-                            },
-                        ),
-                    ];
-
-                    if popup_inner_w >= 70 {
-                        spans.push(Span::styled(
-                            format!("[{}] ", cat),
-                            if is_selected {
-                                Style::default().fg(Theme::accent())
-                            } else {
-                                Style::default().fg(Theme::dim())
-                            },
-                        ));
-                    }
-
-                    spans.push(Span::styled(
-                        format!(" {}", desc),
-                        if is_selected {
-                            Style::default().fg(Theme::fg())
+                match density {
+                    CommandPopupDensity::ExtraLarge => {
+                        let alias_str = if !aliases.is_empty() {
+                            format!(" ({})", aliases.join(", "))
                         } else {
-                            Style::default().fg(Theme::dim())
-                        },
-                    ));
+                            String::new()
+                        };
+                        let cat_badge = format!("[{}]", cat);
+                        let name_text = format!("{}{}{}", prefix, name.to_uppercase(), alias_str);
 
-                    if !syntax.is_empty() && popup_inner_w >= 95 {
-                        spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                        let name_len = name_text.chars().count();
+                        let badge_len = cat_badge.chars().count();
+                        let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
+                        let spacer = " ".repeat(spacer_len);
+
+                        let line1 = Line::from(vec![
+                            Span::styled(
+                                name_text,
+                                if is_selected {
+                                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                                },
+                            ),
+                            Span::raw(spacer),
+                            Span::styled(
+                                cat_badge,
+                                if is_selected {
+                                    Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ),
+                        ]);
+
+                        let line2 = Line::from(vec![
+                            Span::raw("    "),
+                            Span::styled(
+                                *desc,
+                                if is_selected {
+                                    Style::default().fg(Theme::fg())
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ),
+                        ]);
+
+                        let mut line3_spans = vec![
+                            Span::raw("    "),
+                            Span::styled("Usage: ", Style::default().fg(Theme::dim())),
+                            Span::styled(
+                                if !syntax.is_empty() { *syntax } else { *name },
+                                if is_selected {
+                                    Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::yellow())
+                                },
+                            ),
+                        ];
+                        if !aliases.is_empty() {
+                            line3_spans.push(Span::styled("  |  Aliases: ", Style::default().fg(Theme::dim())));
+                            line3_spans.push(Span::styled(
+                                aliases.join(", "),
+                                if is_selected {
+                                    Style::default().fg(Theme::fg())
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ));
+                        }
+                        let line3 = Line::from(line3_spans);
+
+                        ListItem::new(vec![line1, line2, line3]).style(if is_selected {
+                            Theme::selected_row()
+                        } else {
+                            Style::default()
+                        })
+                    }
+                    CommandPopupDensity::Large => {
+                        let alias_str = if !aliases.is_empty() {
+                            format!(" ({})", aliases.join(", "))
+                        } else {
+                            String::new()
+                        };
+                        let cat_badge = format!("[{}]", cat);
+                        let name_text = format!("{}{}{}", prefix, name.to_uppercase(), alias_str);
+
+                        let name_len = name_text.chars().count();
+                        let badge_len = cat_badge.chars().count();
+                        let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
+                        let spacer = " ".repeat(spacer_len);
+
+                        let line1 = Line::from(vec![
+                            Span::styled(
+                                name_text,
+                                if is_selected {
+                                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                                },
+                            ),
+                            Span::raw(spacer),
+                            Span::styled(
+                                cat_badge,
+                                if is_selected {
+                                    Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ),
+                        ]);
+
+                        let mut line2_spans = vec![
+                            Span::raw("    "),
+                            Span::styled(
+                                *desc,
+                                if is_selected {
+                                    Style::default().fg(Theme::fg())
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ),
+                        ];
+
+                        if !syntax.is_empty() && popup_inner_w >= 65 {
+                            line2_spans.push(Span::styled("  •  ", Style::default().fg(Theme::dim())));
+                            line2_spans.push(Span::styled(
+                                *syntax,
+                                if is_selected {
+                                    Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::yellow())
+                                },
+                            ));
+                        }
+
+                        let line2 = Line::from(line2_spans);
+
+                        ListItem::new(vec![line1, line2]).style(if is_selected {
+                            Theme::selected_row()
+                        } else {
+                            Style::default()
+                        })
+                    }
+                    CommandPopupDensity::Standard => {
+                        let alias_str = if !aliases.is_empty() {
+                            format!(" ({})", aliases.join(", "))
+                        } else {
+                            String::new()
+                        };
+                        let name_col = format!("{}{}{}", prefix, name, alias_str);
+                        let pad_width = if popup_inner_w >= 90 { 26 } else { 20 };
+                        let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
+
+                        let mut spans = vec![
+                            Span::styled(
+                                padded_name,
+                                if is_selected {
+                                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                                },
+                            ),
+                        ];
+
+                        if popup_inner_w >= 60 {
+                            spans.push(Span::styled(
+                                format!("[{}] ", cat),
+                                if is_selected {
+                                    Style::default().fg(Theme::accent())
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ));
+                        }
+
                         spans.push(Span::styled(
-                            *syntax,
+                            format!(" {}", desc),
                             if is_selected {
-                                Style::default().fg(Theme::yellow())
+                                Style::default().fg(Theme::fg())
                             } else {
                                 Style::default().fg(Theme::dim())
                             },
                         ));
-                    }
 
-                    ListItem::new(Line::from(spans)).style(if is_selected {
-                        Theme::selected_row()
-                    } else {
-                        Style::default()
-                    })
+                        if !syntax.is_empty() && popup_inner_w >= 85 {
+                            spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                            spans.push(Span::styled(
+                                *syntax,
+                                if is_selected {
+                                    Style::default().fg(Theme::yellow())
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ));
+                        }
+
+                        ListItem::new(Line::from(spans)).style(if is_selected {
+                            Theme::selected_row()
+                        } else {
+                            Style::default()
+                        })
+                    }
+                    CommandPopupDensity::Compact => {
+                        let alias_str = if !aliases.is_empty() {
+                            format!(" ({})", aliases.join(", "))
+                        } else {
+                            String::new()
+                        };
+                        let name_col = format!("{}{}{}", prefix, name, alias_str);
+                        let pad_width = if popup_inner_w >= 90 { 24 } else { 18 };
+                        let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
+
+                        let mut spans = vec![
+                            Span::styled(
+                                padded_name,
+                                if is_selected {
+                                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(Theme::fg())
+                                },
+                            ),
+                            Span::styled(
+                                format!(" {}", desc),
+                                if is_selected {
+                                    Style::default().fg(Theme::fg())
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ),
+                        ];
+
+                        if !syntax.is_empty() && popup_inner_w >= 95 {
+                            spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                            spans.push(Span::styled(
+                                *syntax,
+                                if is_selected {
+                                    Style::default().fg(Theme::yellow())
+                                } else {
+                                    Style::default().fg(Theme::dim())
+                                },
+                            ));
+                        }
+
+                        ListItem::new(Line::from(spans)).style(if is_selected {
+                            Theme::selected_row()
+                        } else {
+                            Style::default()
+                        })
+                    }
                 }
             })
             .collect();

--- a/apps/tui/src/views/tui_config_view.rs
+++ b/apps/tui/src/views/tui_config_view.rs
@@ -10,25 +10,38 @@ use crate::theme::Theme;
 use crate::tui_config::TuiConfig;
 use crate::ui::command_popup_rect;
 
-pub const SAMPLE_SUGGESTIONS: &[(&str, &[&str], &str)] = &[
-    ("pods", &["po"], "Pods in namespace or cluster-wide"),
-    ("deployments", &["deploy"], "Deployments controller"),
-    ("services", &["svc"], "Kubernetes Services"),
-    ("configmaps", &["cm"], "ConfigMaps key-value configurations"),
-    ("secrets", &["sec"], "Kubernetes Secrets (masked)"),
-    ("nodes", &["no"], "Cluster worker and control-plane nodes"),
-    ("events", &["ev"], "Recent cluster events and warnings"),
-    ("helm", &["releases"], "Helm release revisions and values"),
-    ("assistant", &["ai", "chat"], "SRElens AI Assistant Chat"),
-    ("config", &["tui"], "TUI Configuration & Popup Size"),
-    ("toolbox", &["tools"], "Diagnostics (kubectl, helm, krew)"),
-    ("overview", &[], "Cluster health and resource totals"),
-    ("quit", &["q", "exit"], "Quit SRElens"),
+pub const SAMPLE_SUGGESTIONS: &[(&str, &[&str], &str, &str, &str)] = &[
+    ("pods", &["po", "pod"], "Workload", "List, inspect, and tail Kubernetes pods across namespaces", ":pods [namespace]"),
+    ("deployments", &["deploy", "dp"], "Workload", "Manage, inspect, and scale deployment workloads", ":deployments [ns]"),
+    ("services", &["svc", "service"], "Network", "Service routing, cluster IPs, NodePorts and LoadBalancers", ":services [ns]"),
+    ("configmaps", &["cm"], "Config", "Key-value configuration maps and application data", ":configmaps [ns]"),
+    ("secrets", &["sec"], "Config", "Kubernetes secrets with masked base64 credentials", ":secrets [ns]"),
+    ("nodes", &["no", "node"], "Cluster", "Cluster worker and control-plane node hardware and health", ":nodes"),
+    ("events", &["ev", "event"], "Cluster", "Cluster-wide event stream, errors, warnings & scheduling", ":events [ns]"),
+    ("helm", &["releases"], "Helm", "Helm 3 release revisions, status, values and manifests", ":helm [ns]"),
+    ("workloads", &["wl"], "Workload", "Unified view of Pods, Deployments, STS & DS", ":workloads [ns]"),
+    ("statefulsets", &["sts"], "Workload", "Stateful set workloads and distributed replicas", ":statefulsets [ns]"),
+    ("daemonsets", &["ds"], "Workload", "Node-local daemonset agent workloads", ":daemonsets [ns]"),
+    ("jobs", &["job"], "Workload", "Batch job runs and execution completion status", ":jobs [ns]"),
+    ("cronjobs", &["cj"], "Workload", "Scheduled cron jobs and recurring execution history", ":cronjobs [ns]"),
+    ("ingresses", &["ing"], "Network", "HTTP/HTTPS ingress routing rules and TLS certs", ":ingresses [ns]"),
+    ("namespaces", &["ns"], "Cluster", "Cluster tenancy namespaces switcher and viewer", ":namespaces"),
+    ("persistentvolumes", &["pv"], "Storage", "Cluster-wide persistent storage volumes", ":persistentvolumes"),
+    ("persistentvolumeclaims", &["pvc"], "Storage", "Persistent storage volume claims by namespace", ":persistentvolumeclaims [ns]"),
+    ("storageclasses", &["sc"], "Storage", "Storage provisioners, volume plugins & reclaim policies", ":storageclasses"),
+    ("serviceaccounts", &["sa"], "Auth / RBAC", "Service account identities and RBAC token bindings", ":serviceaccounts [ns]"),
+    ("roles", &["role"], "Auth / RBAC", "Namespace-scoped RBAC roles and resource permissions", ":roles [ns]"),
+    ("top", &["toppods"], "Hotspots", "Top Hotspots ranking (Pods & Nodes by CPU/Memory)", ":top"),
+    ("assistant", &["ai", "chat"], "AI Assistant", "SRElens AI Assistant Chat for troubleshooting", ":assistant"),
+    ("config", &["tui"], "Configuration", "Configure command popup dimensions, visible rows & text size", ":config"),
+    ("toolbox", &["tools"], "Diagnostic", "Toolbox diagnostics (kubectl, helm, krew plugins)", ":toolbox"),
+    ("overview", &["info"], "Overview", "Cluster overview, health summary and node/pod capacity", ":overview"),
+    ("quit", &["q", "exit"], "System", "Quit SRElens TUI session", ":quit"),
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TuiConfigViewState {
-    pub selected_field: usize, // 0 = Width, 1 = Visible Rows
+    pub selected_field: usize, // 0 = Width, 1 = Visible Rows, 2 = Text Size / Density
 }
 
 impl Default for TuiConfigViewState {
@@ -43,12 +56,12 @@ impl TuiConfigViewState {
     }
 
     pub fn select_next_field(&mut self) {
-        self.selected_field = (self.selected_field + 1) % 2;
+        self.selected_field = (self.selected_field + 1) % 3;
     }
 
     pub fn select_prev_field(&mut self) {
         if self.selected_field == 0 {
-            self.selected_field = 1;
+            self.selected_field = 2;
         } else {
             self.selected_field -= 1;
         }
@@ -65,6 +78,9 @@ impl TuiConfigViewState {
                 let current = config.command_popup_max_visible as i32;
                 let next = (current + delta).clamp(3, 20) as usize;
                 config.command_popup_max_visible = next;
+            }
+            2 => {
+                config.command_popup_density = config.command_popup_density.toggle();
             }
             _ => {}
         }
@@ -101,9 +117,9 @@ pub fn render_tui_config_view(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3), // Top description
+            Constraint::Length(2), // Top description
             Constraint::Min(10),   // Controls and Live Preview
-            Constraint::Length(2), // Bottom key hints
+            Constraint::Length(1), // Bottom key hints
         ])
         .split(inner);
 
@@ -112,7 +128,7 @@ pub fn render_tui_config_view(
         Line::from(vec![
             Span::styled("TUI Display & Layout Options: ", Theme::header_label()),
             Span::styled(
-                "Configure command menu dimensions and popup sizing.",
+                "Configure command popup dimensions, visible rows & text size.",
                 Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD),
             ),
         ]),
@@ -133,7 +149,7 @@ pub fn render_tui_config_view(
     } else {
         let v_chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(12), Constraint::Min(8)])
+            .constraints([Constraint::Length(16), Constraint::Min(8)])
             .split(chunks[1]);
         (v_chunks[0], v_chunks[1])
     };
@@ -142,8 +158,9 @@ pub fn render_tui_config_view(
     let control_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(6), // Width card
-            Constraint::Length(6), // Visible rows card
+            Constraint::Length(5), // Width card
+            Constraint::Length(5), // Visible rows card
+            Constraint::Length(5), // Text size card
             Constraint::Min(0),
         ])
         .split(controls_area);
@@ -252,6 +269,72 @@ pub fn render_tui_config_view(
     ];
     f.render_widget(Paragraph::new(rows_lines), rows_inner);
 
+    // Setting 2: Command Popup Text Size / Density
+    let is_density_selected = state.selected_field == 2;
+    let density_border_color = if is_density_selected {
+        Theme::cyan()
+    } else {
+        Theme::border()
+    };
+    let density_title = if is_density_selected {
+        " ▶ Command Popup Text Size "
+    } else {
+        "   Command Popup Text Size "
+    };
+    let density_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(density_border_color))
+        .title(Span::styled(
+            density_title,
+            if is_density_selected {
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Theme::fg())
+            },
+        ));
+    let density_inner = density_block.inner(control_chunks[2]);
+    f.render_widget(density_block, control_chunks[2]);
+
+    let is_large_cfg = config.command_popup_density.is_large();
+    let density_lines = vec![
+        Line::from(vec![
+            Span::styled("Size:  ", Style::default().fg(Theme::dim())),
+            if !is_large_cfg {
+                Span::styled(
+                    "[● Compact (1-line)] ",
+                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
+                )
+            } else {
+                Span::styled(
+                    " ○ Compact (1-line)  ",
+                    Style::default().fg(Theme::dim()),
+                )
+            },
+            if is_large_cfg {
+                Span::styled(
+                    "[● Large (2-line cards)]",
+                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
+                )
+            } else {
+                Span::styled(
+                    " ○ Large (2-line cards) ",
+                    Style::default().fg(Theme::dim()),
+                )
+            },
+        ]),
+        Line::from(vec![
+            Span::styled("Toggle: Use ", Style::default().fg(Theme::dim())),
+            Span::styled("Space", Style::default().fg(Theme::yellow())),
+            Span::styled(", ", Style::default().fg(Theme::dim())),
+            Span::styled("Enter", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("h/l", Style::default().fg(Theme::yellow())),
+            Span::styled(" to switch", Style::default().fg(Theme::dim())),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(density_lines), density_inner);
+
     // 3. Live Preview of Command Popup
     let preview_block = Block::default()
         .borders(Borders::ALL)
@@ -286,6 +369,7 @@ pub fn render_tui_config_view(
             SAMPLE_SUGGESTIONS.len(),
             config.command_popup_max_width,
             config.command_popup_max_visible,
+            config.command_popup_density,
         );
 
         // Clamp popup vertically so it stays within preview_inner
@@ -303,41 +387,160 @@ pub fn render_tui_config_view(
 
         f.render_widget(Clear, popup_area);
 
-        let max_visible = config.command_popup_max_visible;
-        let visible_count = SAMPLE_SUGGESTIONS.len().min(max_visible);
+        let density = config.command_popup_density;
+        let is_large = density.is_large();
+        let inner_height = popup_area.height.saturating_sub(2);
+        let item_lines = density.item_height();
+        let max_fits = (inner_height / item_lines) as usize;
+        let visible_count = SAMPLE_SUGGESTIONS
+            .len()
+            .min(config.command_popup_max_visible)
+            .min(max_fits.max(1));
         let visible_slice = &SAMPLE_SUGGESTIONS[0..visible_count];
+        let popup_inner_w = popup_area.width.saturating_sub(2) as usize;
 
         let items: Vec<ListItem> = visible_slice
             .iter()
             .enumerate()
-            .map(|(i, (name, aliases, desc))| {
+            .map(|(i, (name, aliases, cat, desc, syntax))| {
                 let is_selected = i == 0;
                 let prefix = if is_selected { "▶ " } else { "  " };
-                let alias_str = if !aliases.is_empty() {
-                    format!(" ({})", aliases.join(", "))
+
+                if is_large {
+                    let alias_str = if !aliases.is_empty() {
+                        format!(" ({})", aliases.join(", "))
+                    } else {
+                        String::new()
+                    };
+                    let cat_badge = format!("[{}]", cat);
+                    let name_text = format!("{}{}{}", prefix, name.to_uppercase(), alias_str);
+
+                    let name_len = name_text.chars().count();
+                    let badge_len = cat_badge.chars().count();
+                    let spacer_len = popup_inner_w.saturating_sub(name_len + badge_len + 1).max(2);
+                    let spacer = " ".repeat(spacer_len);
+
+                    let line1 = Line::from(vec![
+                        Span::styled(
+                            name_text,
+                            if is_selected {
+                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                            } else {
+                                Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD)
+                            },
+                        ),
+                        Span::raw(spacer),
+                        Span::styled(
+                            cat_badge,
+                            if is_selected {
+                                Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD)
+                            } else {
+                                Style::default().fg(Theme::dim())
+                            },
+                        ),
+                    ]);
+
+                    let mut line2_spans = vec![
+                        Span::raw("    "),
+                        Span::styled(
+                            *desc,
+                            if is_selected {
+                                Style::default().fg(Theme::fg())
+                            } else {
+                                Style::default().fg(Theme::dim())
+                            },
+                        ),
+                    ];
+
+                    if !syntax.is_empty() && popup_inner_w >= 65 {
+                        line2_spans.push(Span::styled("  •  ", Style::default().fg(Theme::dim())));
+                        line2_spans.push(Span::styled(
+                            *syntax,
+                            if is_selected {
+                                Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)
+                            } else {
+                                Style::default().fg(Theme::yellow())
+                            },
+                        ));
+                    }
+
+                    let line2 = Line::from(line2_spans);
+
+                    ListItem::new(vec![line1, line2]).style(if is_selected {
+                        Theme::selected_row()
+                    } else {
+                        Style::default()
+                    })
                 } else {
-                    String::new()
-                };
-                let line = Line::from(vec![
-                    Span::styled(
-                        format!("{}{}{:<18}", prefix, name, alias_str),
+                    let alias_str = if !aliases.is_empty() {
+                        format!(" ({})", aliases.join(", "))
+                    } else {
+                        String::new()
+                    };
+                    let name_col = format!("{}{}{}", prefix, name, alias_str);
+                    let pad_width = if popup_inner_w >= 90 { 26 } else { 20 };
+                    let padded_name = format!("{:<pad_width$}", name_col, pad_width = pad_width);
+
+                    let mut spans = vec![
+                        Span::styled(
+                            padded_name,
+                            if is_selected {
+                                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                            } else {
+                                Style::default().fg(Theme::fg())
+                            },
+                        ),
+                    ];
+
+                    if popup_inner_w >= 70 {
+                        spans.push(Span::styled(
+                            format!("[{}] ", cat),
+                            if is_selected {
+                                Style::default().fg(Theme::accent())
+                            } else {
+                                Style::default().fg(Theme::dim())
+                            },
+                        ));
+                    }
+
+                    spans.push(Span::styled(
+                        format!(" {}", desc),
                         if is_selected {
-                            Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
-                        } else {
                             Style::default().fg(Theme::fg())
+                        } else {
+                            Style::default().fg(Theme::dim())
                         },
-                    ),
-                    Span::styled(format!("  {}", desc), Style::default().fg(Theme::dim())),
-                ]);
-                ListItem::new(line).style(if is_selected {
-                    Theme::selected_row()
-                } else {
-                    Style::default()
-                })
+                    ));
+
+                    if !syntax.is_empty() && popup_inner_w >= 95 {
+                        spans.push(Span::styled("  |  ", Style::default().fg(Theme::dim())));
+                        spans.push(Span::styled(
+                            *syntax,
+                            if is_selected {
+                                Style::default().fg(Theme::yellow())
+                            } else {
+                                Style::default().fg(Theme::dim())
+                            },
+                        ));
+                    }
+
+                    ListItem::new(Line::from(spans)).style(if is_selected {
+                        Theme::selected_row()
+                    } else {
+                        Style::default()
+                    })
+                }
             })
             .collect();
 
-        let title = if SAMPLE_SUGGESTIONS.len() > max_visible {
+        let title = if visible_count < config.command_popup_max_visible {
+            format!(
+                " Commands [1/{}] (window limited: {} of {}) ",
+                SAMPLE_SUGGESTIONS.len(),
+                visible_count,
+                config.command_popup_max_visible
+            )
+        } else if SAMPLE_SUGGESTIONS.len() > visible_count {
             format!(
                 " Commands [1/{}] (Tab: complete, Enter: run) ",
                 SAMPLE_SUGGESTIONS.len()
@@ -362,6 +565,8 @@ pub fn render_tui_config_view(
         Span::styled("Select  ", Style::default().fg(Theme::dim())),
         Span::styled("<h/l, ←/→, -/+> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
         Span::styled("Adjust  ", Style::default().fg(Theme::dim())),
+        Span::styled("<Space or Enter> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+        Span::styled("Toggle  ", Style::default().fg(Theme::dim())),
         Span::styled("<r> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
         Span::styled("Reset Defaults  ", Style::default().fg(Theme::dim())),
         Span::styled("<Esc or q> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),

--- a/apps/tui/src/views/tui_config_view.rs
+++ b/apps/tui/src/views/tui_config_view.rs
@@ -41,7 +41,7 @@ pub const SAMPLE_SUGGESTIONS: &[(&str, &[&str], &str, &str, &str)] = &[
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TuiConfigViewState {
-    pub selected_field: usize, // 0 = Width, 1 = Visible Rows, 2 = Text Size / Density
+    pub selected_field: usize, // 0 = Width, 1 = Visible Rows, 2 = Text Size / Density, 3 = Startup Banner
 }
 
 impl Default for TuiConfigViewState {
@@ -56,12 +56,12 @@ impl TuiConfigViewState {
     }
 
     pub fn select_next_field(&mut self) {
-        self.selected_field = (self.selected_field + 1) % 3;
+        self.selected_field = (self.selected_field + 1) % 4;
     }
 
     pub fn select_prev_field(&mut self) {
         if self.selected_field == 0 {
-            self.selected_field = 2;
+            self.selected_field = 3;
         } else {
             self.selected_field -= 1;
         }
@@ -84,6 +84,9 @@ impl TuiConfigViewState {
                 let next = (current + delta).clamp(1, 4) as u8;
                 config.command_popup_density = CommandPopupDensity::from_scale(next);
             }
+            3 => {
+                config.show_feature_banner = !config.show_feature_banner;
+            }
             _ => {}
         }
         let _ = config.save();
@@ -101,6 +104,9 @@ impl TuiConfigViewState {
             }
             2 => {
                 config.command_popup_density = config.command_popup_density.toggle();
+            }
+            3 => {
+                config.show_feature_banner = !config.show_feature_banner;
             }
             _ => {}
         }
@@ -148,7 +154,7 @@ pub fn render_tui_config_view(
         Line::from(vec![
             Span::styled("TUI Display & Layout Options: ", Theme::header_label()),
             Span::styled(
-                "Configure command popup dimensions, visible rows & text size.",
+                "Configure command popup dimensions, visible rows, text size & startup banner.",
                 Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD),
             ),
         ]),
@@ -169,7 +175,7 @@ pub fn render_tui_config_view(
     } else {
         let v_chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(16), Constraint::Min(8)])
+            .constraints([Constraint::Length(21), Constraint::Min(8)])
             .split(chunks[1]);
         (v_chunks[0], v_chunks[1])
     };
@@ -181,6 +187,7 @@ pub fn render_tui_config_view(
             Constraint::Length(5), // Width card
             Constraint::Length(5), // Visible rows card
             Constraint::Length(5), // Text size card
+            Constraint::Length(5), // Startup banner card
             Constraint::Min(0),
         ])
         .split(controls_area);
@@ -347,19 +354,92 @@ pub fn render_tui_config_view(
     ];
     f.render_widget(Paragraph::new(density_lines), density_inner);
 
-    // 3. Live Preview of Command Popup
-    let preview_block = Block::default()
+    // Setting 3: Startup Feature Banner
+    let is_banner_selected = state.selected_field == 3;
+    let banner_border_color = if is_banner_selected {
+        Theme::cyan()
+    } else {
+        Theme::border()
+    };
+    let banner_title = if is_banner_selected {
+        " ▶ Startup Feature Banner "
+    } else {
+        "   Startup Feature Banner "
+    };
+    let banner_block = Block::default()
         .borders(Borders::ALL)
         .border_type(Theme::border_type())
-        .border_style(Style::default().fg(Theme::border()))
+        .border_style(Style::default().fg(banner_border_color))
         .title(Span::styled(
-            " Live Preview: Command Popup (:) ",
-            Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD),
+            banner_title,
+            if is_banner_selected {
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Theme::fg())
+            },
         ));
-    let preview_inner = preview_block.inner(preview_area);
-    f.render_widget(preview_block, preview_area);
+    let banner_inner = banner_block.inner(control_chunks[3]);
+    f.render_widget(banner_block, control_chunks[3]);
 
-    if preview_inner.height >= 4 && preview_inner.width >= 20 {
+    let (checkbox_str, status_str, status_style) = if config.show_feature_banner {
+        ("[● Show on startup]", "Enabled", Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD))
+    } else {
+        ("[○ Don't show]", "Disabled", Style::default().fg(Theme::dim()))
+    };
+
+    let banner_lines = vec![
+        Line::from(vec![
+            Span::styled("Banner: ", Style::default().fg(Theme::dim())),
+            Span::styled(
+                checkbox_str,
+                if config.show_feature_banner {
+                    Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Theme::dim())
+                },
+            ),
+            Span::styled("  Status: ", Style::default().fg(Theme::dim())),
+            Span::styled(status_str, status_style),
+        ]),
+        Line::from(vec![
+            Span::styled("Action: Toggle  |  Use ", Style::default().fg(Theme::dim())),
+            Span::styled("Space", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("Enter", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("←/→", Style::default().fg(Theme::yellow())),
+            Span::styled(" to toggle", Style::default().fg(Theme::dim())),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(banner_lines), banner_inner);
+
+    // 3. Live Preview (Feature Banner or Command Popup)
+    if state.selected_field == 3 {
+        let preview_block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(Theme::border_type())
+            .border_style(Style::default().fg(Theme::border()))
+            .title(Span::styled(
+                " Live Preview: Startup Feature Banner (:features, :banner) ",
+                Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD),
+            ));
+        let preview_inner = preview_block.inner(preview_area);
+        f.render_widget(preview_block, preview_area);
+
+        crate::ui::render_feature_banner_modal(f, preview_inner, config.show_feature_banner);
+    } else {
+        let preview_block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(Theme::border_type())
+            .border_style(Style::default().fg(Theme::border()))
+            .title(Span::styled(
+                " Live Preview: Command Popup (:) ",
+                Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD),
+            ));
+        let preview_inner = preview_block.inner(preview_area);
+        f.render_widget(preview_block, preview_area);
+
+        if preview_inner.height >= 4 && preview_inner.width >= 20 {
         // Simulated statusbar at bottom of preview area
         let sim_bar_y = preview_inner.y + preview_inner.height.saturating_sub(1);
         let sim_bar_area = Rect {
@@ -696,6 +776,7 @@ pub fn render_tui_config_view(
         );
         f.render_widget(list, popup_area);
     }
+}
 
     // 4. Bottom Key Hints
     let hints_line = Line::from(vec![

--- a/apps/tui/src/views/tui_config_view.rs
+++ b/apps/tui/src/views/tui_config_view.rs
@@ -1,0 +1,371 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
+
+use crate::theme::Theme;
+use crate::tui_config::TuiConfig;
+use crate::ui::command_popup_rect;
+
+pub const SAMPLE_SUGGESTIONS: &[(&str, &[&str], &str)] = &[
+    ("pods", &["po"], "Pods in namespace or cluster-wide"),
+    ("deployments", &["deploy"], "Deployments controller"),
+    ("services", &["svc"], "Kubernetes Services"),
+    ("configmaps", &["cm"], "ConfigMaps key-value configurations"),
+    ("secrets", &["sec"], "Kubernetes Secrets (masked)"),
+    ("nodes", &["no"], "Cluster worker and control-plane nodes"),
+    ("events", &["ev"], "Recent cluster events and warnings"),
+    ("helm", &["releases"], "Helm release revisions and values"),
+    ("assistant", &["ai", "chat"], "SRElens AI Assistant Chat"),
+    ("config", &["tui"], "TUI Configuration & Popup Size"),
+    ("toolbox", &["tools"], "Diagnostics (kubectl, helm, krew)"),
+    ("overview", &[], "Cluster health and resource totals"),
+    ("quit", &["q", "exit"], "Quit SRElens"),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TuiConfigViewState {
+    pub selected_field: usize, // 0 = Width, 1 = Visible Rows
+}
+
+impl Default for TuiConfigViewState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TuiConfigViewState {
+    pub fn new() -> Self {
+        Self { selected_field: 0 }
+    }
+
+    pub fn select_next_field(&mut self) {
+        self.selected_field = (self.selected_field + 1) % 2;
+    }
+
+    pub fn select_prev_field(&mut self) {
+        if self.selected_field == 0 {
+            self.selected_field = 1;
+        } else {
+            self.selected_field -= 1;
+        }
+    }
+
+    pub fn adjust_current(&mut self, delta: i32, config: &mut TuiConfig) {
+        match self.selected_field {
+            0 => {
+                let current = config.command_popup_max_width as i32;
+                let next = (current + delta * 5).clamp(40, 200) as u16;
+                config.command_popup_max_width = next;
+            }
+            1 => {
+                let current = config.command_popup_max_visible as i32;
+                let next = (current + delta).clamp(3, 20) as usize;
+                config.command_popup_max_visible = next;
+            }
+            _ => {}
+        }
+        let _ = config.save();
+    }
+
+    pub fn reset_defaults(&mut self, config: &mut TuiConfig) {
+        *config = TuiConfig::default();
+        let _ = config.save();
+    }
+}
+
+fn render_slider(value: f32, total_width: usize) -> String {
+    let clamped = value.clamp(0.0, 1.0);
+    let filled = (clamped * total_width as f32).round() as usize;
+    let empty = total_width.saturating_sub(filled);
+    format!("[{}{}]", "█".repeat(filled), "░".repeat(empty))
+}
+
+pub fn render_tui_config_view(
+    f: &mut Frame,
+    area: Rect,
+    state: &TuiConfigViewState,
+    config: &TuiConfig,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Theme::accent()))
+        .title(Span::styled(" TUI Configuration ", Theme::title()));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Top description
+            Constraint::Min(10),   // Controls and Live Preview
+            Constraint::Length(2), // Bottom key hints
+        ])
+        .split(inner);
+
+    // 1. Top Header Description
+    let desc_lines = vec![
+        Line::from(vec![
+            Span::styled("TUI Display & Layout Options: ", Theme::header_label()),
+            Span::styled(
+                "Configure command menu dimensions and popup sizing.",
+                Style::default().fg(Theme::fg()).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![Span::styled(
+            "Settings are saved automatically to ~/.config/srelens/tui.json and applied immediately.",
+            Style::default().fg(Theme::dim()),
+        )]),
+    ];
+    f.render_widget(Paragraph::new(desc_lines), chunks[0]);
+
+    // 2. Middle Region: Controls (left) & Live Preview (right) or stacked if narrow
+    let (controls_area, preview_area) = if chunks[1].width >= 90 {
+        let h_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+            .split(chunks[1]);
+        (h_chunks[0], h_chunks[1])
+    } else {
+        let v_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(12), Constraint::Min(8)])
+            .split(chunks[1]);
+        (v_chunks[0], v_chunks[1])
+    };
+
+    // Setting cards
+    let control_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(6), // Width card
+            Constraint::Length(6), // Visible rows card
+            Constraint::Min(0),
+        ])
+        .split(controls_area);
+
+    // Setting 0: Command Popup Max Width
+    let is_width_selected = state.selected_field == 0;
+    let width_border_color = if is_width_selected {
+        Theme::cyan()
+    } else {
+        Theme::border()
+    };
+    let width_title = if is_width_selected {
+        " ▶ Command Popup Max Width "
+    } else {
+        "   Command Popup Max Width "
+    };
+    let width_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(width_border_color))
+        .title(Span::styled(
+            width_title,
+            if is_width_selected {
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Theme::fg())
+            },
+        ));
+    let width_inner = width_block.inner(control_chunks[0]);
+    f.render_widget(width_block, control_chunks[0]);
+
+    let width_val = config.command_popup_max_width;
+    let width_pct = (width_val.saturating_sub(40) as f32) / (160.0);
+    let slider_width = (width_inner.width.saturating_sub(4) as usize).min(24).max(10);
+    let width_lines = vec![
+        Line::from(vec![
+            Span::styled("Width: ", Style::default().fg(Theme::dim())),
+            Span::styled(
+                format!("{width_val:>3} cols "),
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(render_slider(width_pct, slider_width), Style::default().fg(Theme::accent())),
+            Span::styled(" [40..=200]", Style::default().fg(Theme::dim())),
+        ]),
+        Line::from(vec![
+            Span::styled("Step: ±5  |  Use ", Style::default().fg(Theme::dim())),
+            Span::styled("h/l", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("←/→", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("-/+", Style::default().fg(Theme::yellow())),
+            Span::styled(" to adjust", Style::default().fg(Theme::dim())),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(width_lines), width_inner);
+
+    // Setting 1: Command Popup Max Visible Rows
+    let is_rows_selected = state.selected_field == 1;
+    let rows_border_color = if is_rows_selected {
+        Theme::cyan()
+    } else {
+        Theme::border()
+    };
+    let rows_title = if is_rows_selected {
+        " ▶ Command Popup Max Visible Rows "
+    } else {
+        "   Command Popup Max Visible Rows "
+    };
+    let rows_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(rows_border_color))
+        .title(Span::styled(
+            rows_title,
+            if is_rows_selected {
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Theme::fg())
+            },
+        ));
+    let rows_inner = rows_block.inner(control_chunks[1]);
+    f.render_widget(rows_block, control_chunks[1]);
+
+    let rows_val = config.command_popup_max_visible;
+    let rows_pct = (rows_val.saturating_sub(3) as f32) / (17.0);
+    let slider_rows = (rows_inner.width.saturating_sub(4) as usize).min(24).max(10);
+    let rows_lines = vec![
+        Line::from(vec![
+            Span::styled("Rows:  ", Style::default().fg(Theme::dim())),
+            Span::styled(
+                format!("{rows_val:>3} rows "),
+                Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(render_slider(rows_pct, slider_rows), Style::default().fg(Theme::accent())),
+            Span::styled(" [3..=20]", Style::default().fg(Theme::dim())),
+        ]),
+        Line::from(vec![
+            Span::styled("Step: ±1  |  Use ", Style::default().fg(Theme::dim())),
+            Span::styled("h/l", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("←/→", Style::default().fg(Theme::yellow())),
+            Span::styled(" or ", Style::default().fg(Theme::dim())),
+            Span::styled("-/+", Style::default().fg(Theme::yellow())),
+            Span::styled(" to adjust", Style::default().fg(Theme::dim())),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(rows_lines), rows_inner);
+
+    // 3. Live Preview of Command Popup
+    let preview_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(Theme::border_type())
+        .border_style(Style::default().fg(Theme::border()))
+        .title(Span::styled(
+            " Live Preview: Command Popup (:) ",
+            Style::default().fg(Theme::accent()).add_modifier(Modifier::BOLD),
+        ));
+    let preview_inner = preview_block.inner(preview_area);
+    f.render_widget(preview_block, preview_area);
+
+    if preview_inner.height >= 4 && preview_inner.width >= 20 {
+        // Simulated statusbar at bottom of preview area
+        let sim_bar_y = preview_inner.y + preview_inner.height.saturating_sub(1);
+        let sim_bar_area = Rect {
+            x: preview_inner.x,
+            y: sim_bar_y,
+            width: preview_inner.width,
+            height: 1,
+        };
+        let sim_cmd_line = Line::from(vec![
+            Span::styled(":", Theme::prompt()),
+            Span::styled("po", Style::default().fg(Theme::fg())),
+            Span::styled("█", Style::default().fg(Theme::cyan())),
+        ]);
+        f.render_widget(Paragraph::new(sim_cmd_line), sim_bar_area);
+
+        // Compute popup area relative to sim_bar_area using command_popup_rect
+        let calc_popup = command_popup_rect(
+            sim_bar_area,
+            SAMPLE_SUGGESTIONS.len(),
+            config.command_popup_max_width,
+            config.command_popup_max_visible,
+        );
+
+        // Clamp popup vertically so it stays within preview_inner
+        let max_avail_height = preview_inner.height.saturating_sub(1);
+        let popup_height = calc_popup.height.min(max_avail_height);
+        let popup_y = sim_bar_y.saturating_sub(popup_height).max(preview_inner.y);
+        let popup_width = calc_popup.width.min(preview_inner.width.saturating_sub(2));
+
+        let popup_area = Rect {
+            x: preview_inner.x + 1,
+            y: popup_y,
+            width: popup_width,
+            height: popup_height,
+        };
+
+        f.render_widget(Clear, popup_area);
+
+        let max_visible = config.command_popup_max_visible;
+        let visible_count = SAMPLE_SUGGESTIONS.len().min(max_visible);
+        let visible_slice = &SAMPLE_SUGGESTIONS[0..visible_count];
+
+        let items: Vec<ListItem> = visible_slice
+            .iter()
+            .enumerate()
+            .map(|(i, (name, aliases, desc))| {
+                let is_selected = i == 0;
+                let prefix = if is_selected { "▶ " } else { "  " };
+                let alias_str = if !aliases.is_empty() {
+                    format!(" ({})", aliases.join(", "))
+                } else {
+                    String::new()
+                };
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!("{}{}{:<18}", prefix, name, alias_str),
+                        if is_selected {
+                            Style::default().fg(Theme::cyan()).add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(Theme::fg())
+                        },
+                    ),
+                    Span::styled(format!("  {}", desc), Style::default().fg(Theme::dim())),
+                ]);
+                ListItem::new(line).style(if is_selected {
+                    Theme::selected_row()
+                } else {
+                    Style::default()
+                })
+            })
+            .collect();
+
+        let title = if SAMPLE_SUGGESTIONS.len() > max_visible {
+            format!(
+                " Commands [1/{}] (Tab: complete, Enter: run) ",
+                SAMPLE_SUGGESTIONS.len()
+            )
+        } else {
+            " Commands (Tab to complete, Enter to run) ".to_string()
+        };
+
+        let list = List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(Theme::border_type())
+                .border_style(Style::default().fg(Theme::accent()))
+                .title(title),
+        );
+        f.render_widget(list, popup_area);
+    }
+
+    // 4. Bottom Key Hints
+    let hints_line = Line::from(vec![
+        Span::styled("<j/k or ↑/↓> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+        Span::styled("Select  ", Style::default().fg(Theme::dim())),
+        Span::styled("<h/l, ←/→, -/+> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+        Span::styled("Adjust  ", Style::default().fg(Theme::dim())),
+        Span::styled("<r> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+        Span::styled("Reset Defaults  ", Style::default().fg(Theme::dim())),
+        Span::styled("<Esc or q> ", Style::default().fg(Theme::yellow()).add_modifier(Modifier::BOLD)),
+        Span::styled("Back", Style::default().fg(Theme::dim())),
+    ]);
+    f.render_widget(Paragraph::new(hints_line), chunks[2]);
+}

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -3413,15 +3413,72 @@ async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
     press(&mut app, key(KeyCode::Enter)).await;
     assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::ExtraLarge);
 
+    // Switch to startup banner field with 'j'
+    press(&mut app, ch('j')).await;
+    if let ActiveView::TuiConfig(ref s) = app.active_view {
+        assert_eq!(s.selected_field, 3);
+    }
+
+    // Toggle startup banner with Space
+    assert!(app.tui_config.show_feature_banner);
+    press(&mut app, ch(' ')).await;
+    assert!(!app.tui_config.show_feature_banner);
+
+    // Toggle back with Enter
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(app.tui_config.show_feature_banner);
+
     // Reset defaults with 'r'
     press(&mut app, ch('r')).await;
     assert_eq!(app.tui_config.command_popup_max_width, 65);
     assert_eq!(app.tui_config.command_popup_max_visible, 6);
     assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Compact);
+    assert!(app.tui_config.show_feature_banner);
 
     // Press Esc pops back to table view
     press(&mut app, key(KeyCode::Esc)).await;
     assert!(matches!(app.active_view, ActiveView::Table(_)));
+
+    std::env::remove_var("SRELENS_TUI_CONFIG_PATH");
+}
+
+#[tokio::test]
+async fn feature_banner_modal_interactive_navigation_toggle_and_jump() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_file = tmp.path().join("tui.json");
+    std::env::set_var("SRELENS_TUI_CONFIG_PATH", &config_file);
+
+    let (mut app, _rx) = common::app_with("fake-cluster", "default").await;
+
+    // Open via :banner command
+    common::type_str(&mut app, ":banner").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.modal, Some(Modal::FeatureBanner { .. })));
+
+    // Toggle startup banner with 't'
+    assert!(app.tui_config.show_feature_banner);
+    press(&mut app, ch('t')).await;
+    assert!(!app.tui_config.show_feature_banner);
+    assert!(matches!(app.modal, Some(Modal::FeatureBanner { show_on_startup: false })));
+
+    // Toggle back with 'T'
+    press(&mut app, ch('T')).await;
+    assert!(app.tui_config.show_feature_banner);
+    assert!(matches!(app.modal, Some(Modal::FeatureBanner { show_on_startup: true })));
+
+    // Press '1' jumps directly to Helm releases
+    press(&mut app, ch('1')).await;
+    assert!(app.modal.is_none());
+    assert!(matches!(app.active_view, ActiveView::Helm(_)));
+
+    // Re-open via :features
+    common::type_str(&mut app, ":features").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert!(matches!(app.modal, Some(Modal::FeatureBanner { .. })));
+
+    // Dismiss with Esc
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(app.modal.is_none());
 
     std::env::remove_var("SRELENS_TUI_CONFIG_PATH");
 }

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -3393,17 +3393,25 @@ async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
         assert_eq!(s.selected_field, 2);
     }
 
-    // Toggle density to Large with 'l'
+    // Step density to Standard with 'l'
+    press(&mut app, ch('l')).await;
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Standard);
+
+    // Step to Large with 'l'
     press(&mut app, ch('l')).await;
     assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Large);
 
-    // Toggle back to Compact with Space
-    press(&mut app, ch(' ')).await;
-    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Compact);
+    // Step back to Standard with 'h'
+    press(&mut app, ch('h')).await;
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Standard);
 
-    // Toggle to Large with Enter
-    press(&mut app, key(KeyCode::Enter)).await;
+    // Cycle forward with Space (Standard -> Large)
+    press(&mut app, ch(' ')).await;
     assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Large);
+
+    // Cycle forward with Enter (Large -> ExtraLarge)
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::ExtraLarge);
 
     // Reset defaults with 'r'
     press(&mut app, ch('r')).await;

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use srelens_kube::contexts::ContextDto;
 use srelens_tui::app::{ActiveView, App, SuspendAction};
 use srelens_tui::commands::{command_suggestions_with_crds, CrdMeta, PrinterColumn, ResourceKind};
+use srelens_tui::CommandPopupDensity;
 use srelens_tui::event::AppEvent;
 use srelens_tui::ui::{ContainerAction, InputMode, Modal};
 use srelens_tui::views::metrics_panel_view::MetricsTimeRange;
@@ -3335,6 +3336,10 @@ async fn helm_detail_manifest_search_and_navigation_input_flow() {
 
 #[tokio::test]
 async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("tui.json");
+    std::env::set_var("SRELENS_TUI_CONFIG_PATH", &config_path);
+
     let (tx, _rx) = unbounded_channel();
     let mut app = App::new(
         Some("test-ctx".into()),
@@ -3346,10 +3351,6 @@ async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
     )
     .await
     .expect("app");
-
-    let temp = tempfile::tempdir().unwrap();
-    let config_path = temp.path().join("tui.json");
-    std::env::set_var("SRELENS_TUI_CONFIG_PATH", &config_path);
 
     // Initial state: pods table
     assert!(matches!(app.active_view, ActiveView::Table(_)));
@@ -3366,6 +3367,7 @@ async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
     // Initial config values
     assert_eq!(app.tui_config.command_popup_max_width, 65);
     assert_eq!(app.tui_config.command_popup_max_visible, 6);
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Compact);
 
     // Adjust width (+5 with 'l')
     press(&mut app, ch('l')).await;
@@ -3385,10 +3387,29 @@ async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
     press(&mut app, ch('+')).await;
     assert_eq!(app.tui_config.command_popup_max_visible, 7);
 
+    // Switch to text size/density field with 'j'
+    press(&mut app, ch('j')).await;
+    if let ActiveView::TuiConfig(ref s) = app.active_view {
+        assert_eq!(s.selected_field, 2);
+    }
+
+    // Toggle density to Large with 'l'
+    press(&mut app, ch('l')).await;
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Large);
+
+    // Toggle back to Compact with Space
+    press(&mut app, ch(' ')).await;
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Compact);
+
+    // Toggle to Large with Enter
+    press(&mut app, key(KeyCode::Enter)).await;
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Large);
+
     // Reset defaults with 'r'
     press(&mut app, ch('r')).await;
     assert_eq!(app.tui_config.command_popup_max_width, 65);
     assert_eq!(app.tui_config.command_popup_max_visible, 6);
+    assert_eq!(app.tui_config.command_popup_density, CommandPopupDensity::Compact);
 
     // Press Esc pops back to table view
     press(&mut app, key(KeyCode::Esc)).await;

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -3333,3 +3333,66 @@ async fn helm_detail_manifest_search_and_navigation_input_flow() {
     }
 }
 
+#[tokio::test]
+async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
+    let (tx, _rx) = unbounded_channel();
+    let mut app = App::new(
+        Some("test-ctx".into()),
+        Some("default".into()),
+        false,
+        None,
+        vec![],
+        tx,
+    )
+    .await
+    .expect("app");
+
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("tui.json");
+    std::env::set_var("SRELENS_TUI_CONFIG_PATH", &config_path);
+
+    // Initial state: pods table
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+
+    // Open :config
+    press(&mut app, ch(':')).await;
+    assert_eq!(app.input_mode, InputMode::Command);
+    type_str(&mut app, "config").await;
+    press(&mut app, key(KeyCode::Enter)).await;
+
+    // Active view is now TuiConfig
+    assert!(matches!(app.active_view, ActiveView::TuiConfig(_)));
+
+    // Initial config values
+    assert_eq!(app.tui_config.command_popup_max_width, 65);
+    assert_eq!(app.tui_config.command_popup_max_visible, 6);
+
+    // Adjust width (+5 with 'l')
+    press(&mut app, ch('l')).await;
+    assert_eq!(app.tui_config.command_popup_max_width, 70);
+
+    // Adjust width (-5 with 'h')
+    press(&mut app, ch('h')).await;
+    assert_eq!(app.tui_config.command_popup_max_width, 65);
+
+    // Switch to visible rows field with 'j'
+    press(&mut app, ch('j')).await;
+    if let ActiveView::TuiConfig(ref s) = app.active_view {
+        assert_eq!(s.selected_field, 1);
+    }
+
+    // Adjust visible rows (+1 with '+')
+    press(&mut app, ch('+')).await;
+    assert_eq!(app.tui_config.command_popup_max_visible, 7);
+
+    // Reset defaults with 'r'
+    press(&mut app, ch('r')).await;
+    assert_eq!(app.tui_config.command_popup_max_width, 65);
+    assert_eq!(app.tui_config.command_popup_max_visible, 6);
+
+    // Press Esc pops back to table view
+    press(&mut app, key(KeyCode::Esc)).await;
+    assert!(matches!(app.active_view, ActiveView::Table(_)));
+
+    std::env::remove_var("SRELENS_TUI_CONFIG_PATH");
+}

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -2369,3 +2369,28 @@ async fn the_app_renders_helm_and_helm_detail_views_across_all_tabs() {
     let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
     assert!(text.contains("Chart Release Notes") && text.contains("everything is ready"), "{text}");
 }
+
+#[test]
+fn feature_banner_modal_renders_all_highlighted_features_and_toggle_state() {
+    let modal_enabled = Modal::FeatureBanner { show_on_startup: true };
+    let text_enabled = modal_text(100, 30, &modal_enabled);
+
+    assert!(text_enabled.contains("Welcome to SRElens — Feature Highlights"), "has header title");
+    assert!(text_enabled.contains(":helm"), "shows helm command");
+    assert!(text_enabled.contains(":overview"), "shows overview command");
+    assert!(text_enabled.contains(":gpuinfo"), "shows gpuinfo command");
+    assert!(text_enabled.contains(":workloads"), "shows workloads command");
+    assert!(text_enabled.contains(":ai"), "shows ai assistant command");
+    assert!(text_enabled.contains(":ai-settings"), "shows ai-settings command");
+    assert!(text_enabled.contains(":config"), "shows config command");
+    assert!(text_enabled.contains("[●]"), "shows enabled checkbox dot");
+    assert!(text_enabled.contains("Show this feature banner on startup"), "shows checkbox label");
+    assert!(text_enabled.contains("to dismiss"), "shows dismiss key hint");
+    assert!(text_enabled.contains("to jump directly"), "shows jump hint");
+
+    let modal_disabled = Modal::FeatureBanner { show_on_startup: false };
+    let text_disabled = modal_text(100, 30, &modal_disabled);
+    assert!(text_disabled.contains("[○]"), "shows unchecked checkbox");
+    assert!(text_disabled.contains("Disabled"), "shows disabled state");
+}
+

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -23,6 +23,7 @@ use srelens_tui::ui::dialogs::{
 use srelens_tui::ui::header::{render_header, ContextChipInfo, HeaderProps};
 use srelens_tui::ui::help::{centered_rect, render_help_modal};
 use srelens_tui::ui::statusbar::{command_popup_rect, render_statusbar, InputMode, StatusBarProps};
+use srelens_tui::CommandPopupDensity;
 use srelens_tui::views::assistant_view::{
     format_message_content, format_message_content_with_width, parse_inline_markdown,
     render_assistant_view, render_markdown_table, wrap_line, AssistantViewState, ChatMessage,
@@ -118,6 +119,7 @@ fn status_props(mode: &InputMode) -> StatusBarProps<'_> {
         close_pf_rect: None,
         command_popup_max_width: None,
         command_popup_max_visible: None,
+        command_popup_density: None,
     }
 }
 
@@ -903,23 +905,27 @@ fn command_mode_pops_up_the_matching_commands_above_the_bar_and_arrows_the_selec
 #[test]
 fn command_popup_geometry_respects_max_width_and_visible_rows() {
     let bar_area = Rect::new(0, 22, 80, 2);
-    // 2 items, max_visible 6 -> 2 items + 2 borders = 4 height, width 80 - 4 = 76 min 65 = 65
-    let r1 = command_popup_rect(bar_area, 2, 65, 6);
+    // 2 items, max_visible 6, Compact (1 row/item) -> 2 items + 2 borders = 4 height, width 80 - 4 = 76 min 65 = 65
+    let r1 = command_popup_rect(bar_area, 2, 65, 6, CommandPopupDensity::Compact);
     assert_eq!(r1, Rect::new(2, 18, 65, 4));
 
-    // 10 items, max_visible 6 -> 6 items + 2 borders = 8 height
-    let r2 = command_popup_rect(bar_area, 10, 65, 6);
+    // 10 items, max_visible 6, Compact -> 6 items + 2 borders = 8 height
+    let r2 = command_popup_rect(bar_area, 10, 65, 6, CommandPopupDensity::Compact);
     assert_eq!(r2, Rect::new(2, 14, 65, 8));
 
     // Narrow terminal: 50 cols, max_width 65 -> clamped to 50 - 4 = 46
     let narrow_bar = Rect::new(0, 22, 50, 2);
-    let r3 = command_popup_rect(narrow_bar, 5, 65, 6);
+    let r3 = command_popup_rect(narrow_bar, 5, 65, 6, CommandPopupDensity::Compact);
     assert_eq!(r3, Rect::new(2, 15, 46, 7));
 
     // Wide terminal with custom config: 160 cols, 10 items, max_width 120, max_visible 10
     let wide_bar = Rect::new(0, 22, 160, 2);
-    let r4 = command_popup_rect(wide_bar, 10, 120, 10);
+    let r4 = command_popup_rect(wide_bar, 10, 120, 10, CommandPopupDensity::Compact);
     assert_eq!(r4, Rect::new(2, 10, 120, 12));
+
+    // Large density mode: 5 items, max_visible 6 -> 5 items * 2 rows = 10 rows + 2 borders = 12 height
+    let r5 = command_popup_rect(bar_area, 5, 65, 6, CommandPopupDensity::Large);
+    assert_eq!(r5, Rect::new(2, 10, 65, 12));
 }
 
 #[test]
@@ -933,6 +939,7 @@ fn command_popup_rendering_expands_to_configured_width_and_visible_rows() {
     props.suggestions = Some((&suggs, 0));
     props.command_popup_max_width = Some(110);
     props.command_popup_max_visible = Some(10);
+    props.command_popup_density = Some(CommandPopupDensity::Compact);
 
     let lines = common::render_lines(160, 24, |f| {
         render_statusbar(f, Rect::new(0, 22, 160, 2), props)
@@ -951,6 +958,40 @@ fn command_popup_rendering_expands_to_configured_width_and_visible_rows() {
     assert!(
         header_line.trim_end().len() >= 108,
         "popup border should extend to configured max width of 110, got line: {header_line}"
+    );
+}
+
+#[test]
+fn command_popup_rendering_large_density_mode() {
+    let suggs = command_suggestions("");
+    assert!(suggs.len() >= 5, "empty query matches all commands");
+
+    let mode = InputMode::Command;
+    let mut props = status_props(&mode);
+    props.command_input = "";
+    props.suggestions = Some((&suggs, 0));
+    props.command_popup_max_width = Some(90);
+    props.command_popup_max_visible = Some(4);
+    props.command_popup_density = Some(CommandPopupDensity::Large);
+
+    let lines = common::render_lines(120, 24, |f| {
+        render_statusbar(f, Rect::new(0, 22, 120, 2), props)
+    });
+
+    // With 4 visible items in Large mode: 4 * 2 = 8 rows + 2 borders = 10 rows tall.
+    // Base bar at y=22 -> popup top at y = 22 - 10 = 12.
+    let popup_title_row = lines
+        .iter()
+        .position(|l| l.contains("Commands [1/"))
+        .expect("popup title present");
+    assert_eq!(popup_title_row, 12, "top border of large popup is at y=12");
+
+    // Large mode renders bold uppercase command names
+    let content_lines = &lines[popup_title_row + 1..22];
+    let rendered_text = content_lines.join("\n");
+    assert!(
+        rendered_text.contains("THEMES") || rendered_text.contains("WORKLOADS") || rendered_text.contains("PODS"),
+        "large mode renders uppercase command names, got:\n{rendered_text}"
     );
 }
 

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -926,6 +926,10 @@ fn command_popup_geometry_respects_max_width_and_visible_rows() {
     // Large density mode: 5 items, max_visible 6 -> 5 items * 2 rows = 10 rows + 2 borders = 12 height
     let r5 = command_popup_rect(bar_area, 5, 65, 6, CommandPopupDensity::Large);
     assert_eq!(r5, Rect::new(2, 10, 65, 12));
+
+    // ExtraLarge density mode: 3 items, max_visible 6 -> 3 items * 3 rows = 9 rows + 2 borders = 11 height
+    let r6 = command_popup_rect(bar_area, 3, 65, 6, CommandPopupDensity::ExtraLarge);
+    assert_eq!(r6, Rect::new(2, 11, 65, 11));
 }
 
 #[test]
@@ -992,6 +996,40 @@ fn command_popup_rendering_large_density_mode() {
     assert!(
         rendered_text.contains("THEMES") || rendered_text.contains("WORKLOADS") || rendered_text.contains("PODS"),
         "large mode renders uppercase command names, got:\n{rendered_text}"
+    );
+}
+
+#[test]
+fn command_popup_rendering_extra_large_density_mode() {
+    let suggs = command_suggestions("");
+    assert!(suggs.len() >= 3, "empty query matches all commands");
+
+    let mode = InputMode::Command;
+    let mut props = status_props(&mode);
+    props.command_input = "";
+    props.suggestions = Some((&suggs, 0));
+    props.command_popup_max_width = Some(100);
+    props.command_popup_max_visible = Some(3);
+    props.command_popup_density = Some(CommandPopupDensity::ExtraLarge);
+
+    let lines = common::render_lines(120, 24, |f| {
+        render_statusbar(f, Rect::new(0, 22, 120, 2), props)
+    });
+
+    // With 3 visible items in ExtraLarge mode: 3 * 3 = 9 rows + 2 borders = 11 rows tall.
+    // Base bar at y=22 -> popup top at y = 22 - 11 = 11.
+    let popup_title_row = lines
+        .iter()
+        .position(|l| l.contains("Commands [1/"))
+        .expect("popup title present");
+    assert_eq!(popup_title_row, 11, "top border of extra large popup is at y=11");
+
+    // ExtraLarge mode renders 3 lines per item including Usage line
+    let content_lines = &lines[popup_title_row + 1..22];
+    let rendered_text = content_lines.join("\n");
+    assert!(
+        rendered_text.contains("Usage:"),
+        "extra large mode renders usage line, got:\n{rendered_text}"
     );
 }
 

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -22,7 +22,7 @@ use srelens_tui::ui::dialogs::{
 };
 use srelens_tui::ui::header::{render_header, ContextChipInfo, HeaderProps};
 use srelens_tui::ui::help::{centered_rect, render_help_modal};
-use srelens_tui::ui::statusbar::{render_statusbar, InputMode, StatusBarProps};
+use srelens_tui::ui::statusbar::{command_popup_rect, render_statusbar, InputMode, StatusBarProps};
 use srelens_tui::views::assistant_view::{
     format_message_content, format_message_content_with_width, parse_inline_markdown,
     render_assistant_view, render_markdown_table, wrap_line, AssistantViewState, ChatMessage,
@@ -116,6 +116,8 @@ fn status_props(mode: &InputMode) -> StatusBarProps<'_> {
         suggestions: None,
         close_pf_button: None,
         close_pf_rect: None,
+        command_popup_max_width: None,
+        command_popup_max_visible: None,
     }
 }
 
@@ -896,6 +898,60 @@ fn command_mode_pops_up_the_matching_commands_above_the_bar_and_arrows_the_selec
         .unwrap();
     assert!(popup_row < 22, "popup opens above the bar");
     assert!(lines[23].starts_with(":po█"), "{:?}", lines[23]);
+}
+
+#[test]
+fn command_popup_geometry_respects_max_width_and_visible_rows() {
+    let bar_area = Rect::new(0, 22, 80, 2);
+    // 2 items, max_visible 6 -> 2 items + 2 borders = 4 height, width 80 - 4 = 76 min 65 = 65
+    let r1 = command_popup_rect(bar_area, 2, 65, 6);
+    assert_eq!(r1, Rect::new(2, 18, 65, 4));
+
+    // 10 items, max_visible 6 -> 6 items + 2 borders = 8 height
+    let r2 = command_popup_rect(bar_area, 10, 65, 6);
+    assert_eq!(r2, Rect::new(2, 14, 65, 8));
+
+    // Narrow terminal: 50 cols, max_width 65 -> clamped to 50 - 4 = 46
+    let narrow_bar = Rect::new(0, 22, 50, 2);
+    let r3 = command_popup_rect(narrow_bar, 5, 65, 6);
+    assert_eq!(r3, Rect::new(2, 15, 46, 7));
+
+    // Wide terminal with custom config: 160 cols, 10 items, max_width 120, max_visible 10
+    let wide_bar = Rect::new(0, 22, 160, 2);
+    let r4 = command_popup_rect(wide_bar, 10, 120, 10);
+    assert_eq!(r4, Rect::new(2, 10, 120, 12));
+}
+
+#[test]
+fn command_popup_rendering_expands_to_configured_width_and_visible_rows() {
+    let suggs = command_suggestions("");
+    assert!(suggs.len() >= 10, "empty query matches all commands");
+
+    let mode = InputMode::Command;
+    let mut props = status_props(&mode);
+    props.command_input = "";
+    props.suggestions = Some((&suggs, 0));
+    props.command_popup_max_width = Some(110);
+    props.command_popup_max_visible = Some(10);
+
+    let lines = common::render_lines(160, 24, |f| {
+        render_statusbar(f, Rect::new(0, 22, 160, 2), props)
+    });
+
+    // With max_visible = 10, popup has 10 items + 2 borders = 12 rows tall.
+    // Base bar starts at y=22, so popup top is at y = 22 - 12 = 10.
+    let popup_title_row = lines
+        .iter()
+        .position(|l| l.contains("Commands [1/"))
+        .expect("popup title present");
+    assert_eq!(popup_title_row, 10, "top border of popup is at y=10");
+
+    // Check width of the box header line: title line should span ~110 chars
+    let header_line = &lines[popup_title_row];
+    assert!(
+        header_line.trim_end().len() >= 108,
+        "popup border should extend to configured max width of 110, got line: {header_line}"
+    );
 }
 
 #[test]

--- a/apps/tui/tests/core_logic_tests.rs
+++ b/apps/tui/tests/core_logic_tests.rs
@@ -1966,6 +1966,7 @@ fn tui_config_file_paths_clamping_and_round_trip() {
         command_popup_max_width: 120,
         command_popup_max_visible: 12,
         command_popup_density: CommandPopupDensity::Large,
+        show_feature_banner: true,
     };
     cfg.save().expect("save succeeds");
     assert!(file.is_file());
@@ -1981,21 +1982,25 @@ fn tui_config_file_paths_clamping_and_round_trip() {
         command_popup_max_width: 500,
         command_popup_max_visible: 1,
         command_popup_density: CommandPopupDensity::Compact,
+        show_feature_banner: true,
     };
     clamped.clamp();
     assert_eq!(clamped.command_popup_max_width, 200);
     assert_eq!(clamped.command_popup_max_visible, 3);
     assert_eq!(clamped.command_popup_density, CommandPopupDensity::Compact);
+    assert!(clamped.show_feature_banner);
 
     let mut low = TuiConfig {
         command_popup_max_width: 10,
         command_popup_max_visible: 99,
         command_popup_density: CommandPopupDensity::Large,
+        show_feature_banner: false,
     };
     low.clamp();
     assert_eq!(low.command_popup_max_width, 40);
     assert_eq!(low.command_popup_max_visible, 20);
     assert_eq!(low.command_popup_density, CommandPopupDensity::Large);
+    assert!(!low.show_feature_banner);
 
     // 5. Corrupt file gracefully falls back to default
     std::fs::write(&file, "{ corrupt json").unwrap();

--- a/apps/tui/tests/core_logic_tests.rs
+++ b/apps/tui/tests/core_logic_tests.rs
@@ -36,6 +36,7 @@ use srelens_tui::deep_link::DeepLink;
 use srelens_tui::event::{AppEvent, EventHandler};
 use srelens_tui::sink::TuiSink;
 use srelens_tui::theme::{status_style, Theme};
+use srelens_tui::tui_config::TuiConfig;
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -1307,6 +1308,10 @@ fn view_links_format_every_target_kind() {
         "srelens://view/prod/_/settings"
     );
     assert_eq!(
+        view(CommandTarget::Resource(ResourceKind::TuiConfig)),
+        "srelens://view/prod/_/config"
+    );
+    assert_eq!(
         view(CommandTarget::Resource(ResourceKind::Deployments)),
         "srelens://view/prod/_/deployments"
     );
@@ -1525,6 +1530,7 @@ fn all_static_kinds() -> Vec<ResourceKind> {
         ResourceKind::Toolbox,
         ResourceKind::Assistant,
         ResourceKind::Settings,
+        ResourceKind::TuiConfig,
         ResourceKind::Workloads,
     ]
 }
@@ -1570,6 +1576,7 @@ fn watch_kinds_are_lowercase_plurals_for_watchable_kinds_only() {
                         | ResourceKind::Toolbox
                         | ResourceKind::Assistant
                         | ResourceKind::Settings
+                        | ResourceKind::TuiConfig
                         | ResourceKind::Workloads
                 ),
                 "{kind:?} unexpectedly has no watch kind"
@@ -1606,6 +1613,7 @@ fn k8s_kinds_are_singular_pascal_case_and_crds_use_their_own_kind() {
                         | ResourceKind::Toolbox
                         | ResourceKind::Assistant
                         | ResourceKind::Settings
+                        | ResourceKind::TuiConfig
                         | ResourceKind::Workloads
                 ),
                 "{kind:?} unexpectedly has no k8s kind"
@@ -1928,4 +1936,64 @@ fn crd_suggestions_are_scored_by_exact_prefix_alias_and_group() {
     // A CRD prefix (105) outranks a static name prefix (100) for the same query.
     let both = command_suggestions_with_crds("cilium", &crds);
     assert_eq!(both[0].0.name, "ciliumloadbalancerippools");
+}
+
+#[test]
+fn tui_config_file_paths_clamping_and_round_trip() {
+    struct Restore(Vec<(&'static str, Option<String>)>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+    let vars = ["SRELENS_TUI_CONFIG_PATH", "SRELENS_CONFIG_DIR"];
+    let _restore = Restore(vars.iter().map(|k| (*k, std::env::var(k).ok())).collect());
+
+    // 1. Explicit path override
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("nested").join("tui.json");
+    std::env::set_var("SRELENS_TUI_CONFIG_PATH", &file);
+    std::env::remove_var("SRELENS_CONFIG_DIR");
+    assert_eq!(TuiConfig::config_file_path(), file);
+
+    // 2. Round trip save and load
+    let cfg = TuiConfig {
+        command_popup_max_width: 120,
+        command_popup_max_visible: 12,
+    };
+    cfg.save().expect("save succeeds");
+    assert!(file.is_file());
+    assert_eq!(TuiConfig::load(), cfg);
+
+    // 3. Fallback to SRELENS_CONFIG_DIR
+    std::env::remove_var("SRELENS_TUI_CONFIG_PATH");
+    std::env::set_var("SRELENS_CONFIG_DIR", dir.path());
+    assert_eq!(TuiConfig::config_file_path(), dir.path().join("tui.json"));
+
+    // 4. Clamping out-of-range values
+    let mut clamped = TuiConfig {
+        command_popup_max_width: 500,
+        command_popup_max_visible: 1,
+    };
+    clamped.clamp();
+    assert_eq!(clamped.command_popup_max_width, 200);
+    assert_eq!(clamped.command_popup_max_visible, 3);
+
+    let mut low = TuiConfig {
+        command_popup_max_width: 10,
+        command_popup_max_visible: 99,
+    };
+    low.clamp();
+    assert_eq!(low.command_popup_max_width, 40);
+    assert_eq!(low.command_popup_max_visible, 20);
+
+    // 5. Corrupt file gracefully falls back to default
+    std::fs::write(&file, "{ corrupt json").unwrap();
+    std::env::set_var("SRELENS_TUI_CONFIG_PATH", &file);
+    assert_eq!(TuiConfig::load(), TuiConfig::default());
 }

--- a/apps/tui/tests/core_logic_tests.rs
+++ b/apps/tui/tests/core_logic_tests.rs
@@ -36,7 +36,7 @@ use srelens_tui::deep_link::DeepLink;
 use srelens_tui::event::{AppEvent, EventHandler};
 use srelens_tui::sink::TuiSink;
 use srelens_tui::theme::{status_style, Theme};
-use srelens_tui::tui_config::TuiConfig;
+use srelens_tui::tui_config::{CommandPopupDensity, TuiConfig};
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -1672,7 +1672,7 @@ fn static_commands_convert_to_dynamic_definitions_verbatim() {
     let dynamic = DynamicCommandDef::from(pods);
     assert_eq!(dynamic.name, "pods");
     assert_eq!(dynamic.aliases, vec!["po".to_string(), "pod".to_string()]);
-    assert_eq!(dynamic.description, "Pods view");
+    assert_eq!(dynamic.description, pods.description);
     assert_eq!(dynamic.target, CommandTarget::Resource(ResourceKind::Pods));
 }
 
@@ -1965,6 +1965,7 @@ fn tui_config_file_paths_clamping_and_round_trip() {
     let cfg = TuiConfig {
         command_popup_max_width: 120,
         command_popup_max_visible: 12,
+        command_popup_density: CommandPopupDensity::Large,
     };
     cfg.save().expect("save succeeds");
     assert!(file.is_file());
@@ -1979,18 +1980,22 @@ fn tui_config_file_paths_clamping_and_round_trip() {
     let mut clamped = TuiConfig {
         command_popup_max_width: 500,
         command_popup_max_visible: 1,
+        command_popup_density: CommandPopupDensity::Compact,
     };
     clamped.clamp();
     assert_eq!(clamped.command_popup_max_width, 200);
     assert_eq!(clamped.command_popup_max_visible, 3);
+    assert_eq!(clamped.command_popup_density, CommandPopupDensity::Compact);
 
     let mut low = TuiConfig {
         command_popup_max_width: 10,
         command_popup_max_visible: 99,
+        command_popup_density: CommandPopupDensity::Large,
     };
     low.clamp();
     assert_eq!(low.command_popup_max_width, 40);
     assert_eq!(low.command_popup_max_visible, 20);
+    assert_eq!(low.command_popup_density, CommandPopupDensity::Large);
 
     // 5. Corrupt file gracefully falls back to default
     std::fs::write(&file, "{ corrupt json").unwrap();

--- a/apps/tui/tests/tui_tests.rs
+++ b/apps/tui/tests/tui_tests.rs
@@ -191,6 +191,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -288,6 +289,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -397,6 +399,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -580,6 +583,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -795,6 +799,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -992,6 +997,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -1133,6 +1139,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -1457,6 +1464,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -1587,6 +1595,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -1684,6 +1693,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -1773,6 +1783,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -1903,6 +1914,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -2037,6 +2049,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("data-processing-prod-eu-dus1"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -2196,6 +2209,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("prod-eu"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -2301,6 +2315,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::new(),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -2712,6 +2727,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("prod"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -2835,6 +2851,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("prod"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -3065,6 +3082,7 @@ mod tests {
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
             close_pf_button_rect: std::cell::RefCell::new(None),
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("prod"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -3182,6 +3200,7 @@ mod tests {
             context_chip_rects: std::cell::RefCell::new(Vec::new()),
             close_pf_button_rect: std::cell::RefCell::new(None),
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("shop"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -3296,6 +3315,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -3505,6 +3525,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -3707,6 +3728,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -4552,6 +4574,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -4746,6 +4769,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -4978,6 +5002,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -5116,6 +5141,7 @@ mod tests {
             connection_attempt_start: std::time::Instant::now(),
             cluster_unreachable: false,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -5535,7 +5561,7 @@ mod tests {
         );
         assert_eq!(
             resolve_command(":config"),
-            Some(CommandTarget::Resource(ResourceKind::Settings))
+            Some(CommandTarget::Resource(ResourceKind::TuiConfig))
         );
 
         // 2. Test command resolution when CRD is present
@@ -5555,14 +5581,14 @@ mod tests {
             Some(CommandTarget::CustomResource(setting_crd.clone()))
         );
 
-        // :ai-settings and :config must still resolve to AI Settings
+        // :ai-settings resolves to AI Settings, :config resolves to TuiConfig
         assert_eq!(
             resolve_command_with_crds(":ai-settings", &crds),
             Some(CommandTarget::Resource(ResourceKind::Settings))
         );
         assert_eq!(
             resolve_command_with_crds(":config", &crds),
-            Some(CommandTarget::Resource(ResourceKind::Settings))
+            Some(CommandTarget::Resource(ResourceKind::TuiConfig))
         );
 
         // 3. Test suggestions scoring & ranking
@@ -5942,6 +5968,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -6137,6 +6164,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -6279,6 +6307,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("prod"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,
@@ -6449,6 +6478,7 @@ mod tests {
             cluster_unreachable: false,
             toast: None,
             ai_settings: srelens_tui::AiSettings::default(),
+            tui_config: srelens_tui::TuiConfig::default(),
             assistant_state: srelens_tui::views::assistant_view::AssistantViewState::for_context("default"),
             assistant_states: HashMap::new(),
             pod_metrics_tick_counter: 0,

--- a/apps/tui/tests/views_inspect_tests.rs
+++ b/apps/tui/tests/views_inspect_tests.rs
@@ -26,7 +26,7 @@ use srelens_tui::views::overview_view::{
 use srelens_tui::views::settings_view::{render_settings_view, SettingField, SettingsViewState};
 use srelens_tui::views::tui_config_view::{render_tui_config_view, TuiConfigViewState};
 use srelens_tui::views::yaml_view::{render_yaml_view, YamlViewState};
-use srelens_tui::TuiConfig;
+use srelens_tui::{CommandPopupDensity, TuiConfig};
 
 /// Render one frame and hand back the raw buffer, for the few assertions that
 /// need a cell's style rather than its text.
@@ -2030,16 +2030,29 @@ fn tui_config_view_state_field_navigation_and_adjustments() {
     assert_eq!(state.selected_field, 1);
 
     state.select_next_field();
+    assert_eq!(state.selected_field, 2);
+
+    state.select_next_field();
     assert_eq!(state.selected_field, 0);
 
     state.select_prev_field();
-    assert_eq!(state.selected_field, 1);
+    assert_eq!(state.selected_field, 2);
 
     let mut config = TuiConfig::default();
     assert_eq!(config.command_popup_max_width, 65);
     assert_eq!(config.command_popup_max_visible, 6);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
 
-    // Selected field 1: Visible Rows (step 1, range 3..=20)
+    // Selected field 2: Text size / density toggle
+    state.adjust_current(1, &mut config);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::Large);
+    state.adjust_current(1, &mut config);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
+
+    // Switch to field 1: Visible Rows (step 1, range 3..=20)
+    state.select_prev_field();
+    assert_eq!(state.selected_field, 1);
+
     state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_max_visible, 7);
 
@@ -2066,6 +2079,7 @@ fn tui_config_view_state_field_navigation_and_adjustments() {
     state.reset_defaults(&mut config);
     assert_eq!(config.command_popup_max_width, 65);
     assert_eq!(config.command_popup_max_visible, 6);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
 }
 
 #[test]
@@ -2074,6 +2088,7 @@ fn tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow() {
     let config = TuiConfig {
         command_popup_max_width: 80,
         command_popup_max_visible: 8,
+        command_popup_density: CommandPopupDensity::Compact,
     };
 
     // Wide render (120x30)
@@ -2085,6 +2100,7 @@ fn tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow() {
     assert!(full.contains("TUI Configuration"), "has title");
     assert!(full.contains("Command Popup Max Width"), "has width setting card");
     assert!(full.contains("Command Popup Max Visible Rows"), "has rows setting card");
+    assert!(full.contains("Command Popup Text Size"), "has text size setting card");
     assert!(full.contains("80 cols"), "shows configured width");
     assert!(full.contains("8 rows"), "shows configured visible rows");
     assert!(full.contains("Live Preview: Command Popup"), "shows live preview title");
@@ -2098,5 +2114,6 @@ fn tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow() {
     let narrow_full = narrow_lines.join("\n");
     assert!(narrow_full.contains("TUI Configuration"));
     assert!(narrow_full.contains("Command Popup Max Width"));
+    assert!(narrow_full.contains("Command Popup Text Size"));
 }
 

--- a/apps/tui/tests/views_inspect_tests.rs
+++ b/apps/tui/tests/views_inspect_tests.rs
@@ -2033,17 +2033,30 @@ fn tui_config_view_state_field_navigation_and_adjustments() {
     assert_eq!(state.selected_field, 2);
 
     state.select_next_field();
+    assert_eq!(state.selected_field, 3);
+
+    state.select_next_field();
     assert_eq!(state.selected_field, 0);
 
     state.select_prev_field();
-    assert_eq!(state.selected_field, 2);
+    assert_eq!(state.selected_field, 3);
 
     let mut config = TuiConfig::default();
     assert_eq!(config.command_popup_max_width, 65);
     assert_eq!(config.command_popup_max_visible, 6);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
+    assert!(config.show_feature_banner);
 
-    // Selected field 2: Text size / density slider (1..=4)
+    // Selected field 3: Startup Feature Banner toggle
+    state.adjust_current(1, &mut config);
+    assert!(!config.show_feature_banner);
+    state.cycle_current(&mut config);
+    assert!(config.show_feature_banner);
+
+    // Switch to field 2: Text size / density slider (1..=4)
+    state.select_prev_field();
+    assert_eq!(state.selected_field, 2);
+
     state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Standard);
     state.adjust_current(1, &mut config);
@@ -2090,6 +2103,7 @@ fn tui_config_view_state_field_navigation_and_adjustments() {
     assert_eq!(config.command_popup_max_width, 65);
     assert_eq!(config.command_popup_max_visible, 6);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
+    assert!(config.show_feature_banner);
 }
 
 #[test]
@@ -2099,6 +2113,7 @@ fn tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow() {
         command_popup_max_width: 80,
         command_popup_max_visible: 8,
         command_popup_density: CommandPopupDensity::Compact,
+        show_feature_banner: true,
     };
 
     // Wide render (120x30)
@@ -2111,11 +2126,22 @@ fn tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow() {
     assert!(full.contains("Command Popup Max Width"), "has width setting card");
     assert!(full.contains("Command Popup Max Visible Rows"), "has rows setting card");
     assert!(full.contains("Command Popup Text Size"), "has text size setting card");
+    assert!(full.contains("Startup Feature Banner"), "has startup banner setting card");
     assert!(full.contains("80 cols"), "shows configured width");
     assert!(full.contains("8 rows"), "shows configured visible rows");
     assert!(full.contains("Live Preview: Command Popup"), "shows live preview title");
     assert!(full.contains(":po█"), "shows simulated command bar prompt");
     assert!(full.contains("pods"), "shows sample suggestions in preview");
+
+    // Banner preview render when selected_field == 3
+    let mut banner_state = TuiConfigViewState::new();
+    banner_state.selected_field = 3;
+    let banner_lines = common::render_lines(120, 30, |f| {
+        render_tui_config_view(f, f.area(), &banner_state, &config)
+    });
+    let banner_full = banner_lines.join("\n");
+    assert!(banner_full.contains("Live Preview: Startup Feature Banner"), "shows banner preview title");
+    assert!(banner_full.contains("Welcome to SRElens"), "shows banner contents in preview");
 
     // Narrow render (70x24) — should not panic, uses vertical split layout
     let narrow_lines = common::render_lines(70, 24, |f| {
@@ -2125,5 +2151,6 @@ fn tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow() {
     assert!(narrow_full.contains("TUI Configuration"));
     assert!(narrow_full.contains("Command Popup Max Width"));
     assert!(narrow_full.contains("Command Popup Text Size"));
+    assert!(narrow_full.contains("Startup Feature Banner"));
 }
 

--- a/apps/tui/tests/views_inspect_tests.rs
+++ b/apps/tui/tests/views_inspect_tests.rs
@@ -24,7 +24,9 @@ use srelens_tui::views::overview_view::{
     render_overview_view, ClusterOverviewData, OverviewViewState,
 };
 use srelens_tui::views::settings_view::{render_settings_view, SettingField, SettingsViewState};
+use srelens_tui::views::tui_config_view::{render_tui_config_view, TuiConfigViewState};
 use srelens_tui::views::yaml_view::{render_yaml_view, YamlViewState};
+use srelens_tui::TuiConfig;
 
 /// Render one frame and hand back the raw buffer, for the few assertions that
 /// need a cell's style rather than its text.
@@ -2016,3 +2018,85 @@ fn yaml_view_empty_document_renders_a_bare_frame() {
         "no numbered rows: {lines:?}"
     );
 }
+
+// ───────────────────────────── tui config view ─────────────────────────────
+
+#[test]
+fn tui_config_view_state_field_navigation_and_adjustments() {
+    let mut state = TuiConfigViewState::new();
+    assert_eq!(state.selected_field, 0);
+
+    state.select_next_field();
+    assert_eq!(state.selected_field, 1);
+
+    state.select_next_field();
+    assert_eq!(state.selected_field, 0);
+
+    state.select_prev_field();
+    assert_eq!(state.selected_field, 1);
+
+    let mut config = TuiConfig::default();
+    assert_eq!(config.command_popup_max_width, 65);
+    assert_eq!(config.command_popup_max_visible, 6);
+
+    // Selected field 1: Visible Rows (step 1, range 3..=20)
+    state.adjust_current(1, &mut config);
+    assert_eq!(config.command_popup_max_visible, 7);
+
+    state.adjust_current(-3, &mut config);
+    assert_eq!(config.command_popup_max_visible, 4);
+
+    state.adjust_current(-10, &mut config);
+    assert_eq!(config.command_popup_max_visible, 3); // Clamped at 3
+
+    // Switch to field 0: Width (step 5, range 40..=200)
+    state.select_prev_field();
+    assert_eq!(state.selected_field, 0);
+
+    state.adjust_current(2, &mut config);
+    assert_eq!(config.command_popup_max_width, 75);
+
+    state.adjust_current(50, &mut config);
+    assert_eq!(config.command_popup_max_width, 200); // Clamped at 200
+
+    state.adjust_current(-50, &mut config);
+    assert_eq!(config.command_popup_max_width, 40); // Clamped at 40
+
+    // Reset defaults
+    state.reset_defaults(&mut config);
+    assert_eq!(config.command_popup_max_width, 65);
+    assert_eq!(config.command_popup_max_visible, 6);
+}
+
+#[test]
+fn tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow() {
+    let state = TuiConfigViewState::new();
+    let config = TuiConfig {
+        command_popup_max_width: 80,
+        command_popup_max_visible: 8,
+    };
+
+    // Wide render (120x30)
+    let lines = common::render_lines(120, 30, |f| {
+        render_tui_config_view(f, f.area(), &state, &config)
+    });
+    let full = lines.join("\n");
+
+    assert!(full.contains("TUI Configuration"), "has title");
+    assert!(full.contains("Command Popup Max Width"), "has width setting card");
+    assert!(full.contains("Command Popup Max Visible Rows"), "has rows setting card");
+    assert!(full.contains("80 cols"), "shows configured width");
+    assert!(full.contains("8 rows"), "shows configured visible rows");
+    assert!(full.contains("Live Preview: Command Popup"), "shows live preview title");
+    assert!(full.contains(":po█"), "shows simulated command bar prompt");
+    assert!(full.contains("pods"), "shows sample suggestions in preview");
+
+    // Narrow render (70x24) — should not panic, uses vertical split layout
+    let narrow_lines = common::render_lines(70, 24, |f| {
+        render_tui_config_view(f, f.area(), &state, &config)
+    });
+    let narrow_full = narrow_lines.join("\n");
+    assert!(narrow_full.contains("TUI Configuration"));
+    assert!(narrow_full.contains("Command Popup Max Width"));
+}
+

--- a/apps/tui/tests/views_inspect_tests.rs
+++ b/apps/tui/tests/views_inspect_tests.rs
@@ -2043,10 +2043,20 @@ fn tui_config_view_state_field_navigation_and_adjustments() {
     assert_eq!(config.command_popup_max_visible, 6);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
 
-    // Selected field 2: Text size / density toggle
+    // Selected field 2: Text size / density slider (1..=4)
+    state.adjust_current(1, &mut config);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::Standard);
     state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Large);
     state.adjust_current(1, &mut config);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::ExtraLarge);
+    state.adjust_current(1, &mut config);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::ExtraLarge); // Clamped at 4
+    state.adjust_current(-1, &mut config);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::Large);
+    state.cycle_current(&mut config);
+    assert_eq!(config.command_popup_density, CommandPopupDensity::ExtraLarge);
+    state.cycle_current(&mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
 
     // Switch to field 1: Visible Rows (step 1, range 3..=20)

--- a/new-config-plan.md
+++ b/new-config-plan.md
@@ -1,0 +1,53 @@
+# TUI `:config` menu and live command-popup size
+
+## Summary
+
+Command mode (`:`) draws a suggestions popup with hardcoded caps (65 max columns, 6 visible rows). On modern terminal displays, this is often too constrained. Terminals cannot change font size per widget, so sizing the `:` popup means controlling **the popup's column width and visible row count**.
+
+This feature introduces:
+1. `TuiConfig` persisted in `~/.config/srelens/tui.json` (`$SRELENS_CONFIG_DIR/tui.json`, or overridden by `SRELENS_TUI_CONFIG_PATH`).
+2. Driving the statusbar command popup geometry from `TuiConfig`.
+3. A dedicated `:config` view (`ResourceKind::TuiConfig`) featuring live adjustments with `j`/`k`/`h`/`l`/`-`/`+`/arrows and an embedded live preview of the command popup.
+4. Reclaiming `:config` for TUI chrome settings while keeping AI settings accessible on `:ai-settings` (and `:settings`).
+
+## Persistence & Model
+
+New module `apps/tui/src/tui_config.rs` exported from `apps/tui/src/lib.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct TuiConfig {
+    pub command_popup_max_width: u16,    // default 65, clamped 40..=200
+    pub command_popup_max_visible: usize, // default 6, clamped 3..=20
+}
+```
+
+Path resolution order:
+1. `SRELENS_TUI_CONFIG_PATH` if set (for isolated tests)
+2. else `$SRELENS_CONFIG_DIR/tui.json`
+3. else `dirs::config_dir()/srelens/tui.json`
+
+`TuiConfig::load()` returns clamped values or defaults if missing/corrupt.
+`TuiConfig::save()` writes pretty JSON atomically or directly to the resolved path.
+
+## Popup Geometry
+
+Extracted into `command_popup_rect(area: Rect, item_count: usize, max_width: u16, max_visible: usize) -> Rect`:
+- `visible_count = item_count.min(max_visible)`
+- `popup_height = visible_count as u16 + 2`
+- `popup_width = area.width.saturating_sub(4).min(max_width)`
+- `Rect { x: area.x + 2, y: area.y.saturating_sub(popup_height), width: popup_width, height: popup_height }`
+
+Passed to statusbar via `StatusBarProps` and `App.tui_config`.
+
+## `:config` View with Live Preview
+
+- `ResourceKind::TuiConfig` added to `commands.rs`.
+- `COMMAND_REGISTRY` registers primary command `config` with aliases `["tui-config", "tui"]`.
+- Removed `config` from `ai-settings` aliases.
+- View rendered in `apps/tui/src/views/tui_config_view.rs`:
+  - Setting 0: Command Popup Max Width [40..=200]
+  - Setting 1: Command Popup Max Visible Rows [3..=20]
+  - Live preview widget rendering sample command suggestions using the current width and row count.
+  - Value adjustments immediately update `App.tui_config` and call `save()`.


### PR DESCRIPTION
## What changed and why

Command mode (`:`) previously used hardcoded dimensions for the autocomplete suggestions popup (max width 65 columns, max visible 6 rows). On large or wide terminal displays, this was too constrained and could not be configured. In addition, new users had no built-in showcase of SRElens' key troubleshooting capabilities.

This change introduces:
1. **`TuiConfig` configuration model**:
   - Persisted in `~/.config/srelens/tui.json` (with `$SRELENS_CONFIG_DIR/tui.json` and `SRELENS_TUI_CONFIG_PATH` override support).
   - `command_popup_max_width` (default 65, range `40..=200`).
   - `command_popup_max_visible` (default 6, range `3..=20`, preview list expanded to 26 items so all 20 rows are visible).
   - `command_popup_density` / text scale slider (1..=4: `Compact`, `Standard`, `Large`, `ExtraLarge`).
   - `show_feature_banner` (default `true`, toggles startup feature highlights banner).
2. **Dedicated `:config` view (`ResourceKind::TuiConfig`, aliases `:tui-config`, `:tui`)**:
   - Setting card 0: Popup Width (`40..=200`, step ±5).
   - Setting card 1: Visible Rows (`3..=20`, step ±1).
   - Setting card 2: Text Size Slider (`1..=4`: Compact 1-line, Standard 1-line enriched, Large 2-line cards, Extra Large 3-line cards with usage & aliases).
   - Setting card 3: Startup Feature Banner checkbox (`[● Show on startup] ` / `[○ Don't show]`).
   - Interactive live preview on the right pane dynamically switching between Command Popup preview and Feature Banner preview.
   - Adjust with `h`/`l`/`←`/`→`/`-`/`+`, toggle with `Space`/`Enter`, reset with `r`.
3. **Startup Feature Highlights Banner**:
   - Shown each time the binary starts (when `show_feature_banner` is enabled).
   - Highlights 7 key SRE troubleshooting capabilities:
     - `[1] :helm` (Helm 3 release revisions, rollback status, values & manifests)
     - `[2] :overview` (Cluster overview, health summary & node/pod capacity)
     - `[3] :gpuinfo` (GPU hardware inspector, specs & per-pod VRAM allocations)
     - `[4] :workloads` (Unified workloads view: Pods, Deployments, STS, DS, Jobs)
     - `[5] :ai` (SRElens AI Assistant Chat for automated RCA)
     - `[6] :ai-settings` (Configure AI providers, models & keys)
     - `[7] :config` (Lens settings: popup width, visible rows, text scale & banner)
   - Press `1`–`7` to jump directly to any view.
   - Press `t` to toggle startup preference on/off in-place with immediate save and feedback toast.
   - Dismiss with `Esc`, `Enter`, `Space`, or `q`.
   - Reopen anytime with `:features` or `:banner` (aliases `:guide`, `:welcome`).
4. Reclaims `:config` for TUI configuration while keeping AI settings accessible under `:ai-settings` and `:settings`.
5. Deep link routing support for `srelens://view/.../config` and `srelens://view/.../features`.

## Validation

- `apps/tui/tests/core_logic_tests.rs`: `tui_config_file_paths_clamping_and_round_trip`.
- `apps/tui/tests/chrome_tests.rs`:
  - `command_popup_geometry_respects_max_width_and_visible_rows`
  - `command_popup_rendering_expands_to_configured_width_and_visible_rows`
  - `command_popup_rendering_large_density_mode`
  - `command_popup_rendering_extra_large_density_mode`
  - `feature_banner_modal_renders_all_highlighted_features_and_toggle_state`
- `apps/tui/tests/views_inspect_tests.rs`:
  - `tui_config_view_state_field_navigation_and_adjustments`
  - `tui_config_view_renders_cards_and_live_preview_at_wide_and_narrow` (testing width, rows, density slider, banner toggle, and live banner preview)
- `apps/tui/tests/app_input_tests.rs`:
  - `tui_config_view_navigation_and_hotkeys`
  - `feature_banner_modal_interactive_navigation_toggle_and_jump`
- `cargo test --workspace`: All 250+ tests passing cleanly across all crates.
- Release binary compiled and installed to `~/.local/bin/srelens-tui`.