### PR TITLE
fix(tui): execute the completed command after Tab

### DIFF
--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -2343,8 +2343,13 @@ impl App {
                         let idx = self.command_suggestion_idx % suggestions.len();
                         self.command_buffer = suggestions[idx].0.name.clone();
                         // Completion changes the query and rebuilds the list.
-                        // Its exact match is first; the old index is no longer valid.
-                        self.command_suggestion_idx = 0;
+                        // Names and aliases can collide, so follow the selected
+                        // target (including its CRD group), not the old index.
+                        let target = &suggestions[idx].0.target;
+                        self.command_suggestion_idx = command_suggestions_with_crds(&self.command_buffer, &self.crds)
+                            .iter()
+                            .position(|(command, _)| &command.target == target)
+                            .unwrap_or(0);
                     }
                 }
                 KeyCode::BackTab => {

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -2342,7 +2342,9 @@ impl App {
                     if !suggestions.is_empty() {
                         let idx = self.command_suggestion_idx % suggestions.len();
                         self.command_buffer = suggestions[idx].0.name.clone();
-                        self.command_suggestion_idx = (idx + 1) % suggestions.len();
+                        // Completion changes the query and rebuilds the list.
+                        // Its exact match is first; the old index is no longer valid.
+                        self.command_suggestion_idx = 0;
                     }
                 }
                 KeyCode::BackTab => {

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
 use srelens_kube::contexts::ContextDto;
 use srelens_tui::app::{ActiveView, App, SuspendAction};
-use srelens_tui::commands::{command_suggestions_with_crds, CrdMeta, PrinterColumn, ResourceKind};
+use srelens_tui::commands::{command_suggestions_with_crds, CommandTarget, CrdMeta, PrinterColumn, ResourceKind};
 use srelens_tui::CommandPopupDensity;
 use srelens_tui::event::AppEvent;
 use srelens_tui::ui::{ContainerAction, InputMode, Modal};
@@ -1302,6 +1302,38 @@ async fn command_tab_then_enter_executes_the_completed_command() {
         press(&mut app, key(KeyCode::Enter)).await;
         assert_eq!(table(&app).kind, ResourceKind::Services);
         assert_eq!(app.input_mode, InputMode::Normal);
+    }
+}
+
+#[tokio::test]
+async fn command_completion_preserves_crd_identity_across_alias_and_group_collisions() {
+    for group in ["management.cattle.io", "example.io"] {
+        let (mut app, _rx) = common::app().await;
+        app.crds = ["management.cattle.io", "example.io"].into_iter().map(|group| CrdMeta {
+            crd_name: format!("settings.{group}"),
+            group: group.into(), version: "v1".into(), kind: "Setting".into(),
+            plural: "settings".into(), singular: "setting".into(), namespaced: false,
+            short_names: vec![], printer_columns: vec![],
+        }).collect();
+        let expected = CommandTarget::CustomResource(app.crds.iter().find(|crd| crd.group == group).unwrap().clone());
+        press(&mut app, ch(':')).await;
+        type_str(&mut app, "sett").await;
+        let selected = command_suggestions_with_crds("sett", &app.crds).iter()
+            .position(|(cmd, _)| cmd.target == expected).unwrap();
+        for _ in 0..selected {
+            press(&mut app, key(KeyCode::Down)).await;
+        }
+        for _ in 0..2 {
+            press(&mut app, key(KeyCode::Tab)).await;
+            assert_eq!(app.command_buffer, "settings");
+            let suggestions = command_suggestions_with_crds(&app.command_buffer, &app.crds);
+            assert_eq!(suggestions[app.command_suggestion_idx].0.target, expected);
+        }
+        press(&mut app, key(KeyCode::Enter)).await;
+        assert_eq!(table(&app).kind, ResourceKind::CustomResource(match expected {
+            CommandTarget::CustomResource(crd) => crd,
+            _ => unreachable!(),
+        }));
     }
 }
 

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -1123,14 +1123,14 @@ async fn command_mode_tab_and_arrow_keys_cycle_the_suggestions() {
     let len = suggestions.len();
     assert!(len > 1, "':s' should offer several commands");
 
-    // Tab completes to suggestion and advances index
+    // Tab completes the text, so selection resets for the newly filtered list.
     app.command_buffer = "s".to_string();
     app.command_suggestion_idx = 0;
     press(&mut app, key(KeyCode::Tab)).await;
     assert_eq!(app.command_buffer, suggestions[0].0.name);
     assert_eq!(
-        app.command_suggestion_idx, 1,
-        "the cursor advances to the next candidate"
+        app.command_suggestion_idx, 0,
+        "the cursor stays on the completed command in the new list"
     );
 
     // Down arrow and Ctrl-N advance selection index in popup
@@ -1278,6 +1278,31 @@ async fn command_enter_runs_the_command_and_unknown_commands_toast() {
     type_str(&mut app, "q").await;
     press(&mut app, key(KeyCode::Enter)).await;
     assert!(!app.is_running);
+}
+
+#[tokio::test]
+async fn command_tab_then_enter_executes_the_completed_command() {
+    for query in ["serv", "s"] {
+        let (mut app, _rx) = common::app().await;
+        press(&mut app, ch(':')).await;
+        type_str(&mut app, query).await;
+        let suggestions = command_suggestions_with_crds(query, &app.crds);
+        let selected = suggestions.iter().position(|(cmd, _)| cmd.name == "services").unwrap();
+        for _ in 0..selected {
+            press(&mut app, key(KeyCode::Down)).await;
+        }
+        press(&mut app, key(KeyCode::Tab)).await;
+        assert_eq!(app.command_buffer, "services");
+        assert_eq!(app.command_suggestion_idx, 0);
+        let screen = common::render_app(&mut app, 120, 30);
+        assert!(screen.contains(":services"), "screen: {screen}");
+        // Repeated Tab must not move to a secondary match for the completed text.
+        press(&mut app, key(KeyCode::Tab)).await;
+        assert_eq!(app.command_buffer, "services");
+        press(&mut app, key(KeyCode::Enter)).await;
+        assert_eq!(table(&app).kind, ResourceKind::Services);
+        assert_eq!(app.input_mode, InputMode::Normal);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Tab completion changed the TUI command text but retained an index from the previous suggestion list. Enter could then run a different command. Simply resetting to the first match also loses the selected target when a CRD name collides with another command's alias.

After completion, find the selected CommandTarget in the rebuilt suggestions, preserving the full CRD identity including its group. Repeated Tab and Enter stay on the completed target; arrow keys can still select another suggestion.

Regression coverage exercises Services completion from narrow and broad prefixes, plus two `settings` CRDs in different groups that collide with the AI Settings alias. Tests verify repeated completion, rendered command text, and the final destination.

Addresses the finding in #504 and the alias-collision review on this PR. Merge into `dev` before promoting #504 to `main`.

Validation: both regressions failed before their fixes. `cargo test --workspace` passed: 2130 tests, 13 ignored. Mock-server tests ran with local networking allowed. No frontend changes.
