### PR TITLE
test(ui): fix editor schema request race in CI

### DIFF
--- a/packages/ui-next/src/screens/Edit.test.tsx
+++ b/packages/ui-next/src/screens/Edit.test.tsx
@@ -419,7 +419,8 @@ describe("EditResource", () => {
   it("says what the schema allows where the cursor is, and completes from the same schema", async () => {
     render(<EditResource route={ROUTE} />);
     await waitFor(() => expect(latestEditor()?.value).toBe(LIVE));
-    expect(core.openApiSchema).toHaveBeenCalledWith("prod-eu", "v1", "ConfigMap");
+    // Schema loading follows the manifest update in a separate effect.
+    await waitFor(() => expect(core.openApiSchema).toHaveBeenCalledWith("prod-eu", "v1", "ConfigMap"));
     const sidebar = screen.getByRole("complementary", { name: "Analysis" });
     // Cursor at the top: the top-level keys, with type and description.
     expect(await within(sidebar).findByText("immutable")).toBeDefined();


### PR DESCRIPTION
The Node 24 CI run for #504 intermittently asserted that the editor's OpenAPI request had started immediately after the manifest appeared. Schema loading runs in a subsequent React effect, so the request can still have zero calls at that point.

Wait explicitly for the expected schema request, retaining the exact context, API version, kind, schema-content, and completion assertions. This changes test synchronization only; application behavior is unchanged.

The CI failure reproduced the race; all 27 editor tests pass on Node 24 and Node 26 after the fix.

Full validation: `pnpm test` on Node 24 passed all 6,297 tests across 385 files; coverage floors passed with 90.83% line coverage.
