### PR TITLE
fix(tui): address promotion review regressions

### DIFF
--- a/apps/tui/Cargo.toml
+++ b/apps/tui/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-ratatui = { version = "0.30.2", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.30.2", default-features = false, features = ["crossterm", "unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"

--- a/apps/tui/src/app.rs
+++ b/apps/tui/src/app.rs
@@ -1537,10 +1537,12 @@ impl App {
                         }
                         KeyCode::Char('t') | KeyCode::Char('T') => {
                             self.tui_config.show_feature_banner = !self.tui_config.show_feature_banner;
-                            let _ = self.tui_config.save();
+                            let save_result = self.tui_config.save();
                             let is_enabled = self.tui_config.show_feature_banner;
                             self.modal = Some(Modal::FeatureBanner { show_on_startup: is_enabled });
-                            if is_enabled {
+                            if let Err(err) = save_result {
+                                self.set_toast(format!("Settings applied for this session but not saved: {err}"), Theme::status_error());
+                            } else if is_enabled {
                                 self.set_toast("Startup feature banner: Enabled".to_string(), Theme::status_ok());
                             } else {
                                 self.set_toast("Startup feature banner: Disabled".to_string(), Theme::status_warn());
@@ -3517,6 +3519,10 @@ impl App {
                         }
                     }
                     KeyCode::Char('r') => {
+                        if helm.error.is_some() || self.helm_refreshing {
+                            self.set_toast("Refresh Helm releases successfully before rollback (R to retry)".to_string(), Theme::status_warn());
+                            return;
+                        }
                         if let Some(rel) = sel_rel {
                             if rel.revision > 1 {
                                 let target_rev = rel.revision - 1;
@@ -3957,23 +3963,35 @@ impl App {
                     KeyCode::Char('j') | KeyCode::Down | KeyCode::Tab => cfg_state.select_next_field(),
                     KeyCode::Char('k') | KeyCode::Up | KeyCode::BackTab => cfg_state.select_prev_field(),
                     KeyCode::Char('h') | KeyCode::Left | KeyCode::Char('-') => {
-                        cfg_state.adjust_current(-1, &mut self.tui_config);
+                        if let Err(err) = cfg_state.adjust_current(-1, &mut self.tui_config) {
+                            self.set_toast(format!("Settings applied for this session but not saved: {err}"), Theme::status_error());
+                        }
                     }
                     KeyCode::Char('l') | KeyCode::Right | KeyCode::Char('+') | KeyCode::Char('=') => {
-                        cfg_state.adjust_current(1, &mut self.tui_config);
+                        if let Err(err) = cfg_state.adjust_current(1, &mut self.tui_config) {
+                            self.set_toast(format!("Settings applied for this session but not saved: {err}"), Theme::status_error());
+                        }
                     }
                     KeyCode::Enter | KeyCode::Char(' ') => {
-                        cfg_state.cycle_current(&mut self.tui_config);
+                        if let Err(err) = cfg_state.cycle_current(&mut self.tui_config) {
+                            self.set_toast(format!("Settings applied for this session but not saved: {err}"), Theme::status_error());
+                        }
                     }
                     KeyCode::Char('[') | KeyCode::Char('{') => {
-                        cfg_state.adjust_current(-5, &mut self.tui_config);
+                        if let Err(err) = cfg_state.adjust_current(-5, &mut self.tui_config) {
+                            self.set_toast(format!("Settings applied for this session but not saved: {err}"), Theme::status_error());
+                        }
                     }
                     KeyCode::Char(']') | KeyCode::Char('}') => {
-                        cfg_state.adjust_current(5, &mut self.tui_config);
+                        if let Err(err) = cfg_state.adjust_current(5, &mut self.tui_config) {
+                            self.set_toast(format!("Settings applied for this session but not saved: {err}"), Theme::status_error());
+                        }
                     }
                     KeyCode::Char('r') | KeyCode::Char('R') | KeyCode::Char('d') => {
-                        cfg_state.reset_defaults(&mut self.tui_config);
-                        self.set_toast("Reset TUI settings to defaults".to_string(), Theme::status_ok());
+                        match cfg_state.reset_defaults(&mut self.tui_config) {
+                            Ok(()) => self.set_toast("Reset TUI settings to defaults".to_string(), Theme::status_ok()),
+                            Err(err) => self.set_toast(format!("Settings applied for this session but not saved: {err}"), Theme::status_error()),
+                        }
                     }
                     _ => {}
                 }
@@ -6427,7 +6445,6 @@ impl App {
             if helm.releases.is_empty() {
                 helm.is_loading = true;
             }
-            helm.error = None;
         }
         let ctx = self.active_context.clone();
         let ns = if self.active_namespace.is_empty() {
@@ -6463,11 +6480,7 @@ impl App {
                         let items: Vec<HelmReleaseItem> = summaries.into_iter().map(Into::into).collect();
                         helm.set_releases(items);
                     }
-                    Err(err) => {
-                        if helm.releases.is_empty() {
-                            helm.set_error(err);
-                        }
-                    }
+                    Err(err) => helm.set_error(err),
                 }
             } else {
                 self.refresh_helm_releases();
@@ -7291,6 +7304,10 @@ impl App {
             });
             self.set_toast(format!("Uncordoning node '{}'...", node_name), Theme::status_warn());
         } else if action_name.starts_with("helm-rollback:") {
+            if matches!(&self.active_view, ActiveView::Helm(helm) if helm.error.is_some() || self.helm_refreshing) {
+                self.set_toast("Refresh Helm releases successfully before rollback (R to retry)".to_string(), Theme::status_warn());
+                return;
+            }
             let parts: Vec<&str> = action_name.splitn(4, ':').collect();
             if parts.len() == 4 {
                 let name = parts[1].to_string();

--- a/apps/tui/src/ui/dialogs.rs
+++ b/apps/tui/src/ui/dialogs.rs
@@ -758,8 +758,8 @@ pub fn render_modal(f: &mut Frame, area: Rect, modal: &Modal) {
 }
 
 pub fn render_feature_banner_modal(f: &mut Frame, area: Rect, show_on_startup: bool) {
-    let modal_width = (area.width.saturating_sub(4)).min(94).max(48);
-    let modal_height = (area.height.saturating_sub(2)).min(21).max(14);
+    let modal_width = (area.width.saturating_sub(4)).clamp(48, 94).min(area.width);
+    let modal_height = (area.height.saturating_sub(2)).clamp(14, 21).min(area.height);
     let modal_x = area.x + (area.width.saturating_sub(modal_width)) / 2;
     let modal_y = area.y + (area.height.saturating_sub(modal_height)) / 2;
     let modal_area = Rect::new(modal_x, modal_y, modal_width, modal_height);

--- a/apps/tui/src/ui/statusbar.rs
+++ b/apps/tui/src/ui/statusbar.rs
@@ -43,8 +43,8 @@ pub fn command_popup_rect(
 ) -> Rect {
     let visible_count = item_count.min(max_visible);
     let item_h = density.item_height();
-    let content_height = (visible_count as u16) * item_h;
-    let popup_height = content_height + 2;
+    let content_height = visible_count.min(u16::MAX as usize) as u16;
+    let popup_height = content_height.saturating_mul(item_h).saturating_add(2).min(area.y);
     let popup_width = area.width.saturating_sub(4).min(max_width);
     Rect {
         x: area.x + 2,
@@ -84,7 +84,11 @@ pub fn render_statusbar(f: &mut Frame, area: Rect, props: StatusBarProps) {
                     let max_width = props.command_popup_max_width.unwrap_or(65);
                     let max_visible = props.command_popup_max_visible.unwrap_or(6);
                     let density = props.command_popup_density.unwrap_or_default();
+                    let density = if area.y.saturating_sub(2) < density.item_height() {
+                        CommandPopupDensity::Compact
+                    } else { density };
                     let popup_area = command_popup_rect(area, suggs.len(), max_width, max_visible, density);
+                    if popup_area.height < 3 || popup_area.width < 3 { return; }
                     f.render_widget(Clear, popup_area);
                     let inner_height = popup_area.height.saturating_sub(2);
                     let item_lines = density.item_height();

--- a/apps/tui/src/views/helm_detail_view.rs
+++ b/apps/tui/src/views/helm_detail_view.rs
@@ -757,7 +757,7 @@ fn render_manifest_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         String::new()
     };
 
-    let title = format!(" Rendered Kubernetes Manifests (YAML) (<c> Copy  </> Search){} ", search_badge);
+    let title = format!(" Rendered Kubernetes Manifests (YAML) (<y> Copy  </> Search){} ", search_badge);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(Theme::border_type())
@@ -839,7 +839,7 @@ fn render_notes_tab(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         String::new()
     };
 
-    let title = format!(" Chart Release Notes (NOTES.txt) (<c> Copy  </> Search){} ", search_badge);
+    let title = format!(" Chart Release Notes (NOTES.txt) (<y> Copy  </> Search){} ", search_badge);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(Theme::border_type())
@@ -896,8 +896,8 @@ fn render_bottom_hints(f: &mut Frame, area: Rect, state: &HelmDetailViewState) {
         HelmDetailTab::Overview => "<Tab> Switch Tab  <1-5> Jump Tab  <Esc> Back to Releases",
         HelmDetailTab::ValuesDiff => "<Tab> Switch Tab  <m> Toggle Diff Mode  </> Search  <n/N> Next/Prev  <j/k> Scroll  <g/G> Top/Bottom  <Esc> Back",
         HelmDetailTab::Revisions => "<Tab> Switch Tab  <j/k> Select Rev  <r> Rollback to Selected  <Enter>/<v> View  <Esc> Back",
-        HelmDetailTab::Manifest => "<Tab> Switch Tab  <j/k> Scroll  <g/G> Top/Bottom  <c> Copy  </> Search  <n/N> Next/Prev  <Esc> Back",
-        HelmDetailTab::Notes => "<Tab> Switch Tab  <j/k> Scroll  <g/G> Top/Bottom  <c> Copy  </> Search  <n/N> Next/Prev  <Esc> Back",
+        HelmDetailTab::Manifest => "<Tab> Switch Tab  <j/k> Scroll  <g/G> Top/Bottom  <y> Copy  </> Search  <n/N> Next/Prev  <Esc> Back",
+        HelmDetailTab::Notes => "<Tab> Switch Tab  <j/k> Scroll  <g/G> Top/Bottom  <y> Copy  </> Search  <n/N> Next/Prev  <Esc> Back",
     };
 
     let p = Paragraph::new(format!(" {}", hints))

--- a/apps/tui/src/views/helm_view.rs
+++ b/apps/tui/src/views/helm_view.rs
@@ -154,22 +154,41 @@ pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
     }
 
     if let Some(ref err) = state.error {
-        let message = if state.releases.is_empty() {
-            format!("Failed to load Helm releases: {err}. Press R to retry.")
+        let stale = !state.releases.is_empty();
+        let message = if stale {
+            format!("Refresh failed; rows are stale: {err}")
         } else {
-            format!("Refresh failed; rows are stale: {err}. Press R to retry. Rollback is disabled.")
+            format!("Failed to load Helm releases: {err}")
         };
         let error = Paragraph::new(message)
             .wrap(Wrap { trim: true })
             .style(Style::default().fg(Theme::red()));
-        if state.releases.is_empty() {
-            f.render_widget(error, inner);
-            return;
-        }
-        let error_height = error.line_count(inner.width).min(inner.height as usize) as u16;
-        let regions = Layout::vertical([Constraint::Length(error_height), Constraint::Min(0)]).split(inner);
+        let recovery = Paragraph::new(if stale {
+            "Press R to retry. Rollback is disabled."
+        } else {
+            "Press R to retry."
+        }).wrap(Wrap { trim: true }).style(Style::default().fg(Theme::red()));
+        let recovery_height = recovery.line_count(inner.width).min(inner.height as usize) as u16;
+        // Keep the table header, its margin and at least one cached release visible.
+        let table_height = if stale { 3.min(inner.height.saturating_sub(recovery_height)) } else { 0 };
+        let available = inner.height.saturating_sub(recovery_height + table_height);
+        let error_lines = error.line_count(inner.width);
+        let error_height = error_lines.min(available as usize) as u16;
+        let truncated = error_lines > error_height as usize && error_height > 0;
+        let marker_height = u16::from(truncated);
+        let regions = Layout::vertical([
+            Constraint::Length(error_height.saturating_sub(marker_height)),
+            Constraint::Length(marker_height),
+            Constraint::Length(recovery_height),
+            Constraint::Min(table_height),
+        ]).split(inner);
         f.render_widget(error, regions[0]);
-        inner = regions[1];
+        if truncated {
+            f.render_widget(Paragraph::new("… error truncated").style(Style::default().fg(Theme::red())), regions[1]);
+        }
+        f.render_widget(recovery, regions[2]);
+        if !stale { return; }
+        inner = regions[3];
     }
 
     if state.releases.is_empty() {

--- a/apps/tui/src/views/helm_view.rs
+++ b/apps/tui/src/views/helm_view.rs
@@ -159,9 +159,16 @@ pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
         } else {
             format!("Refresh failed; rows are stale: {err}. Press R to retry. Rollback is disabled.")
         };
-        let regions = Layout::vertical([Constraint::Length(2), Constraint::Min(0)]).split(inner);
-        f.render_widget(Paragraph::new(message).wrap(Wrap { trim: true }).style(Style::default().fg(Theme::red())), regions[0]);
-        if state.releases.is_empty() { return; }
+        let error = Paragraph::new(message)
+            .wrap(Wrap { trim: true })
+            .style(Style::default().fg(Theme::red()));
+        if state.releases.is_empty() {
+            f.render_widget(error, inner);
+            return;
+        }
+        let error_height = error.line_count(inner.width).min(inner.height as usize) as u16;
+        let regions = Layout::vertical([Constraint::Length(error_height), Constraint::Min(0)]).split(inner);
+        f.render_widget(error, regions[0]);
         inner = regions[1];
     }
 

--- a/apps/tui/src/views/helm_view.rs
+++ b/apps/tui/src/views/helm_view.rs
@@ -1,8 +1,8 @@
 use ratatui::{
-    layout::{Constraint, Rect},
+    layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::Span,
-    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap},
     Frame,
 };
 use serde::{Deserialize, Serialize};
@@ -143,7 +143,7 @@ pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
         .border_style(Style::default().fg(Theme::border()))
         .title(Span::styled(title, Theme::title()));
 
-    let inner = block.inner(area);
+    let mut inner = block.inner(area);
     f.render_widget(block, area);
 
     if state.is_loading {
@@ -154,10 +154,15 @@ pub fn render_helm_view(f: &mut Frame, area: Rect, state: &HelmViewState) {
     }
 
     if let Some(ref err) = state.error {
-        let error_msg = Paragraph::new(format!("⚠ Failed to load Helm releases: {}", err))
-            .style(Style::default().fg(Theme::red()));
-        f.render_widget(error_msg, inner);
-        return;
+        let message = if state.releases.is_empty() {
+            format!("Failed to load Helm releases: {err}. Press R to retry.")
+        } else {
+            format!("Refresh failed; rows are stale: {err}. Press R to retry. Rollback is disabled.")
+        };
+        let regions = Layout::vertical([Constraint::Length(2), Constraint::Min(0)]).split(inner);
+        f.render_widget(Paragraph::new(message).wrap(Wrap { trim: true }).style(Style::default().fg(Theme::red())), regions[0]);
+        if state.releases.is_empty() { return; }
+        inner = regions[1];
     }
 
     if state.releases.is_empty() {

--- a/apps/tui/src/views/tui_config_view.rs
+++ b/apps/tui/src/views/tui_config_view.rs
@@ -67,7 +67,7 @@ impl TuiConfigViewState {
         }
     }
 
-    pub fn adjust_current(&mut self, delta: i32, config: &mut TuiConfig) {
+    pub fn adjust_current(&mut self, delta: i32, config: &mut TuiConfig) -> Result<(), String> {
         match self.selected_field {
             0 => {
                 let current = config.command_popup_max_width as i32;
@@ -89,10 +89,10 @@ impl TuiConfigViewState {
             }
             _ => {}
         }
-        let _ = config.save();
+        config.save()
     }
 
-    pub fn cycle_current(&mut self, config: &mut TuiConfig) {
+    pub fn cycle_current(&mut self, config: &mut TuiConfig) -> Result<(), String> {
         match self.selected_field {
             0 => {
                 let current = config.command_popup_max_width;
@@ -110,12 +110,12 @@ impl TuiConfigViewState {
             }
             _ => {}
         }
-        let _ = config.save();
+        config.save()
     }
 
-    pub fn reset_defaults(&mut self, config: &mut TuiConfig) {
+    pub fn reset_defaults(&mut self, config: &mut TuiConfig) -> Result<(), String> {
         *config = TuiConfig::default();
-        let _ = config.save();
+        config.save()
     }
 }
 
@@ -159,7 +159,7 @@ pub fn render_tui_config_view(
             ),
         ]),
         Line::from(vec![Span::styled(
-            "Settings are saved automatically to ~/.config/srelens/tui.json and applied immediately.",
+            "Changes apply immediately and are saved automatically. Save failures are reported below.",
             Style::default().fg(Theme::dim()),
         )]),
     ];

--- a/apps/tui/tests/app_input_tests.rs
+++ b/apps/tui/tests/app_input_tests.rs
@@ -32,6 +32,8 @@ use common::{ch, ctrl, key, shift, type_str};
 // Local helpers
 // ---------------------------------------------------------------------------
 
+static TUI_CONFIG_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 async fn press(app: &mut App, k: KeyEvent) {
     app.handle_key_event(k).await;
 }
@@ -501,6 +503,33 @@ async fn tick_schedules_helm_refreshes_and_keys_trigger_manual_refresh() {
     app.toast = None;
     app.handle_key_event(common::ch('r')).await;
     assert!(app.modal.is_none());
+}
+
+#[tokio::test]
+async fn failed_helm_refresh_keeps_rows_stale_and_blocks_rollback_until_success() {
+    let (mut app, _rx) = common::app().await;
+    app.active_view = ActiveView::Helm(srelens_tui::views::helm_view::HelmViewState::new());
+    let release = srelens_kube::helm::HelmReleaseSummary {
+        name: "web".into(), namespace: "default".into(), revision: 3,
+        status: "deployed".into(), chart: "web".into(), chart_version: "1".into(),
+        app_version: "1".into(), updated: "today".into(),
+    };
+    app.handle_helm_releases_result("test-cluster", "default", Ok(vec![release.clone()]));
+    app.handle_helm_releases_result("test-cluster", "default", Err("access denied".into()));
+    let text = common::render_app(&mut app, 160, 30);
+    assert!(text.contains("stale") && text.contains("access denied") && text.contains("web"), "{text}");
+    press(&mut app, ch('r')).await;
+    assert!(app.modal.is_none());
+    // A confirmation opened before the refresh failed must be blocked too.
+    app.execute_modal_confirm("helm-rollback:web:default:2".into()).await;
+    assert!(app.toast.as_ref().unwrap().0.contains("Refresh Helm releases successfully"));
+    app.refresh_helm_releases();
+    if let ActiveView::Helm(helm) = &app.active_view { assert!(helm.error.is_some()); }
+    press(&mut app, ch('r')).await;
+    assert!(app.modal.is_none());
+    app.handle_helm_releases_result("test-cluster", "default", Ok(vec![release]));
+    press(&mut app, ch('r')).await;
+    assert!(matches!(app.modal, Some(Modal::Confirm { ref action_name, .. }) if action_name == "helm-rollback:web:default:2"));
 }
 
 #[tokio::test]
@@ -3454,6 +3483,7 @@ async fn helm_detail_manifest_search_and_navigation_input_flow() {
 
 #[tokio::test]
 async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
+    let _config_guard = TUI_CONFIG_ENV_LOCK.lock().await;
     let temp = tempfile::tempdir().unwrap();
     let config_path = temp.path().join("tui.json");
     std::env::set_var("SRELENS_TUI_CONFIG_PATH", &config_path);
@@ -3562,6 +3592,7 @@ async fn config_command_opens_tui_config_view_and_keys_adjust_values() {
 
 #[tokio::test]
 async fn feature_banner_modal_interactive_navigation_toggle_and_jump() {
+    let _config_guard = TUI_CONFIG_ENV_LOCK.lock().await;
     let tmp = tempfile::tempdir().unwrap();
     let config_file = tmp.path().join("tui.json");
     std::env::set_var("SRELENS_TUI_CONFIG_PATH", &config_file);
@@ -3583,6 +3614,21 @@ async fn feature_banner_modal_interactive_navigation_toggle_and_jump() {
     press(&mut app, ch('T')).await;
     assert!(app.tui_config.show_feature_banner);
     assert!(matches!(app.modal, Some(Modal::FeatureBanner { show_on_startup: true })));
+
+    // A directory cannot be overwritten as the settings file.
+    std::fs::remove_file(&config_file).unwrap();
+    std::fs::create_dir(&config_file).unwrap();
+    press(&mut app, ch('t')).await;
+    assert!(app.toast.as_ref().unwrap().0.contains("Failed to write"));
+    app.modal = None;
+    app.active_view = ActiveView::TuiConfig(Default::default());
+    for code in [KeyCode::Right, KeyCode::Enter, KeyCode::Char('r')] {
+        app.toast = None;
+        press(&mut app, key(code)).await;
+        assert!(app.toast.as_ref().unwrap().0.contains("Failed to write"));
+    }
+    std::fs::remove_dir(&config_file).unwrap();
+    app.modal = Some(Modal::FeatureBanner { show_on_startup: false });
 
     // Press '1' jumps directly to Helm releases
     press(&mut app, ch('1')).await;

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -2454,3 +2454,30 @@ fn long_helm_errors_show_the_reason_and_recovery_with_and_without_stale_rows() {
         }
     }
 }
+
+#[test]
+fn oversized_helm_errors_preserve_recovery_and_stale_rows() {
+    use srelens_tui::views::helm_view::{render_helm_view, HelmReleaseItem, HelmViewState};
+    for (width, height) in [(80, 12), (40, 12), (80, 8)] {
+        for stale in [false, true] {
+            let mut state = HelmViewState::new();
+            if stale {
+                state.set_releases(vec![HelmReleaseItem {
+                    name: "cached".into(), namespace: "ns".into(), revision: 3,
+                    status: "deployed".into(), chart: "web".into(), chart_version: "1".into(),
+                    app_version: "1".into(), updated: "today".into(),
+                }]);
+            }
+            state.set_error("Permission denied while listing Helm secrets. ".repeat(100));
+            let text = common::render_text(width, height, |f| render_helm_view(f, f.area(), &state));
+            let content = text.lines().map(|line| line.trim_matches('│')).collect::<Vec<_>>().join(" ");
+            let words = content.split_whitespace().collect::<Vec<_>>().join(" ");
+            assert!(words.contains("Press R to retry."), "{text}");
+            assert!(words.contains("error truncated"), "{text}");
+            if stale {
+                assert!(words.contains("Rollback is disabled."), "{text}");
+                assert!(text.contains("cached"), "{text}");
+            }
+        }
+    }
+}

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -2429,3 +2429,28 @@ fn feature_banner_stays_inside_small_preview_regions() {
         }
     }
 }
+
+#[test]
+fn long_helm_errors_show_the_reason_and_recovery_with_and_without_stale_rows() {
+    use srelens_tui::views::helm_view::{render_helm_view, HelmReleaseItem, HelmViewState};
+    for stale in [false, true] {
+        let mut state = HelmViewState::new();
+        if stale {
+            state.set_releases(vec![HelmReleaseItem {
+                name: "cached-release".into(), namespace: "default".into(), revision: 3,
+                status: "deployed".into(), chart: "web".into(), chart_version: "1".into(),
+                app_version: "1".into(), updated: "today".into(),
+            }]);
+        }
+        state.set_error(format!("{} permission denied", "Unable to list Helm release secrets in the selected Kubernetes namespace. ".repeat(3)));
+        let text = common::render_text(80, 24, |f| render_helm_view(f, f.area(), &state));
+        let content = text.lines().map(|line| line.trim_matches('│')).collect::<Vec<_>>().join(" ");
+        let words = content.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(words.contains("permission denied"), "{text}");
+        assert!(words.contains("Press R to retry."), "{text}");
+        if stale {
+            assert!(words.contains("Rollback is disabled."), "{text}");
+            assert!(text.contains("cached-release"), "{text}");
+        }
+    }
+}

--- a/apps/tui/tests/chrome_tests.rs
+++ b/apps/tui/tests/chrome_tests.rs
@@ -930,6 +930,21 @@ fn command_popup_geometry_respects_max_width_and_visible_rows() {
     // ExtraLarge density mode: 3 items, max_visible 6 -> 3 items * 3 rows = 9 rows + 2 borders = 11 height
     let r6 = command_popup_rect(bar_area, 3, 65, 6, CommandPopupDensity::ExtraLarge);
     assert_eq!(r6, Rect::new(2, 11, 65, 11));
+    let capped = command_popup_rect(bar_area, 30, 65, 20, CommandPopupDensity::ExtraLarge);
+    assert!(capped.bottom() <= bar_area.y);
+    assert!(capped.height <= bar_area.y);
+}
+
+#[test]
+fn command_popup_keeps_last_selection_visible_in_a_short_terminal() {
+    let suggs = command_suggestions("");
+    let mode = InputMode::Command;
+    let mut props = status_props(&mode);
+    props.suggestions = Some((&suggs, suggs.len() - 1));
+    props.command_popup_max_visible = Some(20);
+    props.command_popup_density = Some(CommandPopupDensity::ExtraLarge);
+    let text = common::render_text(100, 24, |f| render_statusbar(f, Rect::new(0, 22, 100, 2), props));
+    assert!(text.contains(&format!("▶ {}", suggs.last().unwrap().0.name.to_uppercase())), "{text}");
 }
 
 #[test]
@@ -2368,6 +2383,8 @@ async fn the_app_renders_helm_and_helm_detail_views_across_all_tabs() {
     detail_state.set_tab(HelmDetailTab::Notes);
     let text = common::render_text(160, 40, |f| render_helm_detail_view(f, f.area(), &detail_state));
     assert!(text.contains("Chart Release Notes") && text.contains("everything is ready"), "{text}");
+    assert!(text.contains("<y> Copy"), "{text}");
+    assert!(!text.contains("<c> Copy"), "{text}");
 }
 
 #[test]
@@ -2394,3 +2411,21 @@ fn feature_banner_modal_renders_all_highlighted_features_and_toggle_state() {
     assert!(text_disabled.contains("Disabled"), "shows disabled state");
 }
 
+#[test]
+fn feature_banner_stays_inside_small_preview_regions() {
+    for area in [Rect::new(4, 5, 35, 6), Rect::new(4, 5, 20, 1), Rect::new(4, 5, 0, 0)] {
+        let lines = common::render_lines(80, 30, |f| {
+            for y in 0..30 {
+                f.render_widget(ratatui::widgets::Paragraph::new("X".repeat(80)), Rect::new(0, y, 80, 1));
+            }
+            srelens_tui::ui::dialogs::render_feature_banner_modal(f, area, true);
+        });
+        for (y, line) in lines.iter().enumerate() {
+            for (x, c) in line.chars().enumerate() {
+                if x < area.x as usize || x >= area.right() as usize || y < area.y as usize || y >= area.bottom() as usize {
+                    assert_eq!(c, 'X', "banner escaped preview at {x},{y}");
+                }
+            }
+        }
+    }
+}

--- a/apps/tui/tests/tui_tests.rs
+++ b/apps/tui/tests/tui_tests.rs
@@ -6781,6 +6781,17 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await;
         assert!(matches!(app.active_view, ActiveView::Helm(_)));
 
+        // Returning to the list refreshes it; complete that refresh before rollback.
+        let releases = match &app.active_view {
+            ActiveView::Helm(helm) => helm.releases.clone(),
+            _ => unreachable!(),
+        };
+        let summaries = releases.into_iter().map(|r| srelens_kube::helm::HelmReleaseSummary {
+            name: r.name, namespace: r.namespace, revision: r.revision, status: r.status,
+            chart: r.chart, chart_version: r.chart_version, app_version: r.app_version, updated: r.updated,
+        }).collect();
+        app.handle_helm_releases_result("test-ctx", "default", Ok(summaries));
+
         // 5. From Helm list, press 'r' to trigger rollback modal to revision - 1
         app.handle_key_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)).await;
         match &app.modal {

--- a/apps/tui/tests/views_inspect_tests.rs
+++ b/apps/tui/tests/views_inspect_tests.rs
@@ -2048,58 +2048,58 @@ fn tui_config_view_state_field_navigation_and_adjustments() {
     assert!(config.show_feature_banner);
 
     // Selected field 3: Startup Feature Banner toggle
-    state.adjust_current(1, &mut config);
+    let _ = state.adjust_current(1, &mut config);
     assert!(!config.show_feature_banner);
-    state.cycle_current(&mut config);
+    let _ = state.cycle_current(&mut config);
     assert!(config.show_feature_banner);
 
     // Switch to field 2: Text size / density slider (1..=4)
     state.select_prev_field();
     assert_eq!(state.selected_field, 2);
 
-    state.adjust_current(1, &mut config);
+    let _ = state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Standard);
-    state.adjust_current(1, &mut config);
+    let _ = state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Large);
-    state.adjust_current(1, &mut config);
+    let _ = state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::ExtraLarge);
-    state.adjust_current(1, &mut config);
+    let _ = state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::ExtraLarge); // Clamped at 4
-    state.adjust_current(-1, &mut config);
+    let _ = state.adjust_current(-1, &mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Large);
-    state.cycle_current(&mut config);
+    let _ = state.cycle_current(&mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::ExtraLarge);
-    state.cycle_current(&mut config);
+    let _ = state.cycle_current(&mut config);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);
 
     // Switch to field 1: Visible Rows (step 1, range 3..=20)
     state.select_prev_field();
     assert_eq!(state.selected_field, 1);
 
-    state.adjust_current(1, &mut config);
+    let _ = state.adjust_current(1, &mut config);
     assert_eq!(config.command_popup_max_visible, 7);
 
-    state.adjust_current(-3, &mut config);
+    let _ = state.adjust_current(-3, &mut config);
     assert_eq!(config.command_popup_max_visible, 4);
 
-    state.adjust_current(-10, &mut config);
+    let _ = state.adjust_current(-10, &mut config);
     assert_eq!(config.command_popup_max_visible, 3); // Clamped at 3
 
     // Switch to field 0: Width (step 5, range 40..=200)
     state.select_prev_field();
     assert_eq!(state.selected_field, 0);
 
-    state.adjust_current(2, &mut config);
+    let _ = state.adjust_current(2, &mut config);
     assert_eq!(config.command_popup_max_width, 75);
 
-    state.adjust_current(50, &mut config);
+    let _ = state.adjust_current(50, &mut config);
     assert_eq!(config.command_popup_max_width, 200); // Clamped at 200
 
-    state.adjust_current(-50, &mut config);
+    let _ = state.adjust_current(-50, &mut config);
     assert_eq!(config.command_popup_max_width, 40); // Clamped at 40
 
     // Reset defaults
-    state.reset_defaults(&mut config);
+    let _ = state.reset_defaults(&mut config);
     assert_eq!(config.command_popup_max_width, 65);
     assert_eq!(config.command_popup_max_visible, 6);
     assert_eq!(config.command_popup_density, CommandPopupDensity::Compact);


### PR DESCRIPTION
## What changed and why

Fix five TUI findings from the dev-to-main promotion review:

- Keep failed Helm refreshes visible alongside stale rows and block revision-derived rollback until refresh succeeds, including an already-open confirmation.
- Fit command suggestions above the status bar and keep the selected item visible at large text sizes.
- Advertise `y` for copying Helm Notes and Manifest content, matching the existing handler.
- Bound the feature banner to its preview region, including narrow and tiny regions.
- Report settings-write errors for adjustments, cycling, reset and the startup-banner toggle. Explain that unsaved changes apply only to this session.

## Related issues

Addresses review findings on #504. Merge into dev before completing that promotion.

## Validation

- Added regressions that failed before each fix and pass afterward.
- `cargo test --workspace`: 2,143 passed, 13 ignored.
- Final settings assertions: `cargo test -p srelens-tui -p srelens-desktop --test app_input_tests`: 75 passed.
- `pnpm test` on Node 26: 385 files, 6,309 tests passed, coverage gate passed.
- The reported init-log timeout did not reproduce: the exact targeted test passed in 0.57 seconds; all four completion cases also passed in the workspace run. No speculative log-stream change is included.

## UI evidence

Ran the branch's TUI in an 80×24 terminal with an isolated preview context. Opened settings from the feature banner and selected Startup Feature Banner; the preview stayed inside rows 14–19, above its border and the settings footer. Terminal-frame regressions also exercise the last command selection at ExtraLarge density, stale Helm errors and the copy hints.
